### PR TITLE
Major UX/UI Overhaul

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -11,9 +11,50 @@ import SettingsModal from "./components/SettingsModal";
 const STORAGE_MODE_KEY = "waichat:storage-mode";
 const SYSTEM_PROMPT_KEY = "waichat:system-prompt";
 const DEFAULT_MODEL_KEY = "waichat:default-model";
+export const THEME_KEY = "waichat:theme";
 const MOBILE_BREAKPOINT = 768;
 
+export type ThemeMode = "system" | "light" | "dark";
+
 export default function App() {
+  const [theme, setTheme] = useState<ThemeMode>(() => {
+    if (typeof window !== "undefined") {
+      return (localStorage.getItem(THEME_KEY) as ThemeMode) || "system";
+    }
+    return "system";
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.remove("light", "dark");
+
+    if (theme === "system") {
+      const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+      root.classList.add(systemTheme);
+    } else {
+      root.classList.add(theme);
+    }
+
+    // Instantly save to localStorage whenever theme changes
+    localStorage.setItem(THEME_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (theme !== "system") return;
+
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleChange = () => {
+      const root = window.document.documentElement;
+      root.classList.remove("light", "dark");
+      root.classList.add(mediaQuery.matches ? "dark" : "light");
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, [theme]);
+
   // Track the actual saved preference in localStorage separately
   const [savedStorageMode, setSavedStorageMode] = useState<StorageMode>(() => {
     if (typeof window !== "undefined") {
@@ -222,23 +263,27 @@ export default function App() {
   };
 
   return (
-    <div
-      className="relative flex h-screen w-full overflow-hidden font-sans text-white/95"
-      style={{
-        background:
-          "radial-gradient(circle at 15% 50%, #1a1e36, #000 50%), radial-gradient(circle at 85% 30%, #2a1635, #000 50%)",
-        backgroundColor: "#000",
-      }}
-    >
+    <div className="relative flex h-screen w-full overflow-hidden font-sans text-gray-900 dark:text-white/95">
+      {/* Full-screen base layers */}
+      <div className="absolute inset-0 bg-gradient-to-br from-gray-50 to-gray-200 dark:from-transparent dark:to-transparent z-0 transition-colors duration-300" />
+      <div
+        className="absolute inset-0 z-0 hidden dark:block transition-opacity duration-300"
+        style={{
+          background:
+            "radial-gradient(circle at 15% 50%, #1a1e36, #000 50%), radial-gradient(circle at 85% 30%, #2a1635, #000 50%)",
+          backgroundColor: "#000",
+        }}
+      />
+
       {/* Full-screen glassmorphism base layer */}
-      <div className="absolute inset-0 bg-[#1e1e20]/75 backdrop-blur-[40px] backdrop-saturate-[180%] pointer-events-none z-0" />
+      <div className="absolute inset-0 bg-white/40 dark:bg-[#1e1e20]/75 backdrop-blur-[40px] backdrop-saturate-[180%] pointer-events-none z-0 transition-colors duration-300" />
 
       {/* Interactive Content Wrapper */}
       <div className="relative z-10 flex h-full w-full">
         {/* Mobile Backdrop Overlay */}
         {sidebarOpen && (
           <div
-            className="absolute inset-0 bg-black/40 backdrop-blur-sm z-20 md:hidden transition-opacity"
+            className="absolute inset-0 bg-black/20 dark:bg-black/40 backdrop-blur-sm z-20 md:hidden transition-opacity"
             onClick={() => setSidebarOpen(false)}
           />
         )}
@@ -258,12 +303,12 @@ export default function App() {
 
         <main className="flex flex-col flex-1 min-w-0 h-full">
           {/* TOPBAR */}
-          <header className="flex items-center justify-between px-5 py-4 border-b-[0.5px] border-white/10 shrink-0">
+          <header className="flex items-center justify-between px-5 py-4 border-b-[0.5px] border-black/5 dark:border-white/10 shrink-0 transition-colors duration-300">
             <div className="flex items-center gap-3">
               {!sidebarOpen && (
                 <button
                   onClick={() => setSidebarOpen(true)}
-                  className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors focus:outline-none"
+                  className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none"
                   aria-label="Open sidebar"
                 >
                   <svg
@@ -278,9 +323,9 @@ export default function App() {
                 </button>
               )}
 
-              <div className="flex items-center gap-2 bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all">
+              <div className="flex items-center gap-2 bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all">
                 <div className="w-2 h-2 rounded-full bg-[#0A84FF]"></div>
-                <div className="flex-1 min-w-0 text-xs md:text-sm font-medium text-white/65 [&_select]:text-white/65 [&_select]:bg-transparent [&_select]:border-none [&_select]:py-0 [&_select]:pl-0 [&_select]:pr-4 [&_select]:outline-none [&_select]:cursor-pointer [&_select]:appearance-none">
+                <div className="flex-1 min-w-0 text-xs md:text-sm font-medium text-gray-700 dark:text-white/65 [&_select]:text-gray-700 dark:[&_select]:text-white/65 [&_select]:bg-transparent [&_select]:border-none [&_select]:py-0 [&_select]:pl-0 [&_select]:pr-4 [&_select]:outline-none [&_select]:cursor-pointer [&_select]:appearance-none">
                   <ModelPicker
                     models={models}
                     value={model}
@@ -295,13 +340,13 @@ export default function App() {
               <div className="relative storage-dropdown-container shrink-0">
                 <button
                   onClick={() => setStorageDropdownOpen(!storageDropdownOpen)}
-                  className="flex items-center gap-2 bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 rounded-full px-3 py-1.5 text-white/65 hover:text-white/95 text-xs md:text-sm font-medium cursor-pointer transition-all focus:outline-none"
+                  className="flex items-center gap-2 bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/5 dark:border-white/10 rounded-full px-3 py-1.5 text-gray-700 hover:text-gray-900 dark:text-white/65 dark:hover:text-white/95 text-xs md:text-sm font-medium cursor-pointer transition-all focus:outline-none"
                   aria-expanded={storageDropdownOpen}
                 >
                   {storageMode === "cloud" ? (
-                    <div className="w-2 h-2 rounded-full bg-[#34C759] shadow-[0_0_4px_rgba(52,199,89,0.5)]"></div>
+                    <div className="w-2 h-2 rounded-full bg-[#34C759] shadow-[0_0_4px_rgba(52,199,89,0.3)] dark:shadow-[0_0_4px_rgba(52,199,89,0.5)]"></div>
                   ) : (
-                    <div className="w-2 h-2 rounded-full bg-[#FF9F0A] shadow-[0_0_4px_rgba(255,159,10,0.5)]"></div>
+                    <div className="w-2 h-2 rounded-full bg-[#FF9F0A] shadow-[0_0_4px_rgba(255,159,10,0.3)] dark:shadow-[0_0_4px_rgba(255,159,10,0.5)]"></div>
                   )}
                   {storageMode === "cloud" ? "Cloud" : "Local"}
                   <svg className="w-3 h-3 ml-1" viewBox="0 0 12 12" fill="currentColor">
@@ -311,7 +356,7 @@ export default function App() {
 
                 <div
                   role="menu"
-                  className={`absolute right-0 top-full mt-2 w-64 bg-[#1e1e20]/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.5)] overflow-hidden transition-all duration-200 z-50 origin-top-right ${
+                  className={`absolute right-0 top-full mt-2 w-64 bg-white/95 dark:bg-[#1e1e20]/95 backdrop-blur-xl border border-black/5 dark:border-white/10 rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.1)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.5)] overflow-hidden transition-all duration-200 z-50 origin-top-right ${
                     storageDropdownOpen
                       ? "opacity-100 scale-100 visible"
                       : "opacity-0 scale-95 invisible"
@@ -322,7 +367,7 @@ export default function App() {
                       key={mode}
                       role="menuitem"
                       onClick={() => handleStorageToggle(mode)}
-                      className={`w-full flex items-start gap-3 px-4 py-3.5 text-left hover:bg-white/10 transition-colors ${
+                      className={`w-full flex items-start gap-3 px-4 py-3.5 text-left hover:bg-black/5 dark:hover:bg-white/10 transition-colors ${
                         storageMode === mode ? "bg-[#0A84FF]/10" : ""
                       }`}
                     >
@@ -331,11 +376,15 @@ export default function App() {
                       </span>
                       <div>
                         <p
-                          className={`text-sm md:text-base font-medium ${storageMode === mode ? "text-[#0A84FF]" : "text-white/95"}`}
+                          className={`text-sm md:text-base font-medium ${
+                            storageMode === mode
+                              ? "text-[#0A84FF]"
+                              : "text-gray-900 dark:text-white/95"
+                          }`}
                         >
                           {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
                         </p>
-                        <p className="text-xs md:text-sm text-white/40 mt-0.5">
+                        <p className="text-xs md:text-sm text-gray-500 dark:text-white/40 mt-0.5">
                           {mode === "cloud" ? "Syncs across devices" : "Stays in your browser"}
                         </p>
                       </div>
@@ -346,7 +395,7 @@ export default function App() {
 
               <button
                 onClick={() => handleNew(storageMode)}
-                className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors"
+                className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none"
                 title="New Chat"
               >
                 <svg
@@ -363,7 +412,7 @@ export default function App() {
           </header>
 
           {error && (
-            <div className="mx-6 mt-4 px-4 py-3 bg-red-900/30 border border-red-500/30 rounded-lg text-sm text-red-400">
+            <div className="mx-6 mt-4 px-4 py-3 bg-red-100/50 dark:bg-red-900/30 border border-red-200 dark:border-red-500/30 rounded-lg text-sm text-red-600 dark:text-red-400">
               {error}
             </div>
           )}
@@ -383,6 +432,8 @@ export default function App() {
           onSystemPromptChange={handleSystemPromptChange}
           models={models}
           onClearConversations={handleClearConversations}
+          theme={theme}
+          onThemeChange={setTheme}
         />
       </div>
     </div>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -24,6 +24,8 @@ export default function App() {
     return "system";
   });
 
+  const [pendingPrompt, setPendingPrompt] = useState("");
+
   useEffect(() => {
     const root = window.document.documentElement;
     root.classList.remove("light", "dark");
@@ -425,8 +427,17 @@ export default function App() {
             </div>
           )}
 
-          <MessageList messages={messages} isStreaming={isStreaming} />
-          <ChatInput onSend={handleSend} disabled={isStreaming} />
+          <MessageList
+            messages={messages}
+            isStreaming={isStreaming}
+            onSelectPrompt={setPendingPrompt}
+          />
+          <ChatInput
+            onSend={handleSend}
+            disabled={isStreaming}
+            initialValue={pendingPrompt}
+            onClearInitialValue={() => setPendingPrompt("")}
+          />
         </main>
 
         <SettingsModal

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -19,7 +19,8 @@ export type ThemeMode = "system" | "light" | "dark";
 export default function App() {
   const [theme, setTheme] = useState<ThemeMode>(() => {
     if (typeof window !== "undefined") {
-      return (localStorage.getItem(THEME_KEY) as ThemeMode) || "system";
+      const stored = localStorage.getItem(THEME_KEY);
+      return stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
     }
     return "system";
   });
@@ -332,7 +333,7 @@ export default function App() {
 
               <div className="flex items-center gap-2 bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all">
                 <div className="w-2 h-2 rounded-full bg-[#0A84FF]"></div>
-                <div className="flex-1 min-w-0 text-xs md:text-sm font-medium text-gray-700 dark:text-white/65 [&_select]:text-gray-700 dark:[&_select]:text-white/65 [&_select]:bg-transparent [&_select]:border-none [&_select]:py-0 [&_select]:pl-0 [&_select]:pr-4 [&_select]:outline-none [&_select]:cursor-pointer [&_select]:appearance-none">
+                <div className="flex-1 min-w-0">
                   <ModelPicker
                     models={models}
                     value={model}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -222,139 +222,169 @@ export default function App() {
   };
 
   return (
-    <div className="flex h-screen overflow-hidden bg-white dark:bg-gray-950 text-gray-900 dark:text-gray-100">
-      {/* Mobile Backdrop Overlay */}
-      {sidebarOpen && (
-        <div
-          className="fixed inset-0 bg-black/50 backdrop-blur-sm z-20 md:hidden transition-opacity"
-          onClick={() => setSidebarOpen(false)}
-        />
-      )}
+    <div
+      className="relative flex h-screen w-full overflow-hidden font-sans text-white/95"
+      style={{
+        background:
+          "radial-gradient(circle at 15% 50%, #1a1e36, #000 50%), radial-gradient(circle at 85% 30%, #2a1635, #000 50%)",
+        backgroundColor: "#000",
+      }}
+    >
+      {/* Full-screen glassmorphism base layer */}
+      <div className="absolute inset-0 bg-[#1e1e20]/75 backdrop-blur-[40px] backdrop-saturate-[180%] pointer-events-none z-0" />
 
-      <Sidebar
-        conversations={conversations}
-        activeId={activeConversation?.id ?? null}
-        isOpen={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
-        onSelect={handleSelectConversation}
-        onNew={handleNew}
-        onDelete={deleteConversation}
-        onSettingsOpen={() => setSettingsOpen(true)}
-        currentMode={storageMode}
-        savedMode={savedStorageMode}
-      />
-
-      <main className="flex flex-col flex-1 min-w-0">
-        <header className="flex items-center justify-between px-3 md:px-6 py-3 border-b border-gray-200 dark:border-gray-800 shrink-0 gap-2">
-          <div className="flex items-center gap-2 md:gap-3 flex-1 min-w-0">
-            {!sidebarOpen && (
-              <button
-                onClick={() => setSidebarOpen(true)}
-                className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 focus:outline-none transition-colors shrink-0"
-                aria-label="Open sidebar"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M4 6h16M4 12h16M4 18h16"
-                  />
-                </svg>
-              </button>
-            )}
-            <div className="flex-1 min-w-0">
-              <ModelPicker
-                models={models}
-                value={model}
-                onChange={handleDefaultModelChange}
-                disabled={isStreaming}
-              />
-            </div>
-          </div>
-
-          <div className="relative storage-dropdown-container shrink-0">
-            <button
-              onClick={() => setStorageDropdownOpen(!storageDropdownOpen)}
-              className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 border border-gray-200 dark:border-gray-700 rounded-lg px-2 md:px-3 py-1.5 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
-              aria-label="Toggle storage mode"
-              aria-expanded={storageDropdownOpen}
-              aria-haspopup="true"
-            >
-              <span className="text-base md:text-sm leading-none">
-                {storageMode === "cloud" ? "☁️" : "💾"}
-              </span>
-              <span className="hidden md:inline">
-                {storageMode === "cloud" ? "Cloud" : "Local"}
-              </span>
-              <svg className="hidden md:block w-3 h-3" viewBox="0 0 12 12" fill="currentColor">
-                <path d="M6 8L1 3h10z" />
-              </svg>
-            </button>
-
-            <div
-              role="menu"
-              className={`absolute right-0 top-full mt-1 w-56 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-lg overflow-hidden transition-all duration-200 z-10 origin-top-right ${
-                storageDropdownOpen
-                  ? "opacity-100 scale-100 visible"
-                  : "opacity-0 scale-95 invisible"
-              }`}
-            >
-              {(["cloud", "local"] as StorageMode[]).map((mode) => (
-                <button
-                  key={mode}
-                  role="menuitem"
-                  onClick={() => handleStorageToggle(mode)}
-                  className={`w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${
-                    storageMode === mode ? "bg-indigo-50 dark:bg-indigo-950" : ""
-                  }`}
-                >
-                  <span className="text-base mt-0.5">{mode === "cloud" ? "☁️" : "💾"}</span>
-                  <div>
-                    <p
-                      className={`text-sm font-medium ${storageMode === mode ? "text-indigo-600 dark:text-indigo-400" : "text-gray-700 dark:text-gray-300"}`}
-                    >
-                      {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
-                    </p>
-                    <p className="text-xs text-gray-400 dark:text-gray-600 mt-0.5">
-                      {mode === "cloud"
-                        ? "Syncs across devices via Cloudflare D1"
-                        : "Stays in your browser, never uploaded"}
-                    </p>
-                  </div>
-                  {storageMode === mode && (
-                    <span className="ml-auto text-indigo-600 dark:text-indigo-400 text-xs mt-1">
-                      ✓
-                    </span>
-                  )}
-                </button>
-              ))}
-            </div>
-          </div>
-        </header>
-
-        {error && (
-          <div className="mx-6 mt-4 px-4 py-2 bg-red-50 dark:bg-red-950 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-600 dark:text-red-400">
-            {error}
-          </div>
+      {/* Interactive Content Wrapper */}
+      <div className="relative z-10 flex h-full w-full">
+        {/* Mobile Backdrop Overlay */}
+        {sidebarOpen && (
+          <div
+            className="absolute inset-0 bg-black/40 backdrop-blur-sm z-20 md:hidden transition-opacity"
+            onClick={() => setSidebarOpen(false)}
+          />
         )}
 
-        <MessageList messages={messages} isStreaming={isStreaming} />
-        <ChatInput onSend={handleSend} disabled={isStreaming} />
-      </main>
+        <Sidebar
+          conversations={conversations}
+          activeId={activeConversation?.id ?? null}
+          isOpen={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
+          onSelect={handleSelectConversation}
+          onNew={handleNew}
+          onDelete={deleteConversation}
+          onSettingsOpen={() => setSettingsOpen(true)}
+          currentMode={storageMode}
+          savedMode={savedStorageMode}
+        />
 
-      <SettingsModal
-        open={settingsOpen}
-        onClose={() => setSettingsOpen(false)}
-        storageMode={storageMode}
-        onStorageModeChange={handleStorageToggle}
-        defaultModel={model}
-        onDefaultModelChange={handleDefaultModelChange}
-        systemPrompt={systemPrompt}
-        onSystemPromptChange={handleSystemPromptChange}
-        models={models}
-        onClearConversations={handleClearConversations}
-      />
+        <main className="flex flex-col flex-1 min-w-0 h-full">
+          {/* TOPBAR */}
+          <header className="flex items-center justify-between px-5 py-4 border-b-[0.5px] border-white/10 shrink-0">
+            <div className="flex items-center gap-3">
+              {!sidebarOpen && (
+                <button
+                  onClick={() => setSidebarOpen(true)}
+                  className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors focus:outline-none"
+                  aria-label="Open sidebar"
+                >
+                  <svg
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    className="w-5 h-5 stroke-2"
+                  >
+                    <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+                    <line x1="9" y1="3" x2="9" y2="21"></line>
+                  </svg>
+                </button>
+              )}
+
+              <div className="flex items-center gap-2 bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all">
+                <div className="w-2 h-2 rounded-full bg-[#0A84FF]"></div>
+                <div className="flex-1 min-w-0 text-xs md:text-sm font-medium text-white/65 [&_select]:text-white/65 [&_select]:bg-transparent [&_select]:border-none [&_select]:py-0 [&_select]:pl-0 [&_select]:pr-4 [&_select]:outline-none [&_select]:cursor-pointer [&_select]:appearance-none">
+                  <ModelPicker
+                    models={models}
+                    value={model}
+                    onChange={handleDefaultModelChange}
+                    disabled={isStreaming}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <div className="relative storage-dropdown-container shrink-0">
+                <button
+                  onClick={() => setStorageDropdownOpen(!storageDropdownOpen)}
+                  className="flex items-center gap-2 bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 rounded-full px-3 py-1.5 text-white/65 hover:text-white/95 text-xs md:text-sm font-medium cursor-pointer transition-all focus:outline-none"
+                  aria-expanded={storageDropdownOpen}
+                >
+                  {storageMode === "cloud" ? (
+                    <div className="w-2 h-2 rounded-full bg-[#34C759] shadow-[0_0_4px_rgba(52,199,89,0.5)]"></div>
+                  ) : (
+                    <div className="w-2 h-2 rounded-full bg-[#FF9F0A] shadow-[0_0_4px_rgba(255,159,10,0.5)]"></div>
+                  )}
+                  {storageMode === "cloud" ? "Cloud" : "Local"}
+                  <svg className="w-3 h-3 ml-1" viewBox="0 0 12 12" fill="currentColor">
+                    <path d="M6 8L1 3h10z" />
+                  </svg>
+                </button>
+
+                <div
+                  role="menu"
+                  className={`absolute right-0 top-full mt-2 w-64 bg-[#1e1e20]/95 backdrop-blur-xl border border-white/10 rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.5)] overflow-hidden transition-all duration-200 z-50 origin-top-right ${
+                    storageDropdownOpen
+                      ? "opacity-100 scale-100 visible"
+                      : "opacity-0 scale-95 invisible"
+                  }`}
+                >
+                  {(["cloud", "local"] as StorageMode[]).map((mode) => (
+                    <button
+                      key={mode}
+                      role="menuitem"
+                      onClick={() => handleStorageToggle(mode)}
+                      className={`w-full flex items-start gap-3 px-4 py-3.5 text-left hover:bg-white/10 transition-colors ${
+                        storageMode === mode ? "bg-[#0A84FF]/10" : ""
+                      }`}
+                    >
+                      <span className="text-base md:text-lg mt-0.5">
+                        {mode === "cloud" ? "☁️" : "💾"}
+                      </span>
+                      <div>
+                        <p
+                          className={`text-sm md:text-base font-medium ${storageMode === mode ? "text-[#0A84FF]" : "text-white/95"}`}
+                        >
+                          {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
+                        </p>
+                        <p className="text-xs md:text-sm text-white/40 mt-0.5">
+                          {mode === "cloud" ? "Syncs across devices" : "Stays in your browser"}
+                        </p>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <button
+                onClick={() => handleNew(storageMode)}
+                className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors"
+                title="New Chat"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  className="w-5 h-5 stroke-2"
+                >
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                </svg>
+              </button>
+            </div>
+          </header>
+
+          {error && (
+            <div className="mx-6 mt-4 px-4 py-3 bg-red-900/30 border border-red-500/30 rounded-lg text-sm text-red-400">
+              {error}
+            </div>
+          )}
+
+          <MessageList messages={messages} isStreaming={isStreaming} />
+          <ChatInput onSend={handleSend} disabled={isStreaming} />
+        </main>
+
+        <SettingsModal
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+          storageMode={storageMode}
+          onStorageModeChange={handleStorageToggle}
+          defaultModel={model}
+          onDefaultModelChange={handleDefaultModelChange}
+          systemPrompt={systemPrompt}
+          onSystemPromptChange={handleSystemPromptChange}
+          models={models}
+          onClearConversations={handleClearConversations}
+        />
+      </div>
     </div>
   );
 }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -225,6 +225,11 @@ export default function App() {
       window.history.pushState({}, "", "/");
     } else {
       // Standard new chat in the current mode
+      // Prevent creating multiple empty chats if the current one is already empty
+      if (activeConversation && messages.length === 0) {
+        closeSidebarOnMobile();
+        return;
+      }
       await newConversation(model);
     }
     closeSidebarOnMobile();
@@ -356,7 +361,7 @@ export default function App() {
 
                 <div
                   role="menu"
-                  className={`absolute right-0 top-full mt-2 w-64 bg-white/95 dark:bg-[#1e1e20]/95 backdrop-blur-xl border border-black/5 dark:border-white/10 rounded-xl shadow-[0_10px_30px_rgba(0,0,0,0.1)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.5)] overflow-hidden transition-all duration-200 z-50 origin-top-right ${
+                  className={`absolute right-0 top-full mt-2 w-60 p-1.5 bg-white/95 dark:bg-[#1e1e20]/95 backdrop-blur-xl border-[0.5px] border-black/10 dark:border-white/10 rounded-2xl shadow-[0_10px_40px_rgba(0,0,0,0.1)] dark:shadow-[0_10px_40px_rgba(0,0,0,0.5)] overflow-hidden transition-all duration-200 z-50 origin-top-right ${
                     storageDropdownOpen
                       ? "opacity-100 scale-100 visible"
                       : "opacity-0 scale-95 invisible"
@@ -367,27 +372,30 @@ export default function App() {
                       key={mode}
                       role="menuitem"
                       onClick={() => handleStorageToggle(mode)}
-                      className={`w-full flex items-start gap-3 px-4 py-3.5 text-left hover:bg-black/5 dark:hover:bg-white/10 transition-colors ${
-                        storageMode === mode ? "bg-[#0A84FF]/10" : ""
+                      className={`w-full flex flex-col items-start px-3 py-2.5 text-left rounded-xl transition-all duration-200 cursor-pointer ${
+                        storageMode === mode
+                          ? "bg-[#0A84FF]/10 dark:bg-[#0A84FF]/20"
+                          : "hover:bg-black/5 dark:hover:bg-white/10"
                       }`}
                     >
-                      <span className="text-base md:text-lg mt-0.5">
-                        {mode === "cloud" ? "☁️" : "💾"}
-                      </span>
-                      <div>
-                        <p
-                          className={`text-sm md:text-base font-medium ${
-                            storageMode === mode
-                              ? "text-[#0A84FF]"
-                              : "text-gray-900 dark:text-white/95"
-                          }`}
-                        >
-                          {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
-                        </p>
-                        <p className="text-xs md:text-sm text-gray-500 dark:text-white/40 mt-0.5">
-                          {mode === "cloud" ? "Syncs across devices" : "Stays in your browser"}
-                        </p>
-                      </div>
+                      <p
+                        className={`text-[13px] md:text-sm font-medium ${
+                          storageMode === mode
+                            ? "text-[#0A84FF] dark:text-[#3A9FFF]"
+                            : "text-gray-900 dark:text-white/95"
+                        }`}
+                      >
+                        {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
+                      </p>
+                      <p
+                        className={`text-[11px] md:text-xs mt-0.5 ${
+                          storageMode === mode
+                            ? "text-[#0A84FF]/70 dark:text-[#3A9FFF]/70"
+                            : "text-gray-500 dark:text-white/40"
+                        }`}
+                      >
+                        {mode === "cloud" ? "Syncs across devices" : "Stays in your browser"}
+                      </p>
                     </button>
                   ))}
                 </div>

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -3,11 +3,26 @@ import { useEffect, useRef, useState } from "react";
 interface ChatInputProps {
   onSend: (content: string) => void;
   disabled: boolean;
+  initialValue?: string;
+  onClearInitialValue?: () => void;
 }
 
-export default function ChatInput({ onSend, disabled }: ChatInputProps) {
+export default function ChatInput({
+  onSend,
+  disabled,
+  initialValue,
+  onClearInitialValue,
+}: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (initialValue) {
+      setValue(initialValue);
+      onClearInitialValue?.();
+      textareaRef.current?.focus();
+    }
+  }, [initialValue, onClearInitialValue]);
 
   // Auto-resize the textarea
   useEffect(() => {

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -9,6 +9,7 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  // Auto-resize the textarea
   useEffect(() => {
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
@@ -16,14 +17,20 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
     }
   }, [value]);
 
-  const handleSend = () => {
+  const handleSend = (e?: React.FormEvent) => {
+    e?.preventDefault(); // Prevent page reload if triggered via form submission
     const trimmed = value.trim();
     if (!trimmed || disabled) return;
     onSend(trimmed);
     setValue("");
+
+    // Reset height after sending
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       handleSend();
@@ -31,36 +38,63 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
   };
 
   return (
-    <div className="p-4 border-t border-gray-200 dark:border-gray-800">
-      <div className="flex items-end gap-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-2xl px-4 py-3 shadow-sm">
-        <textarea
-          ref={textareaRef}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="Message WaiChat..."
-          disabled={disabled}
-          rows={1}
-          className="flex-1 resize-none bg-transparent text-sm text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-600 outline-none max-h-40 disabled:opacity-50"
-        />
-        <button
-          onClick={handleSend}
-          disabled={disabled || !value.trim()}
-          className="shrink-0 w-8 h-8 flex items-center justify-center rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          aria-label="Send message"
+    <div className="w-full flex justify-center pb-6 pt-2 px-4 md:px-8 shrink-0">
+      <div className="w-full max-w-[720px] relative">
+        <form
+          onSubmit={handleSend}
+          className="relative flex flex-col bg-black/25 focus-within:bg-black/35 border-[0.5px] border-white/10 focus-within:border-white/20 rounded-2xl p-3 shadow-[0_4px_24px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.05)] transition-all duration-200"
         >
-          <svg
-            className="w-4 h-4 text-white"
-            viewBox="0 0 24 24"
-            fill="currentColor"
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Message WaiChat..."
+            disabled={disabled}
+            rows={1}
+            className="w-full bg-transparent border-none text-white/95 text-base outline-none resize-none leading-relaxed min-h-[24px] max-h-[200px] pr-12 placeholder:text-white/40 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
+          />
+
+          <button
+            type="submit"
+            disabled={disabled || !value.trim()}
+            className="absolute right-3 top-2.5 w-8 h-8 bg-white/10 border-[0.5px] border-white/10 rounded-full flex items-center justify-center text-white/80 hover:bg-white hover:text-black hover:scale-105 disabled:opacity-40 disabled:hover:bg-white/10 disabled:hover:text-white/80 disabled:hover:scale-100 transition-all duration-200 cursor-pointer"
+            aria-label="Send message"
           >
-            <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
-          </svg>
-        </button>
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              className="w-4 h-4 stroke-[2.5]"
+            >
+              <line x1="22" y1="2" x2="11" y2="13"></line>
+              <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
+            </svg>
+          </button>
+
+          <div className="flex justify-between items-center mt-3 border-t-[0.5px] border-white/5 pt-2">
+            <button
+              type="button"
+              className="flex items-center gap-2 bg-transparent border-none text-white/50 hover:text-white/95 text-[13px] md:text-sm font-medium cursor-pointer transition-colors focus:outline-none"
+              aria-label="Attach file"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="w-5 h-5 stroke-[1.5]"
+              >
+                <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path>
+              </svg>
+              Attach
+            </button>
+          </div>
+        </form>
+
+        <div className="text-center text-xs text-white/40 mt-3 hidden md:block tracking-wide">
+          Press Enter to send · Shift + Enter for new line
+        </div>
       </div>
-      <p className="text-xs text-gray-400 dark:text-gray-600 text-center mt-2">
-        Enter to send · Shift+Enter for new line
-      </p>
     </div>
   );
 }

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -42,7 +42,7 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
       <div className="w-full max-w-[720px] relative">
         <form
           onSubmit={handleSend}
-          className="relative flex flex-col bg-black/25 focus-within:bg-black/35 border-[0.5px] border-white/10 focus-within:border-white/20 rounded-2xl p-3 shadow-[0_4px_24px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.05)] transition-all duration-200"
+          className="relative flex flex-col bg-white/60 dark:bg-black/25 focus-within:bg-white/80 dark:focus-within:bg-black/35 border-[0.5px] border-black/10 dark:border-white/10 focus-within:border-black/20 dark:focus-within:border-white/20 rounded-2xl p-3 shadow-[0_4px_24px_rgba(0,0,0,0.05),inset_0_1px_0_rgba(255,255,255,0.6)] dark:shadow-[0_4px_24px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.05)] transition-all duration-200"
         >
           <textarea
             ref={textareaRef}
@@ -52,13 +52,13 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
             placeholder="Message WaiChat..."
             disabled={disabled}
             rows={1}
-            className="w-full bg-transparent border-none text-white/95 text-base outline-none resize-none leading-relaxed min-h-[24px] max-h-[200px] pr-12 placeholder:text-white/40 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
+            className="w-full bg-transparent border-none text-gray-900 dark:text-white/95 text-base outline-none resize-none leading-relaxed min-h-[24px] max-h-[200px] pr-12 placeholder:text-gray-400 dark:placeholder:text-white/40 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
           />
 
           <button
             type="submit"
             disabled={disabled || !value.trim()}
-            className="absolute right-3 top-2.5 w-8 h-8 bg-white/10 border-[0.5px] border-white/10 rounded-full flex items-center justify-center text-white/80 hover:bg-white hover:text-black hover:scale-105 disabled:opacity-40 disabled:hover:bg-white/10 disabled:hover:text-white/80 disabled:hover:scale-100 transition-all duration-200 cursor-pointer"
+            className="absolute right-3 top-2.5 w-8 h-8 bg-black/5 dark:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 rounded-full flex items-center justify-center text-gray-500 dark:text-white/80 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black hover:scale-105 disabled:opacity-40 disabled:hover:bg-black/5 disabled:hover:text-gray-500 dark:disabled:hover:bg-white/10 dark:disabled:hover:text-white/80 disabled:hover:scale-100 transition-all duration-200 cursor-pointer"
             aria-label="Send message"
           >
             <svg
@@ -72,10 +72,10 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
             </svg>
           </button>
 
-          <div className="flex justify-between items-center mt-3 border-t-[0.5px] border-white/5 pt-2">
+          <div className="flex justify-between items-center mt-3 border-t-[0.5px] border-black/5 dark:border-white/5 pt-2">
             <button
               type="button"
-              className="flex items-center gap-2 bg-transparent border-none text-white/50 hover:text-white/95 text-[13px] md:text-sm font-medium cursor-pointer transition-colors focus:outline-none"
+              className="flex items-center gap-2 bg-transparent border-none text-gray-500 hover:text-gray-900 dark:text-white/50 dark:hover:text-white/95 text-[13px] md:text-sm font-medium cursor-pointer transition-colors focus:outline-none"
               aria-label="Attach file"
             >
               <svg
@@ -91,7 +91,7 @@ export default function ChatInput({ onSend, disabled }: ChatInputProps) {
           </div>
         </form>
 
-        <div className="text-center text-xs text-white/40 mt-3 hidden md:block tracking-wide">
+        <div className="text-center text-xs text-gray-400 dark:text-white/40 mt-3 hidden md:block tracking-wide">
           Press Enter to send · Shift + Enter for new line
         </div>
       </div>

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -87,7 +87,7 @@ export default function ChatInput({
             </svg>
           </button>
 
-          <div className="flex justify-between items-center mt-3 border-t-[0.5px] border-black/5 dark:border-white/5 pt-2">
+          {/*<div className="flex justify-between items-center mt-3 border-t-[0.5px] border-black/5 dark:border-white/5 pt-2">
             <button
               type="button"
               className="flex items-center gap-2 bg-transparent border-none text-gray-500 hover:text-gray-900 dark:text-white/50 dark:hover:text-white/95 text-[13px] md:text-sm font-medium cursor-pointer transition-colors focus:outline-none"
@@ -101,9 +101,9 @@ export default function ChatInput({
               >
                 <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path>
               </svg>
-              Attach
+              Files
             </button>
-          </div>
+          </div>*/}
         </form>
 
         <div className="text-center text-xs text-gray-400 dark:text-white/40 mt-3 hidden md:block tracking-wide">

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -5,6 +5,7 @@ import type { Message } from "../storage";
 interface MessageListProps {
   messages: Message[];
   isStreaming: boolean;
+  onSelectPrompt: (prompt: string) => void;
 }
 
 function ThoughtParser({ content }: { content: string }) {
@@ -160,7 +161,7 @@ function MarkdownRenderer({ content }: { content: string }) {
   );
 }
 
-export default function MessageList({ messages, isStreaming }: MessageListProps) {
+export default function MessageList({ messages, isStreaming, onSelectPrompt }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
@@ -208,7 +209,14 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-5 w-full max-w-[800px] mb-10">
-          <div className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+          <div
+            onClick={() =>
+              onSelectPrompt(
+                "Can you help me refactor this code snippet to be more efficient and readable?\n\n[Paste code here]",
+              )
+            }
+            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
+          >
             <div className="text-[#0A84FF] mb-4">
               <svg
                 viewBox="0 0 24 24"
@@ -227,7 +235,14 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
               Debug, explain, or improve your programming snippets.
             </div>
           </div>
-          <div className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+          <div
+            onClick={() =>
+              onSelectPrompt(
+                "Please provide a concise summary of the following text, highlighting the key takeaways:\n\n[Paste text here]",
+              )
+            }
+            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
+          >
             <div className="text-[#0A84FF] mb-4">
               <svg
                 viewBox="0 0 24 24"
@@ -249,7 +264,14 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
               Quickly distill long documents or articles down to the essentials.
             </div>
           </div>
-          <div className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+          <div
+            onClick={() =>
+              onSelectPrompt(
+                "I'm curious about [Topic]. Can you explain the core concepts and why they matter?",
+              )
+            }
+            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
+          >
             <div className="text-[#0A84FF] mb-4">
               <svg
                 viewBox="0 0 24 24"

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -79,9 +79,9 @@ function ThoughtParser({ content }: { content: string }) {
       <details
         open={isOpen}
         onToggle={handleToggle}
-        className="group border-[0.5px] border-white/10 rounded-lg bg-white/5"
+        className="group border-[0.5px] border-black/10 dark:border-white/10 rounded-lg bg-black/5 dark:bg-white/5"
       >
-        <summary className="flex items-center gap-2 px-4 py-2.5 cursor-pointer text-[13px] md:text-sm font-medium text-white/65 hover:text-white/95 select-none list-none">
+        <summary className="flex items-center gap-2 px-4 py-2.5 cursor-pointer text-[13px] md:text-sm font-medium text-gray-500 hover:text-gray-900 dark:text-white/65 dark:hover:text-white/95 select-none list-none">
           <svg
             className="w-5 h-5 transition-transform group-open:rotate-90"
             fill="none"
@@ -105,20 +105,20 @@ function ThoughtParser({ content }: { content: string }) {
 
           {isThinking ? (
             <span className="flex gap-1 ml-1">
-              <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:0ms]" />
-              <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:150ms]" />
-              <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:300ms]" />
+              <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:0ms]" />
+              <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:150ms]" />
+              <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:300ms]" />
             </span>
           ) : (
             <button
               onClick={handleCopyThought}
-              className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-xs uppercase tracking-wider px-2.5 py-1 rounded bg-white/10 hover:bg-white/20"
+              className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-xs uppercase tracking-wider px-2.5 py-1 rounded bg-black/5 hover:bg-black/10 dark:bg-white/10 dark:hover:bg-white/20"
             >
               {copied ? "Copied!" : "Copy"}
             </button>
           )}
         </summary>
-        <div className="px-4 pb-4 pt-2 text-xs md:text-sm text-white/65 whitespace-pre-wrap border-t-[0.5px] border-white/10 italic leading-relaxed">
+        <div className="px-4 pb-4 pt-2 text-xs md:text-sm text-gray-600 dark:text-white/65 whitespace-pre-wrap border-t-[0.5px] border-black/10 dark:border-white/10 italic leading-relaxed">
           {thoughtContent}
         </div>
       </details>
@@ -137,11 +137,11 @@ function MarkdownRenderer({ content }: { content: string }) {
         code: ({ children, className }) => {
           const isBlock = className?.includes("language-");
           return isBlock ? (
-            <pre className="bg-[#141416]/80 border-[0.5px] border-white/10 text-white/95 rounded-lg p-4 overflow-x-auto my-3 text-sm">
+            <pre className="bg-gray-100/80 border-[0.5px] border-black/10 text-gray-900 dark:bg-[#141416]/80 dark:border-white/10 dark:text-white/95 rounded-lg p-4 overflow-x-auto my-3 text-sm">
               <code>{children}</code>
             </pre>
           ) : (
-            <code className="bg-white/10 rounded px-1.5 py-0.5 text-sm font-mono text-[#0A84FF]">
+            <code className="bg-black/5 dark:bg-white/10 rounded px-1.5 py-0.5 text-sm font-mono text-[#0A84FF]">
               {children}
             </code>
           );
@@ -199,16 +199,16 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
           </svg>
         </div>
-        <h1 className="text-2xl md:text-3xl font-semibold text-white/95 tracking-tight text-center mb-3">
+        <h1 className="text-2xl md:text-3xl font-semibold text-gray-900 dark:text-white/95 tracking-tight text-center mb-3">
           Let's explore an idea.
         </h1>
-        <p className="text-sm md:text-base text-white/65 text-center mb-12 max-w-[450px] leading-relaxed">
+        <p className="text-sm md:text-base text-gray-600 dark:text-white/65 text-center mb-12 max-w-[450px] leading-relaxed">
           Lightning-fast AI at the edge. Powered by Cloudflare for limitless, zero-latency
           conversations.
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-5 w-full max-w-[800px] mb-10">
-          <div className="bg-white/5 border-[0.5px] border-white/10 hover:border-white/20 hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+          <div className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
             <div className="text-[#0A84FF] mb-4">
               <svg
                 viewBox="0 0 24 24"
@@ -220,14 +220,14 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
                 <polyline points="8 6 2 12 8 18"></polyline>
               </svg>
             </div>
-            <div className="text-[15px] md:text-base font-medium text-white/95 mb-1.5">
+            <div className="text-[15px] md:text-base font-medium text-gray-900 dark:text-white/95 mb-1.5">
               Refactor Code
             </div>
-            <div className="text-xs md:text-sm text-white/40 leading-relaxed">
+            <div className="text-xs md:text-sm text-gray-500 dark:text-white/40 leading-relaxed">
               Debug, explain, or improve your programming snippets.
             </div>
           </div>
-          <div className="bg-white/5 border-[0.5px] border-white/10 hover:border-white/20 hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+          <div className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
             <div className="text-[#0A84FF] mb-4">
               <svg
                 viewBox="0 0 24 24"
@@ -242,14 +242,14 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
                 <polyline points="10 9 9 9 8 9"></polyline>
               </svg>
             </div>
-            <div className="text-[15px] md:text-base font-medium text-white/95 mb-1.5">
+            <div className="text-[15px] md:text-base font-medium text-gray-900 dark:text-white/95 mb-1.5">
               Summarize Texts
             </div>
-            <div className="text-xs md:text-sm text-white/40 leading-relaxed">
+            <div className="text-xs md:text-sm text-gray-500 dark:text-white/40 leading-relaxed">
               Quickly distill long documents or articles down to the essentials.
             </div>
           </div>
-          <div className="bg-white/5 border-[0.5px] border-white/10 hover:border-white/20 hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+          <div className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
             <div className="text-[#0A84FF] mb-4">
               <svg
                 viewBox="0 0 24 24"
@@ -262,10 +262,10 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
                 <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
               </svg>
             </div>
-            <div className="text-[15px] md:text-base font-medium text-white/95 mb-1.5">
+            <div className="text-[15px] md:text-base font-medium text-gray-900 dark:text-white/95 mb-1.5">
               Explore Concepts
             </div>
-            <div className="text-xs md:text-sm text-white/40 leading-relaxed">
+            <div className="text-xs md:text-sm text-gray-500 dark:text-white/40 leading-relaxed">
               Dive into science, physics, history, or anything else you're curious about.
             </div>
           </div>
@@ -275,17 +275,17 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
   }
 
   return (
-    <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
+    <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
       {messages.map((m) => (
         <div
           key={m.id}
           className={`group flex flex-col ${m.role === "user" ? "items-end" : "items-start"}`}
         >
           <div
-            className={`max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed shadow-[0_2px_10px_rgba(0,0,0,0.1)] ${
+            className={`max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:shadow-[0_2px_10px_rgba(0,0,0,0.1)] ${
               m.role === "user"
                 ? "bg-[#0A84FF] text-white rounded-br-sm"
-                : "bg-white/5 border-[0.5px] border-white/10 text-white/95 rounded-bl-sm backdrop-blur-md"
+                : "bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-bl-sm backdrop-blur-md"
             }`}
           >
             {m.role === "assistant" ? (
@@ -297,13 +297,13 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
             {m.role === "assistant" &&
               (isStreaming && m.content === "" ? (
                 <span className="inline-flex gap-1 mt-2">
-                  <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:0ms]" />
-                  <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:150ms]" />
-                  <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:300ms]" />
+                  <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:0ms]" />
+                  <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:150ms]" />
+                  <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:300ms]" />
                 </span>
               ) : (
                 m.model && (
-                  <div className="mt-3 text-xs text-white/40 font-mono tracking-wide uppercase">
+                  <div className="mt-3 text-xs text-gray-400 dark:text-white/40 font-mono tracking-wide uppercase">
                     {m.model.split("/").pop()}
                   </div>
                 )
@@ -313,7 +313,7 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
           {m.content && (
             <button
               onClick={() => handleCopy(m.id, m.content)}
-              className="mt-2 px-3 py-1.5 text-xs font-medium text-white/40 hover:text-white/80 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1.5 cursor-pointer"
+              className="mt-2 px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1.5 cursor-pointer"
               aria-label="Copy message"
             >
               {copiedId === m.id ? (

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -7,7 +7,6 @@ interface MessageListProps {
   isStreaming: boolean;
 }
 
-// Helper component to parse and format <think>...</think> blocks
 function ThoughtParser({ content }: { content: string }) {
   const [elapsed, setElapsed] = useState(0);
   const [copied, setCopied] = useState(false);
@@ -80,11 +79,11 @@ function ThoughtParser({ content }: { content: string }) {
       <details
         open={isOpen}
         onToggle={handleToggle}
-        className="group border border-gray-200 dark:border-gray-700 rounded-lg bg-white/50 dark:bg-black/20"
+        className="group border-[0.5px] border-white/10 rounded-lg bg-white/5"
       >
-        <summary className="flex items-center gap-2 px-4 py-2 cursor-pointer text-xs font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 select-none list-none">
+        <summary className="flex items-center gap-2 px-4 py-2.5 cursor-pointer text-[13px] md:text-sm font-medium text-white/65 hover:text-white/95 select-none list-none">
           <svg
-            className="w-4 h-4 transition-transform group-open:rotate-90"
+            className="w-5 h-5 transition-transform group-open:rotate-90"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -105,21 +104,21 @@ function ThoughtParser({ content }: { content: string }) {
           </span>
 
           {isThinking ? (
-            <span className="flex gap-0.5 ml-1">
-              <span className="w-1 h-1 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
-              <span className="w-1 h-1 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
-              <span className="w-1 h-1 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
+            <span className="flex gap-1 ml-1">
+              <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:0ms]" />
+              <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:150ms]" />
+              <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:300ms]" />
             </span>
           ) : (
             <button
               onClick={handleCopyThought}
-              className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-1 rounded bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700"
+              className="opacity-0 group-hover:opacity-100 transition-opacity flex items-center gap-1 text-xs uppercase tracking-wider px-2.5 py-1 rounded bg-white/10 hover:bg-white/20"
             >
               {copied ? "Copied!" : "Copy"}
             </button>
           )}
         </summary>
-        <div className="px-4 pb-3 pt-1 text-xs text-gray-600 dark:text-gray-400 whitespace-pre-wrap border-t border-gray-100 dark:border-gray-800 italic">
+        <div className="px-4 pb-4 pt-2 text-xs md:text-sm text-white/65 whitespace-pre-wrap border-t-[0.5px] border-white/10 italic leading-relaxed">
           {thoughtContent}
         </div>
       </details>
@@ -138,19 +137,21 @@ function MarkdownRenderer({ content }: { content: string }) {
         code: ({ children, className }) => {
           const isBlock = className?.includes("language-");
           return isBlock ? (
-            <pre className="bg-gray-900 dark:bg-black text-gray-100 rounded-lg p-3 overflow-x-auto my-2 text-xs">
+            <pre className="bg-[#141416]/80 border-[0.5px] border-white/10 text-white/95 rounded-lg p-4 overflow-x-auto my-3 text-sm">
               <code>{children}</code>
             </pre>
           ) : (
-            <code className="bg-gray-200 dark:bg-gray-700 rounded px-1 py-0.5 text-xs font-mono">
+            <code className="bg-white/10 rounded px-1.5 py-0.5 text-sm font-mono text-[#0A84FF]">
               {children}
             </code>
           );
         },
-        p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-        ul: ({ children }) => <ul className="list-disc list-inside mb-2 space-y-1">{children}</ul>,
+        p: ({ children }) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
+        ul: ({ children }) => (
+          <ul className="list-disc list-inside mb-3 space-y-1.5">{children}</ul>
+        ),
         ol: ({ children }) => (
-          <ol className="list-decimal list-inside mb-2 space-y-1">{children}</ol>
+          <ol className="list-decimal list-inside mb-3 space-y-1.5">{children}</ol>
         ),
       }}
     >
@@ -180,26 +181,111 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
     }
   };
 
+  // Empty State Hero Design
   if (messages.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center text-gray-400 dark:text-gray-600">
-        <p className="text-sm">Send a message to get started</p>
+      <div className="flex-1 flex flex-col items-center justify-center p-6 overflow-y-auto w-full">
+        <div
+          className="w-16 h-16 md:w-20 md:h-20 rounded-2xl flex items-center justify-center mb-8 shadow-[0_8px_24px_rgba(10,132,255,0.3),inset_0_1px_0_rgba(255,255,255,0.4)]"
+          style={{ background: "linear-gradient(135deg, #0A84FF, #5E5CE6)" }}
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            className="w-10 h-10 text-white"
+          >
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+          </svg>
+        </div>
+        <h1 className="text-2xl md:text-3xl font-semibold text-white/95 tracking-tight text-center mb-3">
+          Let's explore an idea.
+        </h1>
+        <p className="text-sm md:text-base text-white/65 text-center mb-12 max-w-[450px] leading-relaxed">
+          Lightning-fast AI at the edge. Powered by Cloudflare for limitless, zero-latency
+          conversations.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-5 w-full max-w-[800px] mb-10">
+          <div className="bg-white/5 border-[0.5px] border-white/10 hover:border-white/20 hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+            <div className="text-[#0A84FF] mb-4">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="w-6 h-6 stroke-[1.5]"
+              >
+                <polyline points="16 18 22 12 16 6"></polyline>
+                <polyline points="8 6 2 12 8 18"></polyline>
+              </svg>
+            </div>
+            <div className="text-[15px] md:text-base font-medium text-white/95 mb-1.5">
+              Refactor Code
+            </div>
+            <div className="text-xs md:text-sm text-white/40 leading-relaxed">
+              Debug, explain, or improve your programming snippets.
+            </div>
+          </div>
+          <div className="bg-white/5 border-[0.5px] border-white/10 hover:border-white/20 hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+            <div className="text-[#0A84FF] mb-4">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="w-6 h-6 stroke-[1.5]"
+              >
+                <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                <polyline points="14 2 14 8 20 8"></polyline>
+                <line x1="16" y1="13" x2="8" y2="13"></line>
+                <line x1="16" y1="17" x2="8" y2="17"></line>
+                <polyline points="10 9 9 9 8 9"></polyline>
+              </svg>
+            </div>
+            <div className="text-[15px] md:text-base font-medium text-white/95 mb-1.5">
+              Summarize Texts
+            </div>
+            <div className="text-xs md:text-sm text-white/40 leading-relaxed">
+              Quickly distill long documents or articles down to the essentials.
+            </div>
+          </div>
+          <div className="bg-white/5 border-[0.5px] border-white/10 hover:border-white/20 hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]">
+            <div className="text-[#0A84FF] mb-4">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                className="w-6 h-6 stroke-[1.5]"
+              >
+                <circle cx="12" cy="12" r="10"></circle>
+                <line x1="2" y1="12" x2="22" y2="12"></line>
+                <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+              </svg>
+            </div>
+            <div className="text-[15px] md:text-base font-medium text-white/95 mb-1.5">
+              Explore Concepts
+            </div>
+            <div className="text-xs md:text-sm text-white/40 leading-relaxed">
+              Dive into science, physics, history, or anything else you're curious about.
+            </div>
+          </div>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="flex-1 overflow-y-auto p-6 space-y-6">
+    <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
       {messages.map((m) => (
         <div
           key={m.id}
           className={`group flex flex-col ${m.role === "user" ? "items-end" : "items-start"}`}
         >
           <div
-            className={`max-w-[75%] rounded-2xl px-4 py-3 text-sm ${
+            className={`max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed shadow-[0_2px_10px_rgba(0,0,0,0.1)] ${
               m.role === "user"
-                ? "bg-indigo-600 text-white rounded-br-sm"
-                : "bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-bl-sm"
+                ? "bg-[#0A84FF] text-white rounded-br-sm"
+                : "bg-white/5 border-[0.5px] border-white/10 text-white/95 rounded-bl-sm backdrop-blur-md"
             }`}
           >
             {m.role === "assistant" ? (
@@ -208,37 +294,35 @@ export default function MessageList({ messages, isStreaming }: MessageListProps)
               <p className="whitespace-pre-wrap">{m.content}</p>
             )}
 
-            {/* Show streaming indicator OR model attribution */}
             {m.role === "assistant" &&
               (isStreaming && m.content === "" ? (
                 <span className="inline-flex gap-1 mt-2">
-                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:0ms]" />
-                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:150ms]" />
-                  <span className="w-1.5 h-1.5 bg-gray-400 rounded-full animate-bounce [animation-delay:300ms]" />
+                  <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:0ms]" />
+                  <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:150ms]" />
+                  <span className="w-1.5 h-1.5 bg-white/40 rounded-full animate-bounce [animation-delay:300ms]" />
                 </span>
               ) : (
                 m.model && (
-                  <div className="mt-3 text-[10px] text-gray-400 dark:text-gray-500 font-mono tracking-wide uppercase">
+                  <div className="mt-3 text-xs text-white/40 font-mono tracking-wide uppercase">
                     {m.model.split("/").pop()}
                   </div>
                 )
               ))}
           </div>
 
-          {/* Master Message Copy Button */}
           {m.content && (
             <button
               onClick={() => handleCopy(m.id, m.content)}
-              className="mt-1.5 px-2 py-1 text-[11px] font-medium text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1 cursor-pointer"
+              className="mt-2 px-3 py-1.5 text-xs font-medium text-white/40 hover:text-white/80 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1.5 cursor-pointer"
               aria-label="Copy message"
             >
               {copiedId === m.id ? (
                 <>
-                  <span className="text-green-500 dark:text-green-400">✓</span> Copied
+                  <span className="text-[#34C759]">✓</span> Copied
                 </>
               ) : (
                 <>
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -304,7 +304,7 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
           className={`group flex flex-col ${m.role === "user" ? "items-end" : "items-start"}`}
         >
           <div
-            className={`max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed shadow-[0_2px_10px_rgba(0,0,0,0.05)] dark:shadow-[0_2px_10px_rgba(0,0,0,0.1)] ${
+            className={`max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed ${
               m.role === "user"
                 ? "bg-[#0A84FF] text-white rounded-br-sm"
                 : "bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-bl-sm backdrop-blur-md"
@@ -325,8 +325,8 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
                 </span>
               ) : (
                 m.model && (
-                  <div className="mt-3 text-xs text-gray-400 dark:text-white/40 font-mono tracking-wide uppercase">
-                    {m.model.split("/").pop()}
+                  <div className="mt-3 text-xs text-gray-400 dark:text-white/40 capitalize">
+                    {m.model.split("/").pop()?.replaceAll("-", " ")}
                   </div>
                 )
               ))}

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -209,13 +209,14 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-5 w-full max-w-[800px] mb-10">
-          <div
+          <button
+            type="button"
             onClick={() =>
               onSelectPrompt(
                 "Can you help me refactor this code snippet to be more efficient and readable?\n\n[Paste code here]",
               )
             }
-            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
+            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 text-left cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
           >
             <div className="text-[#0A84FF] mb-4">
               <svg
@@ -234,14 +235,15 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
             <div className="text-xs md:text-sm text-gray-500 dark:text-white/40 leading-relaxed">
               Debug, explain, or improve your programming snippets.
             </div>
-          </div>
-          <div
+          </button>
+          <button
+            type="button"
             onClick={() =>
               onSelectPrompt(
                 "Please provide a concise summary of the following text, highlighting the key takeaways:\n\n[Paste text here]",
               )
             }
-            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
+            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 text-left cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
           >
             <div className="text-[#0A84FF] mb-4">
               <svg
@@ -263,14 +265,15 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
             <div className="text-xs md:text-sm text-gray-500 dark:text-white/40 leading-relaxed">
               Quickly distill long documents or articles down to the essentials.
             </div>
-          </div>
-          <div
+          </button>
+          <button
+            type="button"
             onClick={() =>
               onSelectPrompt(
                 "I'm curious about [Topic]. Can you explain the core concepts and why they matter?",
               )
             }
-            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
+            className="bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:border-black/20 dark:hover:border-white/20 hover:bg-white/80 dark:hover:bg-white/10 rounded-xl p-5 text-left cursor-pointer backdrop-blur-md transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_8px_24px_rgba(0,0,0,0.05)] dark:hover:shadow-[0_8px_24px_rgba(0,0,0,0.15)]"
           >
             <div className="text-[#0A84FF] mb-4">
               <svg
@@ -290,7 +293,7 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
             <div className="text-xs md:text-sm text-gray-500 dark:text-white/40 leading-relaxed">
               Dive into science, physics, history, or anything else you're curious about.
             </div>
-          </div>
+          </button>
         </div>
       </div>
     );

--- a/src/client/components/ModelPicker.tsx
+++ b/src/client/components/ModelPicker.tsx
@@ -5,21 +5,47 @@ interface ModelPickerProps {
   value: string;
   onChange: (model: string) => void;
   disabled?: boolean;
+  className?: string;
 }
 
-export default function ModelPicker({ models, value, onChange, disabled }: ModelPickerProps) {
+export default function ModelPicker({
+  models,
+  value,
+  onChange,
+  disabled,
+  className = "",
+}: ModelPickerProps) {
   return (
-    <select
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      disabled={disabled}
-      className="w-full md:max-w-md truncate text-sm bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-1.5 text-gray-700 dark:text-gray-300 outline-none cursor-pointer hover:border-gray-300 dark:hover:border-gray-600 transition-colors disabled:opacity-50"
-    >
-      {models.map((m) => (
-        <option key={m.id} value={m.id}>
-          {m.name}
-        </option>
-      ))}
-    </select>
+    <div className={`relative flex items-center ${className}`}>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="w-full appearance-none bg-transparent border-none py-0 pl-0 pr-5 outline-none cursor-pointer text-xs md:text-sm font-medium text-gray-700 dark:text-white/65 hover:text-gray-900 dark:hover:text-white/95 transition-colors disabled:opacity-50 disabled:cursor-not-allowed focus:ring-0 truncate"
+      >
+        {models.map((m) => (
+          <option
+            key={m.id}
+            value={m.id}
+            // Style the native dropdown options to match the theme
+            className="bg-white dark:bg-[#1e1e20] text-gray-900 dark:text-white/95 py-2 font-sans"
+          >
+            {m.name}
+          </option>
+        ))}
+      </select>
+
+      {/* Custom native-feeling dropdown arrow to replace the default OS one */}
+      <div className="absolute right-0 pointer-events-none text-gray-400 dark:text-white/40">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          className="w-3.5 h-3.5 stroke-[2.5]"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+        </svg>
+      </div>
+    </div>
   );
 }

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -139,7 +139,7 @@ export default function SettingsModal({
                           : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
                       }`}
                     >
-                      {mode === "cloud" ? "☁️ Cloud (D1)" : "💾 Local (Browser)"}
+                      {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
                     </button>
                   ))}
                 </div>
@@ -197,7 +197,7 @@ export default function SettingsModal({
               <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
                 <div>
                   <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
-                    ☁️ Cloud (D1)
+                    Cloud (D1)
                   </p>
                   <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
                     Stored in Cloudflare D1
@@ -219,7 +219,7 @@ export default function SettingsModal({
               <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
                 <div>
                   <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
-                    💾 Local (Browser)
+                    Local (Browser)
                   </p>
                   <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
                     Stored in browser localStorage

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -67,54 +67,57 @@ export default function SettingsModal({
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
-      onClick={(e) => { if (e.target === overlayRef.current) handleCancel(); }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4 transition-opacity"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) handleCancel();
+      }}
     >
-      <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-2xl shadow-xl mx-4 overflow-hidden max-h-[90vh] flex flex-col">
-
+      <div className="w-full max-w-md bg-[#1e1e20]/95 backdrop-blur-2xl border-[0.5px] border-white/10 rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.5)] overflow-hidden max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-800 shrink-0">
-          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Settings</h2>
+        <div className="flex items-center justify-between px-6 py-4 border-b-[0.5px] border-white/10 shrink-0">
+          <h2 className="text-base md:text-lg font-semibold text-white/95 tracking-tight">
+            Settings
+          </h2>
           <button
             onClick={handleCancel}
-            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            className="text-white/40 hover:text-white/95 transition-colors focus:outline-none"
             aria-label="Close settings"
           >
-            ✕
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 stroke-2">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
           </button>
         </div>
 
         {/* Scrollable body */}
-        <div className="overflow-y-auto flex-1 px-6 py-5 space-y-8">
-
+        <div className="overflow-y-auto flex-1 px-6 py-6 space-y-8 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
           {/* Preferences */}
           <section>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-600 mb-4">
+            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">
               Preferences
             </h3>
             <div className="space-y-5">
-
-              {/* Storage mode */}
+              {/* Storage mode Segmented Control */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Storage
+                <label className="block text-[13px] md:text-sm font-medium text-white/80 mb-2">
+                  Storage Mode
                 </label>
-                <div className="flex rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                <div className="flex rounded-xl bg-black/20 p-1 border-[0.5px] border-white/10">
                   {(["cloud", "local"] as StorageMode[]).map((mode) => (
                     <button
                       key={mode}
                       onClick={() => setDraftStorageMode(mode)}
-                      className={`flex-1 py-2 text-sm font-medium transition-colors ${
+                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-lg transition-all duration-200 ${
                         draftStorageMode === mode
-                          ? "bg-indigo-600 text-white"
-                          : "text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800"
+                          ? "bg-white/15 text-white/95 shadow-sm"
+                          : "text-white/65 hover:text-white/95 hover:bg-white/5"
                       }`}
                     >
                       {mode === "cloud" ? "☁️ Cloud (D1)" : "💾 Local (Browser)"}
                     </button>
                   ))}
                 </div>
-                <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-600">
+                <p className="mt-2 text-xs text-white/40 leading-relaxed">
                   {draftStorageMode === "cloud"
                     ? "Conversations saved to Cloudflare D1. Persists across devices."
                     : "Conversations saved in your browser. Never leaves your device."}
@@ -123,23 +126,25 @@ export default function SettingsModal({
 
               {/* Default model */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label className="block text-[13px] md:text-sm font-medium text-white/80 mb-2">
                   Default Model
                 </label>
                 <select
                   value={draftModel}
                   onChange={(e) => setDraftModel(e.target.value)}
-                  className="w-full text-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 text-gray-700 dark:text-gray-300 outline-none focus:border-indigo-500 transition-colors"
+                  className="w-full text-base md:text-sm bg-black/20 border-[0.5px] border-white/10 rounded-xl px-3 py-2.5 text-white/95 outline-none focus:border-[#0A84FF] focus:bg-black/30 transition-colors [&>option]:bg-[#1e1e20] [&>option]:text-white/95"
                 >
                   {models.map((m) => (
-                    <option key={m.id} value={m.id}>{m.name}</option>
+                    <option key={m.id} value={m.id}>
+                      {m.name}
+                    </option>
                   ))}
                 </select>
               </div>
 
               {/* System prompt */}
               <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                <label className="block text-[13px] md:text-sm font-medium text-white/80 mb-2">
                   System Prompt
                 </label>
                 <textarea
@@ -147,27 +152,26 @@ export default function SettingsModal({
                   onChange={(e) => setDraftSystemPrompt(e.target.value)}
                   placeholder="You are a helpful assistant..."
                   rows={4}
-                  className="w-full text-sm bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 text-gray-700 dark:text-gray-300 placeholder-gray-400 dark:placeholder-gray-600 outline-none focus:border-indigo-500 transition-colors resize-none"
+                  className="w-full text-base md:text-sm bg-black/20 border-[0.5px] border-white/10 rounded-xl px-3 py-2.5 text-white/95 placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
                 />
-                <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-600">
-                  Applied to all new conversations.
-                </p>
+                <p className="mt-1.5 text-xs text-white/40">Applied to all new conversations.</p>
               </div>
             </div>
           </section>
 
           {/* Conversations */}
           <section>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-600 mb-4">
+            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">
               Conversations
             </h3>
             <div className="space-y-3">
-
               {/* Cloud */}
-              <div className="flex items-center justify-between py-3 px-4 rounded-lg border border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/5 border-[0.5px] border-white/10">
                 <div>
-                  <p className="text-sm font-medium text-gray-700 dark:text-gray-300">☁️ Cloud (D1)</p>
-                  <p className="text-xs text-gray-400 dark:text-gray-600 mt-0.5">Stored in Cloudflare D1</p>
+                  <p className="text-[13px] md:text-sm font-medium text-white/95">☁️ Cloud (D1)</p>
+                  <p className="text-[11px] md:text-xs text-white/40 mt-0.5">
+                    Stored in Cloudflare D1
+                  </p>
                 </div>
                 <button
                   onClick={() => {
@@ -175,17 +179,21 @@ export default function SettingsModal({
                       onClearConversations("cloud");
                     }
                   }}
-                  className="text-xs font-medium text-red-500 hover:text-red-600 border border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950 rounded-lg px-3 py-1.5 transition-colors"
+                  className="text-[11px] md:text-xs font-medium text-red-400 hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
                 >
                   Clear
                 </button>
               </div>
 
               {/* Local */}
-              <div className="flex items-center justify-between py-3 px-4 rounded-lg border border-gray-200 dark:border-gray-700">
+              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/5 border-[0.5px] border-white/10">
                 <div>
-                  <p className="text-sm font-medium text-gray-700 dark:text-gray-300">💾 Local (Browser)</p>
-                  <p className="text-xs text-gray-400 dark:text-gray-600 mt-0.5">Stored in browser localStorage</p>
+                  <p className="text-[13px] md:text-sm font-medium text-white/95">
+                    💾 Local (Browser)
+                  </p>
+                  <p className="text-[11px] md:text-xs text-white/40 mt-0.5">
+                    Stored in browser localStorage
+                  </p>
                 </div>
                 <button
                   onClick={() => {
@@ -193,27 +201,26 @@ export default function SettingsModal({
                       onClearConversations("local");
                     }
                   }}
-                  className="text-xs font-medium text-red-500 hover:text-red-600 border border-red-200 dark:border-red-800 hover:bg-red-50 dark:hover:bg-red-950 rounded-lg px-3 py-1.5 transition-colors"
+                  className="text-[11px] md:text-xs font-medium text-red-400 hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
                 >
                   Clear
                 </button>
               </div>
-
             </div>
           </section>
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-800 flex gap-3 shrink-0">
+        <div className="px-6 py-4 border-t-[0.5px] border-white/10 flex gap-3 shrink-0 bg-white/[0.02]">
           <button
             onClick={handleCancel}
-            className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors"
+            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white/80 bg-white/5 border-[0.5px] border-white/10 hover:bg-white/10 hover:text-white/95 rounded-xl transition-all focus:outline-none"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
-            className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition-colors"
+            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] rounded-xl shadow-[0_2px_8px_rgba(10,132,255,0.3)] transition-all focus:outline-none"
           >
             Save
           </button>

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -13,6 +13,8 @@ interface SettingsModalProps {
   onSystemPromptChange: (prompt: string) => void;
   models: Model[];
   onClearConversations: (mode: StorageMode) => void;
+  theme: "system" | "light" | "dark";
+  onThemeChange: (theme: "system" | "light" | "dark") => void;
 }
 
 export default function SettingsModal({
@@ -26,6 +28,8 @@ export default function SettingsModal({
   onSystemPromptChange,
   models,
   onClearConversations,
+  theme,
+  onThemeChange,
 }: SettingsModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
 
@@ -67,20 +71,20 @@ export default function SettingsModal({
   return (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm p-4 transition-opacity"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 dark:bg-black/40 backdrop-blur-sm p-4 transition-opacity"
       onClick={(e) => {
         if (e.target === overlayRef.current) handleCancel();
       }}
     >
-      <div className="w-full max-w-md bg-[#1e1e20]/95 backdrop-blur-2xl border-[0.5px] border-white/10 rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.5)] overflow-hidden max-h-[90vh] flex flex-col">
+      <div className="w-full max-w-md bg-white/95 dark:bg-[#1e1e20]/95 backdrop-blur-2xl border-[0.5px] border-black/10 dark:border-white/10 rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.1)] dark:shadow-[0_20px_40px_rgba(0,0,0,0.5)] overflow-hidden max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b-[0.5px] border-white/10 shrink-0">
-          <h2 className="text-base md:text-lg font-semibold text-white/95 tracking-tight">
+        <div className="flex items-center justify-between px-6 py-4 border-b-[0.5px] border-black/10 dark:border-white/10 shrink-0">
+          <h2 className="text-base md:text-lg font-semibold text-gray-900 dark:text-white/95 tracking-tight">
             Settings
           </h2>
           <button
             onClick={handleCancel}
-            className="text-white/40 hover:text-white/95 transition-colors focus:outline-none"
+            className="text-gray-400 hover:text-gray-900 dark:text-white/40 dark:hover:text-white/95 transition-colors focus:outline-none"
             aria-label="Close settings"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 stroke-2">
@@ -90,34 +94,56 @@ export default function SettingsModal({
         </div>
 
         {/* Scrollable body */}
-        <div className="overflow-y-auto flex-1 px-6 py-6 space-y-8 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
+        <div className="overflow-y-auto flex-1 px-6 py-6 space-y-8 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
           {/* Preferences */}
           <section>
-            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">
+            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
               Preferences
             </h3>
             <div className="space-y-5">
+              {/* Theme Segmented Control */}
+              <div>
+                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
+                  Theme
+                </label>
+                <div className="flex rounded-xl bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
+                  {(["system", "light", "dark"] as const).map((t) => (
+                    <button
+                      key={t}
+                      onClick={() => onThemeChange(t)}
+                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-lg transition-all duration-200 capitalize ${
+                        theme === t
+                          ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
+                          : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
+                      }`}
+                    >
+                      {t}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
               {/* Storage mode Segmented Control */}
               <div>
-                <label className="block text-[13px] md:text-sm font-medium text-white/80 mb-2">
+                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
                   Storage Mode
                 </label>
-                <div className="flex rounded-xl bg-black/20 p-1 border-[0.5px] border-white/10">
+                <div className="flex rounded-xl bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
                   {(["cloud", "local"] as StorageMode[]).map((mode) => (
                     <button
                       key={mode}
                       onClick={() => setDraftStorageMode(mode)}
                       className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-lg transition-all duration-200 ${
                         draftStorageMode === mode
-                          ? "bg-white/15 text-white/95 shadow-sm"
-                          : "text-white/65 hover:text-white/95 hover:bg-white/5"
+                          ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
+                          : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
                       }`}
                     >
                       {mode === "cloud" ? "☁️ Cloud (D1)" : "💾 Local (Browser)"}
                     </button>
                   ))}
                 </div>
-                <p className="mt-2 text-xs text-white/40 leading-relaxed">
+                <p className="mt-2 text-xs text-gray-500 dark:text-white/40 leading-relaxed">
                   {draftStorageMode === "cloud"
                     ? "Conversations saved to Cloudflare D1. Persists across devices."
                     : "Conversations saved in your browser. Never leaves your device."}
@@ -126,13 +152,13 @@ export default function SettingsModal({
 
               {/* Default model */}
               <div>
-                <label className="block text-[13px] md:text-sm font-medium text-white/80 mb-2">
+                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
                   Default Model
                 </label>
                 <select
                   value={draftModel}
                   onChange={(e) => setDraftModel(e.target.value)}
-                  className="w-full text-base md:text-sm bg-black/20 border-[0.5px] border-white/10 rounded-xl px-3 py-2.5 text-white/95 outline-none focus:border-[#0A84FF] focus:bg-black/30 transition-colors [&>option]:bg-[#1e1e20] [&>option]:text-white/95"
+                  className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors [&>option]:bg-white dark:[&>option]:bg-[#1e1e20] [&>option]:text-gray-900 dark:[&>option]:text-white/95"
                 >
                   {models.map((m) => (
                     <option key={m.id} value={m.id}>
@@ -144,7 +170,7 @@ export default function SettingsModal({
 
               {/* System prompt */}
               <div>
-                <label className="block text-[13px] md:text-sm font-medium text-white/80 mb-2">
+                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
                   System Prompt
                 </label>
                 <textarea
@@ -152,24 +178,28 @@ export default function SettingsModal({
                   onChange={(e) => setDraftSystemPrompt(e.target.value)}
                   placeholder="You are a helpful assistant..."
                   rows={4}
-                  className="w-full text-base md:text-sm bg-black/20 border-[0.5px] border-white/10 rounded-xl px-3 py-2.5 text-white/95 placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
+                  className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
                 />
-                <p className="mt-1.5 text-xs text-white/40">Applied to all new conversations.</p>
+                <p className="mt-1.5 text-xs text-gray-500 dark:text-white/40">
+                  Applied to all new conversations.
+                </p>
               </div>
             </div>
           </section>
 
           {/* Conversations */}
           <section>
-            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-white/40 mb-4">
+            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
               Conversations
             </h3>
             <div className="space-y-3">
               {/* Cloud */}
-              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/5 border-[0.5px] border-white/10">
+              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
                 <div>
-                  <p className="text-[13px] md:text-sm font-medium text-white/95">☁️ Cloud (D1)</p>
-                  <p className="text-[11px] md:text-xs text-white/40 mt-0.5">
+                  <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+                    ☁️ Cloud (D1)
+                  </p>
+                  <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
                     Stored in Cloudflare D1
                   </p>
                 </div>
@@ -179,19 +209,19 @@ export default function SettingsModal({
                       onClearConversations("cloud");
                     }
                   }}
-                  className="text-[11px] md:text-xs font-medium text-red-400 hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
+                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
                 >
                   Clear
                 </button>
               </div>
 
               {/* Local */}
-              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/5 border-[0.5px] border-white/10">
+              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
                 <div>
-                  <p className="text-[13px] md:text-sm font-medium text-white/95">
+                  <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
                     💾 Local (Browser)
                   </p>
-                  <p className="text-[11px] md:text-xs text-white/40 mt-0.5">
+                  <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
                     Stored in browser localStorage
                   </p>
                 </div>
@@ -201,7 +231,7 @@ export default function SettingsModal({
                       onClearConversations("local");
                     }
                   }}
-                  className="text-[11px] md:text-xs font-medium text-red-400 hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
+                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
                 >
                   Clear
                 </button>
@@ -211,16 +241,16 @@ export default function SettingsModal({
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t-[0.5px] border-white/10 flex gap-3 shrink-0 bg-white/[0.02]">
+        <div className="px-6 py-4 border-t-[0.5px] border-black/10 dark:border-white/10 flex gap-3 shrink-0 bg-black/[0.02] dark:bg-white/[0.02]">
           <button
             onClick={handleCancel}
-            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white/80 bg-white/5 border-[0.5px] border-white/10 hover:bg-white/10 hover:text-white/95 rounded-xl transition-all focus:outline-none"
+            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:bg-white dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white/95 rounded-xl transition-all focus:outline-none"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
-            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] rounded-xl shadow-[0_2px_8px_rgba(10,132,255,0.3)] transition-all focus:outline-none"
+            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] rounded-xl shadow-[0_2px_8px_rgba(10,132,255,0.2)] dark:shadow-[0_2px_8px_rgba(10,132,255,0.3)] transition-all focus:outline-none"
           >
             Save
           </button>

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import type { Model } from "../hooks/useModels";
 import type { StorageMode } from "../storage";
+import ModelPicker from "./ModelPicker";
 
 interface SettingsModalProps {
   open: boolean;
@@ -155,19 +156,16 @@ export default function SettingsModal({
                 <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
                   Default Model
                 </label>
-                <select
-                  value={draftModel}
-                  onChange={(e) => setDraftModel(e.target.value)}
-                  className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-full px-3 py-2.5 text-gray-900 dark:text-white/95 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors [&>option]:bg-white dark:[&>option]:bg-[#1e1e20] [&>option]:text-gray-900 dark:[&>option]:text-white/95"
-                >
-                  {models.map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.name}
-                    </option>
-                  ))}
-                </select>
+                {/* Wrapper provides the input-box styling, ModelPicker stays transparent inside! */}
+                <div className="w-full bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 focus-within:border-[#0A84FF] focus-within:bg-white dark:focus-within:bg-black/30 transition-colors">
+                  <ModelPicker
+                    models={models}
+                    value={draftModel}
+                    onChange={setDraftModel}
+                    className="w-full"
+                  />
+                </div>
               </div>
-
               {/* System prompt */}
               <div>
                 <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -106,12 +106,12 @@ export default function SettingsModal({
                 <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
                   Theme
                 </label>
-                <div className="flex rounded-xl bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
+                <div className="flex rounded-full bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
                   {(["system", "light", "dark"] as const).map((t) => (
                     <button
                       key={t}
                       onClick={() => onThemeChange(t)}
-                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-lg transition-all duration-200 capitalize ${
+                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 capitalize ${
                         theme === t
                           ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
                           : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
@@ -128,12 +128,12 @@ export default function SettingsModal({
                 <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
                   Storage Mode
                 </label>
-                <div className="flex rounded-xl bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
+                <div className="flex rounded-full bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
                   {(["cloud", "local"] as StorageMode[]).map((mode) => (
                     <button
                       key={mode}
                       onClick={() => setDraftStorageMode(mode)}
-                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-lg transition-all duration-200 ${
+                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 ${
                         draftStorageMode === mode
                           ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
                           : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
@@ -158,7 +158,7 @@ export default function SettingsModal({
                 <select
                   value={draftModel}
                   onChange={(e) => setDraftModel(e.target.value)}
-                  className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors [&>option]:bg-white dark:[&>option]:bg-[#1e1e20] [&>option]:text-gray-900 dark:[&>option]:text-white/95"
+                  className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-full px-3 py-2.5 text-gray-900 dark:text-white/95 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors [&>option]:bg-white dark:[&>option]:bg-[#1e1e20] [&>option]:text-gray-900 dark:[&>option]:text-white/95"
                 >
                   {models.map((m) => (
                     <option key={m.id} value={m.id}>
@@ -209,7 +209,7 @@ export default function SettingsModal({
                       onClearConversations("cloud");
                     }
                   }}
-                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
+                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-full px-3 py-1.5 transition-all focus:outline-none"
                 >
                   Clear
                 </button>
@@ -231,7 +231,7 @@ export default function SettingsModal({
                       onClearConversations("local");
                     }
                   }}
-                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-lg px-3 py-1.5 transition-all focus:outline-none"
+                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-full px-3 py-1.5 transition-all focus:outline-none"
                 >
                   Clear
                 </button>
@@ -244,13 +244,13 @@ export default function SettingsModal({
         <div className="px-6 py-4 border-t-[0.5px] border-black/10 dark:border-white/10 flex gap-3 shrink-0 bg-black/[0.02] dark:bg-white/[0.02]">
           <button
             onClick={handleCancel}
-            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:bg-white dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white/95 rounded-xl transition-all focus:outline-none"
+            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:bg-white dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white/95 rounded-full transition-all focus:outline-none"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
-            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] rounded-xl shadow-[0_2px_8px_rgba(10,132,255,0.2)] dark:shadow-[0_2px_8px_rgba(10,132,255,0.3)] transition-all focus:outline-none"
+            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] rounded-full shadow-[0_2px_8px_rgba(10,132,255,0.2)] dark:shadow-[0_2px_8px_rgba(10,132,255,0.3)] transition-all focus:outline-none"
           >
             Save
           </button>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -32,27 +32,33 @@ export default function Sidebar({
   return (
     <>
       <aside
-        className={`absolute md:relative z-30 flex flex-col w-[280px] h-full bg-[#141416]/60 border-r-[0.5px] border-white/10 shrink-0 transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] ${
+        className={`absolute md:relative z-30 flex flex-col w-[280px] h-full bg-white/60 dark:bg-[#141416]/60 border-r-[0.5px] border-black/10 dark:border-white/10 shrink-0 transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] ${
           isOpen
             ? "translate-x-0"
             : "-translate-x-full md:-ml-[280px] opacity-0 invisible md:visible border-none"
         }`}
       >
         <div className="flex items-center justify-between px-5 pt-5 pb-4">
-          <div className="flex items-center gap-2 text-base md:text-lg font-semibold text-white/95 tracking-tight">
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              className="w-5 h-5 text-[#0A84FF]"
+          <div className="flex items-center gap-2 text-base md:text-lg font-semibold text-gray-900 dark:text-white/95 tracking-tight">
+            <div
+              className="w-8 h-8 rounded-2xl flex items-center justify-center shadow-[0_8px_24px_rgba(10,132,255,0.3),inset_0_1px_0_rgba(255,255,255,0.4)]"
+              style={{ background: "linear-gradient(135deg, #0A84FF, #5E5CE6)" }}
             >
-              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
-            </svg>
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="w-5 h-5 text-white"
+              >
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+              </svg>
+            </div>
             WaiChat
           </div>
           <button
             onClick={onClose}
-            className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors focus:outline-none"
+            className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none"
             title="Hide Sidebar"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 stroke-2">
@@ -70,7 +76,7 @@ export default function Sidebar({
           {currentMode === savedMode ? (
             <button
               onClick={() => onNew(currentMode)}
-              className="flex items-center gap-2 w-full bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium shadow-[0_1px_2px_rgba(0,0,0,0.1)] transition-all"
+              className="flex items-center gap-2 w-full bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium shadow-[0_1px_2px_rgba(0,0,0,0.05)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.1)] transition-all"
             >
               <span className="text-lg font-light leading-none">+</span> New Chat
             </button>
@@ -85,7 +91,7 @@ export default function Sidebar({
               </button>
               <button
                 onClick={() => onNew(currentMode)}
-                className="flex items-center gap-2 w-full bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium transition-all"
+                className="flex items-center gap-2 w-full bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium transition-all"
                 title={`Create a new chat in the current temporary ${currentMode} workspace`}
               >
                 New in {currentMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
@@ -94,14 +100,16 @@ export default function Sidebar({
           )}
         </div>
 
-        <nav className="flex-1 overflow-y-auto px-2 pb-2 space-y-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
+        <nav className="flex-1 overflow-y-auto px-2 pb-2 space-y-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
           {conversations.length > 0 && (
-            <div className="px-4 py-3 pb-2 text-[11px] md:text-xs font-medium text-white/40 uppercase tracking-wider">
+            <div className="px-4 py-3 pb-2 text-[11px] md:text-xs font-medium text-gray-500 dark:text-white/40 uppercase tracking-wider">
               Recent
             </div>
           )}
           {conversations.length === 0 && (
-            <p className="text-sm text-white/40 text-center mt-10">No conversations yet</p>
+            <p className="text-sm text-gray-500 dark:text-white/40 text-center mt-10">
+              No conversations yet
+            </p>
           )}
           {conversations.map((c) => (
             <div
@@ -109,7 +117,7 @@ export default function Sidebar({
               className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-[13px] md:text-sm transition-all duration-150 ${
                 activeId === c.id
                   ? "bg-[#0A84FF] text-white font-medium"
-                  : "text-white/65 hover:bg-white/5 hover:text-white/95"
+                  : "text-gray-600 hover:bg-black/5 hover:text-gray-900 dark:text-white/65 dark:hover:bg-white/5 dark:hover:text-white/95"
               }`}
               onClick={() => onSelect(c.id)}
             >
@@ -122,7 +130,7 @@ export default function Sidebar({
                 className={`p-1.5 rounded-md focus:outline-none transition-all ml-2 shrink-0 ${
                   activeId === c.id
                     ? "text-white/70 hover:text-white opacity-100"
-                    : "text-white/40 hover:text-red-400 opacity-0 group-hover:opacity-100"
+                    : "text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 opacity-0 group-hover:opacity-100"
                 }`}
                 aria-label="Delete conversation"
               >
@@ -139,19 +147,19 @@ export default function Sidebar({
           ))}
         </nav>
 
-        <div className="p-4 border-t-[0.5px] border-white/10 flex items-center gap-3">
+        <div className="p-4 border-t-[0.5px] border-black/10 dark:border-white/10 flex items-center gap-3">
           <div
             className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.2)]"
             style={{ background: "linear-gradient(135deg, #4A5568, #2D3748)" }}
           >
             WC
           </div>
-          <span className="flex-1 text-[13px] md:text-sm text-white/95 font-medium">
+          <span className="flex-1 text-[13px] md:text-sm text-gray-900 dark:text-white/95 font-medium">
             WaiChat User
           </span>
           <button
             onClick={onSettingsOpen}
-            className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors focus:outline-none cursor-pointer"
+            className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none cursor-pointer"
             title="Settings"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 stroke-2">

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -32,55 +32,84 @@ export default function Sidebar({
   return (
     <>
       <aside
-        className={`absolute md:relative z-30 flex flex-col w-64 h-screen bg-gray-50 dark:bg-gray-900 border-r border-gray-200 dark:border-gray-800 shrink-0 transition-all duration-300 ease-in-out ${
-          isOpen ? "translate-x-0" : "-translate-x-full md:-ml-64"
+        className={`absolute md:relative z-30 flex flex-col w-[280px] h-full bg-[#141416]/60 border-r-[0.5px] border-white/10 shrink-0 transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] ${
+          isOpen
+            ? "translate-x-0"
+            : "-translate-x-full md:-ml-[280px] opacity-0 invisible md:visible border-none"
         }`}
       >
+        <div className="flex items-center justify-between px-5 pt-5 pb-4">
+          <div className="flex items-center gap-2 text-base md:text-lg font-semibold text-white/95 tracking-tight">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              className="w-5 h-5 text-[#0A84FF]"
+            >
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+            </svg>
+            WaiChat
+          </div>
+          <button
+            onClick={onClose}
+            className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors focus:outline-none"
+            title="Hide Sidebar"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 stroke-2">
+              <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+              <line x1="9" y1="3" x2="9" y2="21"></line>
+            </svg>
+          </button>
+        </div>
+
         {/* Explicit split-button flow to the Sidebar for "New Chat" actions when a user views a deep link
           that differs from their saved default storage mode. The user can now seamlessly opt to return to
           their default workspace or explicitly create a new chat in the temporary storage mode they are viewing,
           preventing accidental database pollution. */}
-        <div className="p-4 border-b border-gray-200 dark:border-gray-800 flex flex-col gap-2">
+        <div className="px-4 pb-4 flex flex-col gap-2.5">
           {currentMode === savedMode ? (
             <button
               onClick={() => onNew(currentMode)}
-              className="w-full py-2 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+              className="flex items-center gap-2 w-full bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium shadow-[0_1px_2px_rgba(0,0,0,0.1)] transition-all"
             >
-              New Chat
+              <span className="text-lg font-light leading-none">+</span> New Chat
             </button>
           ) : (
             <>
               <button
                 onClick={() => onNew(savedMode)}
-                className="w-full py-2 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium transition-colors"
+                className="flex items-center gap-2 w-full bg-[#0A84FF] hover:bg-[#0070E0] text-white rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium shadow-[0_1px_2px_rgba(0,0,0,0.1)] transition-all"
                 title={`Return to your default ${savedMode} workspace`}
               >
                 New Chat in {savedMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
               </button>
               <button
                 onClick={() => onNew(currentMode)}
-                className="w-full py-2 px-4 rounded-lg bg-gray-200 dark:bg-gray-800 hover:bg-gray-300 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium transition-colors"
+                className="flex items-center gap-2 w-full bg-white/5 hover:bg-white/10 border-[0.5px] border-white/10 text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium transition-all"
                 title={`Create a new chat in the current temporary ${currentMode} workspace`}
               >
-                New Chat in {currentMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
+                New in {currentMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
               </button>
             </>
           )}
         </div>
 
-        <nav className="flex-1 overflow-y-auto p-2 space-y-1">
+        <nav className="flex-1 overflow-y-auto px-2 pb-2 space-y-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
+          {conversations.length > 0 && (
+            <div className="px-4 py-3 pb-2 text-[11px] md:text-xs font-medium text-white/40 uppercase tracking-wider">
+              Recent
+            </div>
+          )}
           {conversations.length === 0 && (
-            <p className="text-xs text-gray-400 dark:text-gray-600 text-center mt-8">
-              No conversations yet
-            </p>
+            <p className="text-sm text-white/40 text-center mt-10">No conversations yet</p>
           )}
           {conversations.map((c) => (
             <div
               key={c.id}
-              className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-sm transition-colors ${
+              className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-[13px] md:text-sm transition-all duration-150 ${
                 activeId === c.id
-                  ? "bg-indigo-50 dark:bg-indigo-950 text-indigo-700 dark:text-indigo-300"
-                  : "text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+                  ? "bg-[#0A84FF] text-white font-medium"
+                  : "text-white/65 hover:bg-white/5 hover:text-white/95"
               }`}
               onClick={() => onSelect(c.id)}
             >
@@ -90,40 +119,46 @@ export default function Sidebar({
                   e.stopPropagation();
                   setPendingDelete(c);
                 }}
-                className="p-1 rounded-md md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 focus-visible:ring-2 focus-visible:ring-red-500 focus:outline-none text-gray-400 cursor-pointer md:hover:text-red-500 active:text-red-500 transition-all ml-2 shrink-0"
+                className={`p-1.5 rounded-md focus:outline-none transition-all ml-2 shrink-0 ${
+                  activeId === c.id
+                    ? "text-white/70 hover:text-white opacity-100"
+                    : "text-white/40 hover:text-red-400 opacity-0 group-hover:opacity-100"
+                }`}
                 aria-label="Delete conversation"
               >
-                ✕
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-4 h-4">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M6 18L18 6M6 6l12 12"
+                  ></path>
+                </svg>
               </button>
             </div>
           ))}
         </nav>
 
-        <div className="p-4 border-t border-gray-200 dark:border-gray-800 flex items-center justify-between">
-          <p className="text-base text-gray-400 dark:text-gray-600">WaiChat</p>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={onSettingsOpen}
-              className="text-base text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer"
-              aria-label="Open settings"
-            >
-              ⚙️
-            </button>
-            <button
-              onClick={onClose}
-              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors cursor-pointer flex items-center justify-center"
-              aria-label="Close sidebar"
-            >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth="2"
-                  d="M15 19l-7-7 7-7"
-                />
-              </svg>
-            </button>
+        <div className="p-4 border-t-[0.5px] border-white/10 flex items-center gap-3">
+          <div
+            className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium text-white shadow-[inset_0_1px_0_rgba(255,255,255,0.2)]"
+            style={{ background: "linear-gradient(135deg, #4A5568, #2D3748)" }}
+          >
+            WC
           </div>
+          <span className="flex-1 text-[13px] md:text-sm text-white/95 font-medium">
+            WaiChat User
+          </span>
+          <button
+            onClick={onSettingsOpen}
+            className="w-8 h-8 rounded-md flex items-center justify-center text-white/65 hover:text-white/95 hover:bg-white/5 transition-colors focus:outline-none cursor-pointer"
+            title="Settings"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 stroke-2">
+              <circle cx="12" cy="12" r="3"></circle>
+              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+            </svg>
+          </button>
         </div>
       </aside>
 

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -25,7 +25,7 @@ export default function Sidebar({
   onDelete,
   onSettingsOpen,
   currentMode,
-  savedMode,
+  savedMode, // Kept in props to satisfy the interface and App.tsx
 }: SidebarProps) {
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
 
@@ -68,36 +68,30 @@ export default function Sidebar({
           </button>
         </div>
 
-        {/* Explicit split-button flow to the Sidebar for "New Chat" actions when a user views a deep link
-          that differs from their saved default storage mode. The user can now seamlessly opt to return to
-          their default workspace or explicitly create a new chat in the temporary storage mode they are viewing,
-          preventing accidental database pollution. */}
-        <div className="px-4 pb-4 flex flex-col gap-2.5">
-          {currentMode === savedMode ? (
-            <button
-              onClick={() => onNew(currentMode)}
-              className="flex items-center gap-2 w-full bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium shadow-[0_1px_2px_rgba(0,0,0,0.05)] dark:shadow-[0_1px_2px_rgba(0,0,0,0.1)] transition-all"
-            >
-              <span className="text-lg font-light leading-none">+</span> New Chat
-            </button>
-          ) : (
-            <>
+        {/* Workspace Storage Switcher (Pill Tabs) */}
+        <div className="px-4 pb-4">
+          <div className="flex rounded-full bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
+            {(["cloud", "local"] as StorageMode[]).map((mode) => (
               <button
-                onClick={() => onNew(savedMode)}
-                className="flex items-center gap-2 w-full bg-[#0A84FF] hover:bg-[#0070E0] text-white rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium shadow-[0_1px_2px_rgba(0,0,0,0.1)] transition-all"
-                title={`Return to your default ${savedMode} workspace`}
+                key={mode}
+                onClick={() => {
+                  if (currentMode !== mode) onNew(mode);
+                }}
+                className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 ${
+                  currentMode === mode
+                    ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm cursor-default"
+                    : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 cursor-pointer"
+                }`}
+                title={
+                  currentMode === mode
+                    ? `${mode === "cloud" ? "Cloud" : "Local"} Workspace`
+                    : `Switch to ${mode === "cloud" ? "Cloud" : "Local"} Workspace`
+                }
               >
-                New Chat in {savedMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
+                {mode === "cloud" ? "Cloud" : "Local"}
               </button>
-              <button
-                onClick={() => onNew(currentMode)}
-                className="flex items-center gap-2 w-full bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-xl px-4 py-2.5 text-[13px] md:text-sm font-medium transition-all"
-                title={`Create a new chat in the current temporary ${currentMode} workspace`}
-              >
-                New in {currentMode === "cloud" ? "☁️ Cloud" : "💾 Local"}
-              </button>
-            </>
-          )}
+            ))}
+          </div>
         </div>
 
         <nav className="flex-1 overflow-y-auto px-2 pb-2 space-y-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
@@ -162,7 +156,14 @@ export default function Sidebar({
             className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none cursor-pointer"
             title="Settings"
           >
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 stroke-2">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="w-5 h-5 stroke-2"
+            >
               <circle cx="12" cy="12" r="3"></circle>
               <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
             </svg>

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -1,1 +1,4 @@
 @import "tailwindcss";
+
+/* Override default OS dark mode to look for the .dark class on the <html> tag instead */
+@custom-variant dark (&:where(.dark, .dark *));

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -2,3 +2,19 @@
 
 /* Override default OS dark mode to look for the .dark class on the <html> tag instead */
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* Universal Interactive Cursors */
+@layer base {
+  button,
+  [role="button"],
+  [onclick],
+  .cursor-pointer {
+    cursor: pointer;
+  }
+
+  /* Ensure disabled states don't show the pointer */
+  button:disabled,
+  [disabled] {
+    cursor: not-allowed;
+  }
+}

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -18,3 +18,8 @@
     cursor: not-allowed;
   }
 }
+
+/* If the [onclick] selector doesn't catch React divs */
+.interactive-card {
+  @apply cursor-pointer transition-all active:scale-[0.98];
+}


### PR DESCRIPTION
## Major UX/UI Overhaul & Aesthetic Modernization

**Fixes #37**
**Fixes #31**

Introduces a comprehensive visual and functional overhaul of the WaiChat interface. The primary objective was to move from a standard pre-alpha web interface to a premium, modern "Glassmorphic" aesthetic that supports dynamic themes and improved workspace management.

### Key Changes

#### Aesthetic & Theming
- Glassmorphism Implementation
- Multi-Theme Support
- System (OS-level) preferences with instant live-updates
- Refined Typography & Scaling
- UI Consistency

#### Functional UX Improvements
- Workspace Management
- Interactive Hero Actions
- Input Refinement
- Implemented logic to prevent the creation of multiple empty conversations.
- Added a universal interactive cursor rule in CSS for better affordance across the app.
- Added `localStorage` persistence for theme preferences and thought-process visibility states.

#### Fixes & Polish
- Icon Geometry
- Storage Dropdown


## Checklist
- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)

<img width="1432" height="1053" alt="Screenshot 2026-04-15 at 10 36 11 PM" src="https://github.com/user-attachments/assets/09dd3b82-eeb7-4175-ad61-cd029e3926f3" />

<img width="1553" height="1117" alt="Screenshot 2026-04-15 at 10 37 58 PM" src="https://github.com/user-attachments/assets/fb8456b4-74c7-4b1b-ba2d-06473990f628" />

---

## 1-Click Test Deployment
Want to test these changes live without setting up a local environment? Use the button below to deploy this exact branch directly to your own Cloudflare account. 

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/37-major-ux-ui-overhaul)
