### PR TITLE
feat(ui): implement smart auto-scroll lock during message streaming

### DIFF
--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -167,20 +167,31 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
   const isUserScrolled = useRef(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
+  // Keep track of how many message blocks exist
+  const prevMessageCount = useRef(messages.length);
+
   // Detects when the user scrolls away from the bottom
   const handleScroll = () => {
     if (!scrollRef.current) return;
     const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
 
-    // Calculate distance from the bottom
     const distanceToBottom = scrollHeight - scrollTop - clientHeight;
 
-    // If the user is more than 100px away from the bottom, they scrolled up. Lock auto-scroll.
-    isUserScrolled.current = distanceToBottom > 100;
+    // If the user is more than 20px away from the bottom, they scrolled up. Lock auto-scroll.
+    isUserScrolled.current = distanceToBottom > 20;
   };
 
   useEffect(() => {
-    // Only auto-scroll if the user hasn't manually scrolled up
+    // If a brand new message block was added, a new turn just started.
+    // This safely catches both new user prompts and model retries.
+    if (messages.length > prevMessageCount.current) {
+      isUserScrolled.current = false; // Break the lock!
+    }
+
+    // Update the ref for the next render
+    prevMessageCount.current = messages.length;
+
+    // Scroll down if we aren't locked
     if (!isUserScrolled.current) {
       bottomRef.current?.scrollIntoView({ behavior: "auto" });
     }

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -163,10 +163,27 @@ function MarkdownRenderer({ content }: { content: string }) {
 
 export default function MessageList({ messages, isStreaming, onSelectPrompt }: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isUserScrolled = useRef(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
 
+  // Detects when the user scrolls away from the bottom
+  const handleScroll = () => {
+    if (!scrollRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+
+    // Calculate distance from the bottom
+    const distanceToBottom = scrollHeight - scrollTop - clientHeight;
+
+    // If the user is more than 100px away from the bottom, they scrolled up. Lock auto-scroll.
+    isUserScrolled.current = distanceToBottom > 100;
+  };
+
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    // Only auto-scroll if the user hasn't manually scrolled up
+    if (!isUserScrolled.current) {
+      bottomRef.current?.scrollIntoView({ behavior: "auto" });
+    }
   }, [messages]);
 
   const handleCopy = async (id: string, content: string) => {
@@ -287,7 +304,11 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
   }
 
   return (
-    <div className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
+    <div
+      ref={scrollRef}
+      onScroll={handleScroll}
+      className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full"
+    >
       {messages.map((m) => (
         <div
           key={m.id}


### PR DESCRIPTION


## Description
**Fixes #51**

- Added an onScroll listener to the chat container to track user scroll position.
- Auto-scroll is now locked if the user scrolls up (more than 100px from the bottom) while the model is typing.
- Auto-scroll automatically resumes when the user scrolls back to the bottom.
- Swapped scrollIntoView behavior from 'smooth' to 'auto' to eliminate animation stuttering during rapid token streams.


## Checklist
- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)

---

## 1-Click Test Deployment
Want to test these changes live without setting up a local environment? Use the button below to deploy this exact branch directly to your own Cloudflare account. 

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/51-add-smart-autoscroll)

**Note**: _To simplify maintenance, we are introducing workflows that let you update your existing instance in-place, rather than spinning up a new one. The newer releases of WaiChat will allow users to effortlessly deploy the latest stable release, pre-releases (alpha/beta), a specific branch, or an exact release tag._