### PR TITLE
fix(ui): constrain ModelPicker width on desktop screens

### DIFF
--- a/src/client/components/ModelPicker.tsx
+++ b/src/client/components/ModelPicker.tsx
@@ -13,7 +13,7 @@ export default function ModelPicker({ models, value, onChange, disabled }: Model
       value={value}
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
-      className="w-full md:w-auto md:max-w-md truncate text-sm bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5 text-gray-700 dark:text-gray-300 outline-none cursor-pointer hover:border-gray-300 dark:hover:border-gray-600 transition-colors disabled:opacity-50"
+      className="w-full md:max-w-md truncate text-sm bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5 text-gray-700 dark:text-gray-300 outline-none cursor-pointer hover:border-gray-300 dark:hover:border-gray-600 transition-colors disabled:opacity-50"
     >
       {models.map((m) => (
         <option key={m.id} value={m.id}>

--- a/src/client/components/ModelPicker.tsx
+++ b/src/client/components/ModelPicker.tsx
@@ -13,7 +13,7 @@ export default function ModelPicker({ models, value, onChange, disabled }: Model
       value={value}
       onChange={(e) => onChange(e.target.value)}
       disabled={disabled}
-      className="w-full truncate text-sm bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5 text-gray-700 dark:text-gray-300 outline-none cursor-pointer hover:border-gray-300 dark:hover:border-gray-600 transition-colors disabled:opacity-50"
+      className="w-full md:w-auto md:max-w-md truncate text-sm bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5 text-gray-700 dark:text-gray-300 outline-none cursor-pointer hover:border-gray-300 dark:hover:border-gray-600 transition-colors disabled:opacity-50"
     >
       {models.map((m) => (
         <option key={m.id} value={m.id}>


### PR DESCRIPTION
Fixes #18

**Description**
Added `md:w-auto` and `md:max-w-md` to the ModelPicker component. This allows the select element to remain fully fluid (`w-full`) on mobile devices while preventing it from unnecessarily stretching across the entire header flex container on desktop viewports.

- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)
