### PR TITLE
feat(chat): display model attribution on assistant responses

### DIFF
--- a/migrations/0002_add_message_model.sql
+++ b/migrations/0002_add_message_model.sql
@@ -1,0 +1,1 @@
+ALTER TABLE messages ADD COLUMN model TEXT;

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -76,12 +76,21 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
             ) : (
               <p className="whitespace-pre-wrap">{m.content}</p>
             )}
-            {m.role === "assistant" && isStreaming && m.content === "" && (
-              <span className="inline-flex gap-1">
+
+            {/* Show streaming indicator OR model attribution */}
+            {m.role === "assistant" && isStreaming && m.content === "" ? (
+              <span className="inline-flex gap-1 mt-2">
                 <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
                 <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
                 <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
               </span>
+            ) : (
+              m.role === "assistant" &&
+              m.model && (
+                <div className="mt-3 text-[10px] text-gray-400 dark:text-gray-500 font-mono tracking-wide uppercase">
+                  {m.model.split("/").pop()}
+                </div>
+              )
             )}
           </div>
 

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -78,18 +78,19 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
             )}
 
             {/* Show streaming indicator OR model attribution */}
-            {m.role === "assistant" && isStreaming && m.content === "" ? (
-              <span className="inline-flex gap-1 mt-2">
-                <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
-                <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
-                <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
-              </span>
-            ) : (
-              m.role === "assistant" &&
-              m.model && (
-                <div className="mt-3 text-[10px] text-gray-400 dark:text-gray-500 font-mono tracking-wide uppercase">
-                  {m.model.split("/").pop()}
-                </div>
+            {m.role === "assistant" && (
+              isStreaming && m.content === "" ? (
+                <span className="inline-flex gap-1 mt-2">
+                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
+                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
+                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
+                </span>
+              ) : (
+                m.model && (
+                  <div className="mt-3 text-[10px] text-gray-400 dark:text-gray-500 font-mono tracking-wide uppercase">
+                    {m.model.split('/').pop()}
+                  </div>
+                )
               )
             )}
           </div>

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -29,7 +29,6 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Auto-close active chat and clear errors when storage mode changes
   useEffect(() => {
     setActiveConversation(null);
     setMessages([]);
@@ -108,6 +107,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
         role: "assistant",
         content: "",
         created_at: Date.now(),
+        model,
       };
 
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
@@ -178,6 +178,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
           conversation_id: conversationId,
           role: "assistant",
           content: fullContent,
+          model,
         });
 
         if (messages.length === 0 && storageMode === "local") {

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -12,13 +12,12 @@ export interface Message {
   role: "user" | "assistant";
   content: string;
   created_at: number;
+  model?: string;
 }
 
 export interface StorageAdapter {
   getConversations(): Promise<Conversation[]>;
-  getConversation(
-    id: string,
-  ): Promise<{ conversation: Conversation; messages: Message[] } | null>;
+  getConversation(id: string): Promise<{ conversation: Conversation; messages: Message[] } | null>;
   createConversation(model: string): Promise<Conversation>;
   deleteConversation(id: string): Promise<void>;
   saveMessage(message: Omit<Message, "id" | "created_at">): Promise<Message>;

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -1,22 +1,14 @@
 import type { Conversation, Message } from "./types";
 
-export async function getConversations(
-  db: D1Database,
-): Promise<Conversation[]> {
+export async function getConversations(db: D1Database): Promise<Conversation[]> {
   const { results } = await db
     .prepare("SELECT * FROM conversations ORDER BY updated_at DESC")
     .all<Conversation>();
   return results;
 }
 
-export async function getConversation(
-  db: D1Database,
-  id: string,
-): Promise<Conversation | null> {
-  return db
-    .prepare("SELECT * FROM conversations WHERE id = ?")
-    .bind(id)
-    .first<Conversation>();
+export async function getConversation(db: D1Database, id: string): Promise<Conversation | null> {
+  return db.prepare("SELECT * FROM conversations WHERE id = ?").bind(id).first<Conversation>();
 }
 
 export async function createConversation(
@@ -48,43 +40,29 @@ export async function updateConversationTitle(
     .run();
 }
 
-export async function updateConversationTimestamp(
-  db: D1Database,
-  id: string,
-): Promise<void> {
+export async function updateConversationTimestamp(db: D1Database, id: string): Promise<void> {
   await db
     .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")
     .bind(Date.now(), id)
     .run();
 }
 
-export async function deleteConversation(
-  db: D1Database,
-  id: string,
-): Promise<void> {
+export async function deleteConversation(db: D1Database, id: string): Promise<void> {
   await db.prepare("DELETE FROM conversations WHERE id = ?").bind(id).run();
 }
 
-export async function getMessages(
-  db: D1Database,
-  conversationId: string,
-): Promise<Message[]> {
+export async function getMessages(db: D1Database, conversationId: string): Promise<Message[]> {
   const { results } = await db
-    .prepare(
-      "SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at ASC",
-    )
+    .prepare("SELECT * FROM messages WHERE conversation_id = ? ORDER BY created_at ASC")
     .bind(conversationId)
     .all<Message>();
   return results;
 }
 
-export async function saveMessage(
-  db: D1Database,
-  message: Message,
-): Promise<void> {
+export async function saveMessage(db: D1Database, message: Message): Promise<void> {
   await db
     .prepare(
-      "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)",
+      "INSERT INTO messages (id, conversation_id, role, content, created_at, model) VALUES (?, ?, ?, ?, ?, ?)",
     )
     .bind(
       message.id,
@@ -92,6 +70,7 @@ export async function saveMessage(
       message.role,
       message.content,
       message.created_at,
+      message.model || null,
     )
     .run();
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -41,8 +41,7 @@ function scoreModel(id: string): number {
   // Penalize old models
   if (id.includes("v0.1") || id.includes("v0.2")) score -= 20;
   if (id.includes("llama-2")) score -= 30;
-  if (id.includes("1.5b") || id.includes("0.5b") || id.includes("1.1b"))
-    score -= 15;
+  if (id.includes("1.5b") || id.includes("0.5b") || id.includes("1.1b")) score -= 15;
   if (id.includes("lora")) score -= 10;
 
   return score;
@@ -181,10 +180,10 @@ app.post("/api/title", async (c) => {
   const title = await generateTitle(c.env.AI, message);
   return c.json({ title });
 });
+
 app.post("/api/chat", async (c) => {
   const body = await c.req.json<ChatRequest>();
-  const { conversation_id, model, messages, storage_mode, system_prompt } =
-    body;
+  const { conversation_id, model, messages, storage_mode, system_prompt } = body;
   const isCloud = storage_mode !== "local";
   const now = Date.now();
 
@@ -211,11 +210,8 @@ app.post("/api/chat", async (c) => {
       );
     }
   }
-  const stream = await streamAiResponse(
-    c.env.AI,
-    model as any,
-    messagesWithSystem,
-  );
+
+  const stream = await streamAiResponse(c.env.AI, model as any, messagesWithSystem);
 
   if (isCloud) {
     const [streamForClient, streamForSave] = stream.tee();
@@ -224,6 +220,7 @@ app.post("/api/chat", async (c) => {
     const savePromise = saveAssistantMessage(
       c.env.DB,
       conversation_id,
+      model,
       streamForSave,
     ).then(() => updateConversationTimestamp(c.env.DB, conversation_id));
 
@@ -248,6 +245,7 @@ app.post("/api/chat", async (c) => {
 async function saveAssistantMessage(
   db: D1Database,
   conversationId: string,
+  model: string,
   stream: ReadableStream,
 ): Promise<void> {
   const reader = stream.getReader();
@@ -285,18 +283,15 @@ async function saveAssistantMessage(
   }
 
   if (fullContent) {
-    await db
-      .prepare(
-        "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)",
-      )
-      .bind(
-        crypto.randomUUID(),
-        conversationId,
-        "assistant",
-        fullContent,
-        Date.now(),
-      )
-      .run();
+    // Re-use our saveMessage helper so the DB logic is centralized!
+    await saveMessage(db, {
+      id: crypto.randomUUID(),
+      conversation_id: conversationId,
+      role: "assistant",
+      content: fullContent,
+      created_at: Date.now(),
+      model,
+    });
   }
 }
 

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -19,6 +19,7 @@ export interface Message {
   role: "user" | "assistant";
   content: string;
   created_at: number;
+  model?: string;
 }
 
 export interface ChatRequest {


### PR DESCRIPTION
Fixes #21 

**Description**
Added model tracking to individual messages to support mid-conversation model switching.
- Created D1 migration `0002` to add a `model` column to the `messages` table.
- Updated `useChat` to eagerly attach the selected model to the assistant's message state.
- Updated the Cloudflare Worker to persist the `model` to D1 during Cloud storage mode.
- Enhanced `MessageList` UI to display a subtle, uppercase slug of the model name beneath the assistant's response.


- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)
