### PR TITLE
feat: add confirmation modal for conversation deletion

### DIFF
--- a/src/client/components/ConfirmModal.tsx
+++ b/src/client/components/ConfirmModal.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from "react";
+
+interface ConfirmModalProps {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmLabel = "Delete",
+  onConfirm,
+  onCancel,
+}: ConfirmModalProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+      if (e.key === "Enter") onConfirm();
+    };
+    if (open) document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onCancel, onConfirm]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) onCancel();
+      }}
+    >
+      <div className="w-full max-w-sm bg-white dark:bg-gray-900 rounded-2xl shadow-xl mx-4 overflow-hidden">
+        <div className="px-6 pt-6 pb-4">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
+            {title}
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {description}
+          </p>
+        </div>
+        <div className="px-6 pb-6 flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="flex-1 py-2 text-sm font-medium text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors cursor-pointer"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/ConfirmModal.tsx
+++ b/src/client/components/ConfirmModal.tsx
@@ -19,14 +19,14 @@ export default function ConfirmModal({
 }: ConfirmModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
 
+  // Only handle Escape - no global Enter listener to avoid conflict with focused buttons
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onCancel();
-      if (e.key === "Enter") onConfirm();
     };
     if (open) document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
-  }, [open, onCancel, onConfirm]);
+  }, [open, onCancel]);
 
   if (!open) return null;
 
@@ -38,9 +38,17 @@ export default function ConfirmModal({
         if (e.target === overlayRef.current) onCancel();
       }}
     >
-      <div className="w-full max-w-sm bg-white dark:bg-gray-900 rounded-2xl shadow-xl mx-4 overflow-hidden">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+        className="w-full max-w-sm bg-white dark:bg-gray-900 rounded-2xl shadow-xl mx-4 overflow-hidden"
+      >
         <div className="px-6 pt-6 pb-4">
-          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">
+          <h2
+            id="confirm-modal-title"
+            className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1"
+          >
             {title}
           </h2>
           <p className="text-sm text-gray-500 dark:text-gray-400">
@@ -50,13 +58,13 @@ export default function ConfirmModal({
         <div className="px-6 pb-6 flex gap-3">
           <button
             onClick={onCancel}
-            className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors cursor-pointer"
+            className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors"
           >
             Cancel
           </button>
           <button
             onClick={onConfirm}
-            className="flex-1 py-2 text-sm font-medium text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors cursor-pointer"
+            className="flex-1 py-2 text-sm font-medium text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors"
           >
             {confirmLabel}
           </button>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import type { Conversation } from "../storage";
+import ConfirmModal from "./ConfirmModal";
 
 interface SidebarProps {
   conversations: Conversation[];
@@ -17,58 +19,72 @@ export default function Sidebar({
   onDelete,
   onSettingsOpen,
 }: SidebarProps) {
+  const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
+
   return (
-    <aside className="flex flex-col w-64 h-screen bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 shrink-0">
-      <div className="p-4 border-b border-gray-200 dark:border-gray-800">
-        <button
-          onClick={onNew}
-          className="w-full py-2 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
-        >
-          New Chat
-        </button>
-      </div>
-
-      <nav className="flex-1 overflow-y-auto p-2 space-y-1">
-        {conversations.length === 0 && (
-          <p className="text-xs text-gray-400 dark:text-gray-600 text-center mt-8">
-            No conversations yet
-          </p>
-        )}
-        {conversations.map((c) => (
-          <div
-            key={c.id}
-            className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-sm transition-colors ${
-              activeId === c.id
-                ? "bg-indigo-50 dark:bg-indigo-950 text-indigo-700 dark:text-indigo-300"
-                : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
-            }`}
-            onClick={() => onSelect(c.id)}
+    <>
+      <aside className="flex flex-col w-64 h-screen bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 shrink-0">
+        <div className="p-4 border-b border-gray-200 dark:border-gray-800">
+          <button
+            onClick={onNew}
+            className="w-full py-2 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
           >
-            <span className="truncate">{c.title}</span>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(c.id);
-              }}
-              className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity ml-2 shrink-0"
-              aria-label="Delete conversation"
+            New Chat
+          </button>
+        </div>
+        <nav className="flex-1 overflow-y-auto p-2 space-y-1">
+          {conversations.length === 0 && (
+            <p className="text-xs text-gray-400 dark:text-gray-600 text-center mt-8">
+              No conversations yet
+            </p>
+          )}
+          {conversations.map((c) => (
+            <div
+              key={c.id}
+              className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-sm transition-colors ${
+                activeId === c.id
+                  ? "bg-indigo-50 dark:bg-indigo-950 text-indigo-700 dark:text-indigo-300"
+                  : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+              }`}
+              onClick={() => onSelect(c.id)}
             >
-              ✕
-            </button>
-          </div>
-        ))}
-      </nav>
+              <span className="truncate">{c.title}</span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setPendingDelete(c);
+                }}
+                className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity ml-2 shrink-0 cursor-pointer"
+                aria-label="Delete conversation"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </nav>
+        <div className="p-4 border-t border-gray-200 dark:border-gray-800 flex items-center justify-between">
+          <p className="text-base text-gray-400 dark:text-gray-600">WaiChat</p>
+          <button
+            onClick={onSettingsOpen}
+            className="text-base text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer"
+            aria-label="Open settings"
+          >
+            ⚙️
+          </button>
+        </div>
+      </aside>
 
-      <div className="p-4 border-t border-gray-200 dark:border-gray-800 flex items-center justify-between">
-        <p className="text-base text-gray-400 dark:text-gray-600">WaiChat</p>
-        <button
-          onClick={onSettingsOpen}
-          className="text-base text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer"
-          aria-label="Open settings"
-        >
-          ⚙️
-        </button>
-      </div>
-    </aside>
+      <ConfirmModal
+        open={pendingDelete !== null}
+        title="Delete conversation?"
+        description={`"${pendingDelete?.title}" will be permanently deleted.`}
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (pendingDelete) onDelete(pendingDelete.id);
+          setPendingDelete(null);
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </>
   );
 }

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -54,7 +54,7 @@ export default function Sidebar({
                   e.stopPropagation();
                   setPendingDelete(c);
                 }}
-                className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity ml-2 shrink-0 cursor-pointer"
+                className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity ml-2 shrink-0"
                 aria-label="Delete conversation"
               >
                 ✕
@@ -77,7 +77,11 @@ export default function Sidebar({
       <ConfirmModal
         open={pendingDelete !== null}
         title="Delete conversation?"
-        description={`"${pendingDelete?.title}" will be permanently deleted.`}
+        description={
+          pendingDelete
+            ? `"${pendingDelete.title}" will be permanently deleted.`
+            : ""
+        }
         confirmLabel="Delete"
         onConfirm={() => {
           if (pendingDelete) onDelete(pendingDelete.id);


### PR DESCRIPTION
Fixes #6

**Description**
Require user confirmation via modal before deleting any chat to prevent accidental data loss.

- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)
