### PR TITLE
fix: d1 migration failure on deploy to cloudflare

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev:client": "vite --config vite.config.ts",
     "dev:worker": "wrangler dev",
-    "build": "vite build --config vite.config.ts && touch dist/.gitkeep && pnpm run db:migrate:binding",
+    "build": "([ \"$CF_PAGES\" = \"1\" ] && pnpm db:migrate:remote || echo 'Skipping migrations'); vite build --config vite.config.ts && touch dist/.gitkeep",
     "deploy:production": "pnpm build && wrangler deploy",
     "db:migrate:local": "wrangler d1 migrations apply waichat-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply waichat-db --remote",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "dev:client": "vite --config vite.config.ts",
     "dev:worker": "wrangler dev",
-    "build": "vite build --config vite.config.ts && touch dist/.gitkeep",
-    "cf:deploy": "wrangler d1 migrations apply DB --remote && wrangler deploy",
-    "deploy:production": "pnpm build && pnpm run cf:deploy",
+    "build": "vite build --config vite.config.ts && touch dist/.gitkeep && pnpm run db:migrate:binding",
+    "deploy:production": "pnpm build && wrangler deploy",
     "db:migrate:local": "wrangler d1 migrations apply waichat-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply waichat-db --remote",
+    "db:migrate:binding": "wrangler d1 migrations apply DB --remote",
     "type-check": "tsc --noEmit"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "deploy:production": "pnpm build && wrangler deploy",
     "db:migrate:local": "wrangler d1 migrations apply waichat-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply waichat-db --remote",
-    "db:migrate:binding": "wrangler d1 migrations apply DB --remote",
+    "db:migrate:binding": "npx wrangler d1 migrations apply DB --remote",
     "type-check": "tsc --noEmit"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev:client": "vite --config vite.config.ts",
     "dev:worker": "wrangler dev",
     "build": "vite build --config vite.config.ts && touch dist/.gitkeep",
-    "deploy:production": "pnpm build && wrangler deploy",
+    "cf:deploy": "wrangler d1 migrations apply DB --remote && wrangler deploy",
+    "deploy:production": "pnpm build && pnpm run cf:deploy",
     "db:migrate:local": "wrangler d1 migrations apply waichat-db --local",
     "db:migrate:remote": "wrangler d1 migrations apply waichat-db --remote",
     "type-check": "tsc --noEmit"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,11 +7,6 @@ compatibility_flags = ["nodejs_compat"]
 [assets]
 directory = "./dist"
 
-# Build & deploy commands — used by Cloudflare Workers Builds and the Deploy button
-[build]
-command = "pnpm build"
-deploy_command = "pnpm run cf:deploy"
-
 # Workers AI binding
 [ai]
 binding = "AI"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,11 @@ compatibility_flags = ["nodejs_compat"]
 [assets]
 directory = "./dist"
 
+# Build & deploy commands — used by Cloudflare Workers Builds and the Deploy button
+[build]
+command = "pnpm build"
+deploy_command = "pnpm run cf:deploy"
+
 # Workers AI binding
 [ai]
 binding = "AI"


### PR DESCRIPTION
Fixes #2

**Description**
We need to run `npx wrangler d1 migrations apply DB --remote` prior to the `npx wrangler deploy`, so adding it the `build` command ensures it runs. Tried using config from `wrangler.toml` but Cloudflare isn't picking up those configs.

- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)
