### PR TITLE
fix(ui): make conversation delete button visible on mobile

### DIFF
--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -63,7 +63,7 @@ export default function Sidebar({
                   e.stopPropagation();
                   setPendingDelete(c);
                 }}
-                className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-opacity ml-2 shrink-0"
+                className="md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-red-500 transition-opacity ml-2 shrink-0 cursor-pointer"
                 aria-label="Delete conversation"
               >
                 ✕

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -63,7 +63,7 @@ export default function Sidebar({
                   e.stopPropagation();
                   setPendingDelete(c);
                 }}
-                className="md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 text-gray-400 hover:text-red-500 transition-opacity ml-2 shrink-0 cursor-pointer"
+                className="p-1 rounded-md md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-red-500 focus:outline-none text-gray-400 cursor-pointer md:hover:text-red-500 active:text-red-500 transition-all ml-2 shrink-0"
                 aria-label="Delete conversation"
               >
                 ✕


### PR DESCRIPTION

Fixes #14 

**Description**
Updated the sidebar conversation delete button to be visible by default on mobile devices, removing reliance on the hover state. The button now only hides itself and uses hover-to-reveal logic on medium (md) breakpoints and above. Added focus states for better accessibility.


- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)
