### PR TITLE
feat(ui): implement native deep linking for conversations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev:client": "vite --config vite.config.ts",
     "dev:worker": "wrangler dev -c wrangler.local.toml",
-    "build": "(test -d /opt/buildhome && pnpm db:migrate:binding || echo 'Not on Cloudflare, skipping migration.'); vite build --config vite.config.ts && touch dist/.gitkeep",
+    "build": "(test -d /opt/buildhome && pnpm db:migrate:binding || echo 'Not on Cloudflare, skipping migration.'); vite build --config vite.config.ts && pnpm run build:assets",
+    "build:assets": "touch dist/.gitkeep && echo '/api/* /api/:splat 200' > dist/_redirects && echo '/* /index.html 200' >> dist/_redirects",
     "deploy:production": "pnpm build && wrangler deploy -c wrangler.local.toml",
     "db:migrate:local": "wrangler d1 migrations apply waichat-db --local -c wrangler.local.toml",
     "db:migrate:remote": "wrangler d1 migrations apply waichat-db --remote -c wrangler.local.toml",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "dev:client": "vite --config vite.config.ts",
     "dev:worker": "wrangler dev -c wrangler.local.toml",
-    "build": "(test -d /opt/buildhome && pnpm db:migrate:binding || echo 'Not on Cloudflare, skipping migration.'); vite build --config vite.config.ts && pnpm run build:assets",
-    "build:assets": "touch dist/.gitkeep && echo '/api/* /api/:splat 200' > dist/_redirects && echo '/* /index.html 200' >> dist/_redirects",
+    "build": "(test -d /opt/buildhome && pnpm db:migrate:binding || echo 'Not on Cloudflare, skipping migration.'); vite build --config vite.config.ts && touch dist/.gitkeep",
     "deploy:production": "pnpm build && wrangler deploy -c wrangler.local.toml",
     "db:migrate:local": "wrangler d1 migrations apply waichat-db --local -c wrangler.local.toml",
     "db:migrate:remote": "wrangler d1 migrations apply waichat-db --remote -c wrangler.local.toml",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -14,6 +14,15 @@ const DEFAULT_MODEL_KEY = "waichat:default-model";
 const MOBILE_BREAKPOINT = 768;
 
 export default function App() {
+  // Track the actual saved preference in localStorage separately
+  const [savedStorageMode, setSavedStorageMode] = useState<StorageMode>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem(STORAGE_MODE_KEY);
+      return stored === "local" ? "local" : "cloud";
+    }
+    return "cloud";
+  });
+
   // Check the URL for a forced storage mode first, fallback to localStorage
   const [storageMode, setStorageMode] = useState<StorageMode>(() => {
     if (typeof window !== "undefined") {
@@ -21,8 +30,7 @@ export default function App() {
       if (path.startsWith("/c/local/")) return "local";
       if (path.startsWith("/c/cloud/")) return "cloud";
     }
-    const stored = localStorage.getItem(STORAGE_MODE_KEY);
-    return stored === "local" ? "local" : "cloud";
+    return savedStorageMode;
   });
 
   const {
@@ -155,15 +163,29 @@ export default function App() {
     }
   };
 
-  // Wrapper for selecting a chat: automatically close sidebar on mobile
   const handleSelectConversation = (id: string) => {
     selectConversation(id);
     closeSidebarOnMobile();
   };
 
-  // Wrapper for new chat: automatically close sidebar on mobile
-  const handleNew = async () => {
-    await newConversation(model);
+  const handleStorageToggle = (next: StorageMode) => {
+    setStorageMode(next);
+    setSavedStorageMode(next); // Sync saved mode when manually toggled
+    localStorage.setItem(STORAGE_MODE_KEY, next);
+    setStorageDropdownOpen(false);
+  };
+
+  // Wrapper for new chat with mode support
+  const handleNew = async (targetMode: StorageMode = storageMode) => {
+    if (targetMode !== storageMode) {
+      // User opted to return to their default mode. We toggle state and reset home.
+      handleStorageToggle(targetMode);
+      clearConversation();
+      window.history.pushState({}, "", "/");
+    } else {
+      // Standard new chat in the current mode
+      await newConversation(model);
+    }
     closeSidebarOnMobile();
   };
 
@@ -175,12 +197,6 @@ export default function App() {
     } else {
       await sendMessage(content, model, activeConversation.id, storageMode, systemPrompt);
     }
-  };
-
-  const handleStorageToggle = (next: StorageMode) => {
-    setStorageMode(next);
-    localStorage.setItem(STORAGE_MODE_KEY, next);
-    setStorageDropdownOpen(false); // Close dropdown after selection
   };
 
   const handleDefaultModelChange = (m: string) => {
@@ -197,7 +213,6 @@ export default function App() {
     if (mode === "cloud") {
       await fetch("/api/conversations", { method: "DELETE" });
     } else {
-      // Clear localStorage conversations and messages
       const keys = Object.keys(localStorage).filter(
         (k) => k.startsWith("waichat:conversations") || k.startsWith("waichat:messages:"),
       );
@@ -225,6 +240,8 @@ export default function App() {
         onNew={handleNew}
         onDelete={deleteConversation}
         onSettingsOpen={() => setSettingsOpen(true)}
+        currentMode={storageMode}
+        savedMode={savedStorageMode}
       />
 
       <main className="flex flex-col flex-1 min-w-0">

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -29,6 +29,7 @@ export default function App() {
     selectConversation,
     newConversation,
     deleteConversation,
+    clearConversation,
     sendMessage,
   } = useChat(storageMode);
 
@@ -52,6 +53,43 @@ export default function App() {
   useEffect(() => {
     loadConversations();
   }, [loadConversations]);
+
+  // Check the URL on the very first render
+  useEffect(() => {
+    const path = window.location.pathname;
+    if (path.startsWith("/c/")) {
+      const id = path.slice(3);
+      selectConversation(id);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Browser Back/Forward: Listen to history pops
+  useEffect(() => {
+    const handlePopState = () => {
+      const path = window.location.pathname;
+      if (path.startsWith("/c/")) {
+        selectConversation(path.slice(3));
+      } else {
+        clearConversation();
+      }
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, [selectConversation, clearConversation]);
+
+  // Update the URL when the active chat changes
+  useEffect(() => {
+    const currentPath = window.location.pathname;
+    if (activeConversation) {
+      const expectedPath = `/c/${activeConversation.id}`;
+      if (currentPath !== expectedPath) {
+        window.history.pushState({}, "", expectedPath);
+      }
+    } else if (currentPath !== "/") {
+      window.history.pushState({}, "", "/");
+    }
+  }, [activeConversation]);
 
   // Close storage dropdown when clicking outside or pressing Escape
   useEffect(() => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -14,7 +14,13 @@ const DEFAULT_MODEL_KEY = "waichat:default-model";
 const MOBILE_BREAKPOINT = 768;
 
 export default function App() {
+  // Check the URL for a forced storage mode first, fallback to localStorage
   const [storageMode, setStorageMode] = useState<StorageMode>(() => {
+    if (typeof window !== "undefined") {
+      const path = window.location.pathname;
+      if (path.startsWith("/c/local/")) return "local";
+      if (path.startsWith("/c/cloud/")) return "cloud";
+    }
     const stored = localStorage.getItem(STORAGE_MODE_KEY);
     return stored === "local" ? "local" : "cloud";
   });
@@ -56,29 +62,48 @@ export default function App() {
 
   const initialLoadDone = useRef(false);
 
-  // Check the URL on the very first render safely
+  // Safely parse the new URL format on initial render
   useEffect(() => {
     if (initialLoadDone.current) return;
 
     const path = window.location.pathname;
     if (path.startsWith("/c/")) {
-      const id = path.slice(3);
-      if (id) selectConversation(id);
+      const parts = path.split("/");
+      const mode = parts[2];
+      const id = parts[3];
+
+      if ((mode === "cloud" || mode === "local") && id) {
+        selectConversation(id);
+      } else {
+        // Invalid path format, just go back home cleanly
+        window.history.replaceState({}, "", "/");
+      }
     }
 
     initialLoadDone.current = true;
   }, [selectConversation]);
 
-  // Browser Back/Forward: Listen to history pops
+  // Handle browser Back/Forward with cross-mode support
   useEffect(() => {
     const handlePopState = () => {
       const path = window.location.pathname;
       if (path.startsWith("/c/")) {
-        const id = path.slice(3);
-        if (id) {
+        const parts = path.split("/");
+        const mode = parts[2] as StorageMode;
+        const id = parts[3];
+
+        if ((mode === "cloud" || mode === "local") && id) {
+          if (mode !== storageMode) {
+            // If the user hits "Back" and it crosses into a different storage mode,
+            // the safest way to re-initialize all hooks and state is a hard reload.
+            window.location.reload();
+            return;
+          }
           selectConversation(id);
         } else {
+          // Invalid URL format, act as if we hit home
           clearConversation();
+          window.history.replaceState({}, "", "/");
         }
       } else {
         clearConversation();
@@ -86,20 +111,20 @@ export default function App() {
     };
     window.addEventListener("popstate", handlePopState);
     return () => window.removeEventListener("popstate", handlePopState);
-  }, [selectConversation, clearConversation]);
+  }, [selectConversation, clearConversation, storageMode]);
 
-  // Update the URL when the active chat changes
+  // Update the URL format to include the storage mode
   useEffect(() => {
     const currentPath = window.location.pathname;
     if (activeConversation) {
-      const expectedPath = `/c/${activeConversation.id}`;
+      const expectedPath = `/c/${storageMode}/${activeConversation.id}`;
       if (currentPath !== expectedPath) {
         window.history.pushState({}, "", expectedPath);
       }
     } else if (currentPath !== "/") {
       window.history.pushState({}, "", "/");
     }
-  }, [activeConversation]);
+  }, [activeConversation, storageMode]);
 
   // Close storage dropdown when clicking outside or pressing Escape
   useEffect(() => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useChat } from "./hooks/useChat";
 import { useModels, DEFAULT_MODEL_ID } from "./hooks/useModels";
 import type { StorageMode } from "./storage";
@@ -54,22 +54,32 @@ export default function App() {
     loadConversations();
   }, [loadConversations]);
 
-  // Check the URL on the very first render
+  const initialLoadDone = useRef(false);
+
+  // Check the URL on the very first render safely
   useEffect(() => {
+    if (initialLoadDone.current) return;
+
     const path = window.location.pathname;
     if (path.startsWith("/c/")) {
       const id = path.slice(3);
-      selectConversation(id);
+      if (id) selectConversation(id);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+
+    initialLoadDone.current = true;
+  }, [selectConversation]);
 
   // Browser Back/Forward: Listen to history pops
   useEffect(() => {
     const handlePopState = () => {
       const path = window.location.pathname;
       if (path.startsWith("/c/")) {
-        selectConversation(path.slice(3));
+        const id = path.slice(3);
+        if (id) {
+          selectConversation(id);
+        } else {
+          clearConversation();
+        }
       } else {
         clearConversation();
       }

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { Conversation } from "../storage";
+import type { Conversation, StorageMode } from "../storage";
 import ConfirmModal from "./ConfirmModal";
 
 interface SidebarProps {
@@ -8,9 +8,11 @@ interface SidebarProps {
   isOpen: boolean;
   onClose: () => void;
   onSelect: (id: string) => void;
-  onNew: () => void;
+  onNew: (mode?: StorageMode) => void;
   onDelete: (id: string) => void;
   onSettingsOpen: () => void;
+  currentMode: StorageMode;
+  savedMode: StorageMode;
 }
 
 export default function Sidebar({
@@ -22,6 +24,8 @@ export default function Sidebar({
   onNew,
   onDelete,
   onSettingsOpen,
+  currentMode,
+  savedMode,
 }: SidebarProps) {
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
 
@@ -32,13 +36,36 @@ export default function Sidebar({
           isOpen ? "translate-x-0" : "-translate-x-full md:-ml-64"
         }`}
       >
-        <div className="p-4 border-b border-gray-200 dark:border-gray-800">
-          <button
-            onClick={onNew}
-            className="w-full py-2 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
-          >
-            New Chat
-          </button>
+        {/* Explicit split-button flow to the Sidebar for "New Chat" actions when a user views a deep link
+          that differs from their saved default storage mode. The user can now seamlessly opt to return to
+          their default workspace or explicitly create a new chat in the temporary storage mode they are viewing,
+          preventing accidental database pollution. */}
+        <div className="p-4 border-b border-gray-200 dark:border-gray-800 flex flex-col gap-2">
+          {currentMode === savedMode ? (
+            <button
+              onClick={() => onNew(currentMode)}
+              className="w-full py-2 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+            >
+              New Chat
+            </button>
+          ) : (
+            <>
+              <button
+                onClick={() => onNew(savedMode)}
+                className="w-full py-2 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+                title={`Return to your default ${savedMode} workspace`}
+              >
+                New Chat in {savedMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
+              </button>
+              <button
+                onClick={() => onNew(currentMode)}
+                className="w-full py-2 px-4 rounded-lg bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium transition-colors"
+                title={`Create a new chat in the current temporary ${currentMode} workspace`}
+              >
+                New Chat in {currentMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
+              </button>
+            </>
+          )}
         </div>
 
         <nav className="flex-1 overflow-y-auto p-2 space-y-1">

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -12,6 +12,7 @@ interface UseChatReturn {
   selectConversation: (id: string) => Promise<void>;
   newConversation: (model: string) => Promise<Conversation>;
   deleteConversation: (id: string) => Promise<void>;
+  clearConversation: () => void;
   sendMessage: (
     content: string,
     model: string,
@@ -81,6 +82,12 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     },
     [storage, activeConversation],
   );
+
+  const clearConversation = useCallback(() => {
+    setActiveConversation(null);
+    setMessages([]);
+    setError(null);
+  }, []);
 
   const sendMessage = useCallback(
     async (
@@ -237,6 +244,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     selectConversation,
     newConversation,
     deleteConversation,
+    clearConversation,
     sendMessage,
   };
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,18 @@ compatibility_flags = ["nodejs_compat"]
 # Built React app served as static assets
 [assets]
 directory = "./dist"
+# Enables Single Page Application routing (serves index.html for unknown routes like /c/cloud/123)
 not_found_handling = "single-page-application"
+# --- ROUTING ESCAPE HATCH ---
+# Currently, Cloudflare smartly routes fetch() calls to the Hono backend without explicit config.
+# It does this by reading request headers (like `Sec-Fetch-Mode: cors` or `Accept: application/json`)
+# to differentiate between a human navigating to a URL and React fetching API data.
+#
+# IF THIS BREAKS IN THE FUTURE (e.g., /api/ requests start returning the React index.html file),
+# uncomment the line below. This explicitly forces the edge network to run the Worker script
+# for all API routes before checking the static assets folder.
+#
+# run_worker_first = ["/api/*"]
 
 # Workers AI binding
 [ai]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,7 @@ compatibility_flags = ["nodejs_compat"]
 # Built React app served as static assets
 [assets]
 directory = "./dist"
+not_found_handling = "single-page-application"
 
 # Workers AI binding
 [ai]


### PR DESCRIPTION
## Description
**Fixes #30** 

Added native browser History API integration (`window.history.pushState` and `popstate` listeners) to support deep linking into specific conversations using the `/c/:id` route format. Added a `clearConversation` method to the `useChat` hook to properly handle routing back to the root (`/`) path. This approach adds bookmarkable URLs with zero external routing dependencies.

✅ **Note**: This works flawlessly with Vite's default SPA behavior on Local development. But we might need to configure deployment on Cloudflare to redirect all missing routes to index.html.

**Update**: Added `not_found_handling = "single-page-application"` to `wrangler.toml`. This ensures Cloudflare redirects all missing routes to index.html.

## Checklist

- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)


## 1-Click Test Deployment
Want to test these changes live without setting up a local environment? Use the button below to deploy this exact branch directly to your own Cloudflare account.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/30-deep-linking-chat-id-url)
