### PR TITLE
feat(chat): add ability to abort streaming responses

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -89,6 +89,7 @@ export default function App() {
     deleteConversation,
     clearConversation,
     sendMessage,
+    stopGeneration,
   } = useChat(storageMode);
 
   const { models } = useModels();
@@ -438,6 +439,7 @@ export default function App() {
             disabled={isStreaming}
             initialValue={pendingPrompt}
             onClearInitialValue={() => setPendingPrompt("")}
+            onAbort={stopGeneration}
           />
         </main>
 

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -5,6 +5,7 @@ interface ChatInputProps {
   disabled: boolean;
   initialValue?: string;
   onClearInitialValue?: () => void;
+  onAbort?: () => void;
 }
 
 export default function ChatInput({
@@ -12,6 +13,7 @@ export default function ChatInput({
   disabled,
   initialValue,
   onClearInitialValue,
+  onAbort,
 }: ChatInputProps) {
   const [value, setValue] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -55,6 +57,19 @@ export default function ChatInput({
   return (
     <div className="w-full flex justify-center pb-6 pt-2 px-4 md:px-8 shrink-0">
       <div className="w-full max-w-[720px] relative">
+        {disabled && onAbort && (
+          <div className="absolute -top-12 left-1/2 -translate-x-1/2 z-20">
+            <button
+              type="button"
+              onClick={onAbort}
+              className="flex items-center gap-2 px-4 py-2 bg-white/80 dark:bg-[#1e1e20]/80 backdrop-blur-md border-[0.5px] border-black/10 dark:border-white/10 rounded-xl text-sm font-medium text-gray-700 dark:text-white/80 hover:bg-white dark:hover:bg-[#1e1e20] hover:scale-105 active:scale-95 transition-all duration-200 shadow-lg cursor-pointer"
+            >
+              <div className="w-2.5 h-2.5 bg-gray-900 dark:bg-white rounded-[2px]" />
+              Stop Generating
+            </button>
+          </div>
+        )}
+
         <form
           onSubmit={handleSend}
           className="relative flex flex-col bg-white/60 dark:bg-black/25 focus-within:bg-white/80 dark:focus-within:bg-black/35 border-[0.5px] border-black/10 dark:border-white/10 focus-within:border-black/20 dark:focus-within:border-white/20 rounded-2xl p-3 shadow-[0_4px_24px_rgba(0,0,0,0.05),inset_0_1px_0_rgba(255,255,255,0.6)] dark:shadow-[0_4px_24px_rgba(0,0,0,0.2),inset_0_1px_0_rgba(255,255,255,0.05)] transition-all duration-200"

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo, useEffect, useRef } from "react";
 import type { Conversation, Message, StorageMode } from "../storage";
 import { createStorage } from "../storage";
 
@@ -20,6 +20,7 @@ interface UseChatReturn {
     storageMode: StorageMode,
     systemPrompt?: string,
   ) => Promise<void>;
+  stopGeneration: () => void;
 }
 
 export function useChat(storageMode: StorageMode): UseChatReturn {
@@ -29,6 +30,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setActiveConversation(null);
@@ -89,6 +91,13 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     setError(null);
   }, []);
 
+  const stopGeneration = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
+  }, []);
+
   const sendMessage = useCallback(
     async (
       content: string,
@@ -126,9 +135,13 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
           content,
         }));
 
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
+
         const res = await fetch("/api/chat", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
+          signal: abortController.signal,
           body: JSON.stringify({
             conversation_id: conversationId,
             model,
@@ -148,38 +161,47 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
         let fullContent = "";
         let buffer = "";
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
 
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split("\n");
+            buffer = lines.pop() ?? "";
 
-          for (const line of lines) {
-            const trimmed = line.trim();
-            if (!trimmed || !trimmed.startsWith("data: ")) continue;
-            if (trimmed === "data: [DONE]") continue;
-            try {
-              const json = JSON.parse(trimmed.slice(6));
-              let token: string | undefined;
-              if (typeof json.choices?.[0]?.delta?.content === "string") {
-                token = json.choices[0].delta.content;
-              } else if (typeof json.response === "string") {
-                token = json.response;
-              }
-              if (token) {
-                fullContent += token;
-                setMessages((prev) =>
-                  prev.map((m) =>
-                    m.id === assistantMessage.id ? { ...m, content: fullContent } : m,
-                  ),
-                );
-              }
-            } catch {}
+            for (const line of lines) {
+              const trimmed = line.trim();
+              if (!trimmed || !trimmed.startsWith("data: ")) continue;
+              if (trimmed === "data: [DONE]") continue;
+              try {
+                const json = JSON.parse(trimmed.slice(6));
+                let token: string | undefined;
+                if (typeof json.choices?.[0]?.delta?.content === "string") {
+                  token = json.choices[0].delta.content;
+                } else if (typeof json.response === "string") {
+                  token = json.response;
+                }
+                if (token) {
+                  fullContent += token;
+                  setMessages((prev) =>
+                    prev.map((m) =>
+                      m.id === assistantMessage.id ? { ...m, content: fullContent } : m,
+                    ),
+                  );
+                }
+              } catch {}
+            }
+          }
+        } catch (e) {
+          if (e instanceof Error && e.name === "AbortError") {
+            console.log("[sendMessage] stream aborted");
+          } else {
+            throw e;
           }
         }
 
+        // Save whatever we got (full or partial)
         await storage.saveMessage({ conversation_id: conversationId, role: "user", content });
         await storage.saveMessage({
           conversation_id: conversationId,
@@ -188,7 +210,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
           model,
         });
 
-        if (messages.length === 0 && storageMode === "local") {
+        if (messages.length === 0 && storageMode === "local" && fullContent) {
           try {
             const res = await fetch("/api/title", {
               method: "POST",
@@ -229,6 +251,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
         setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
       } finally {
         setIsStreaming(false);
+        abortControllerRef.current = null;
       }
     },
     [isStreaming, messages, storage],
@@ -246,5 +269,6 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     deleteConversation,
     clearConversation,
     sendMessage,
+    stopGeneration,
   };
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -242,6 +242,7 @@ app.post("/api/chat", async (c) => {
         } catch (e) {
           // Client aborted the connection
           console.log("[/api/chat] Client disconnected");
+          await reader.cancel();
           break;
         }
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,17 +1,17 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import type { Env, ChatRequest } from "./types";
-import { streamAiResponse, generateTitle, AVAILABLE_MODELS } from "./ai";
+import { AVAILABLE_MODELS, generateTitle, streamAiResponse } from "./ai";
 import {
-  getConversations,
-  getConversation,
   createConversation,
-  updateConversationTitle,
-  updateConversationTimestamp,
   deleteConversation,
+  getConversation,
+  getConversations,
   getMessages,
   saveMessage,
+  updateConversationTimestamp,
+  updateConversationTitle,
 } from "./db";
+import type { ChatRequest, Env } from "./types";
 
 function scoreModel(id: string): number {
   let score = 0;
@@ -211,22 +211,10 @@ app.post("/api/chat", async (c) => {
     }
   }
 
-  const stream = await streamAiResponse(c.env.AI, model as any, messagesWithSystem);
+  const sourceStream = await streamAiResponse(c.env.AI, model as any, messagesWithSystem);
 
-  if (isCloud) {
-    const [streamForClient, streamForSave] = stream.tee();
-
-    // Save assistant message and update title/timestamp after stream ends
-    const savePromise = saveAssistantMessage(
-      c.env.DB,
-      conversation_id,
-      model,
-      streamForSave,
-    ).then(() => updateConversationTimestamp(c.env.DB, conversation_id));
-
-    c.executionCtx.waitUntil(savePromise);
-
-    return new Response(streamForClient, {
+  if (!isCloud) {
+    return new Response(sourceStream, {
       headers: {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -234,7 +222,80 @@ app.post("/api/chat", async (c) => {
     });
   }
 
-  return new Response(stream, {
+  // Cloud Mode: Transform stream to capture fullContent and handle abort
+  const { readable, writable } = new TransformStream();
+  const writer = writable.getWriter();
+  const reader = sourceStream.getReader();
+  const decoder = new TextDecoder();
+  let fullContent = "";
+  let buffer = "";
+
+  const processStream = async () => {
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        // Try writing to client. If client aborted, this will throw.
+        try {
+          await writer.write(value);
+        } catch (e) {
+          // Client aborted the connection
+          console.log("[/api/chat] Client disconnected");
+          break;
+        }
+
+        // Process chunk for saving
+        const chunk = decoder.decode(value, { stream: true });
+        buffer += chunk;
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith("data: ")) continue;
+          if (trimmed === "data: [DONE]") continue;
+          try {
+            const json = JSON.parse(trimmed.slice(6));
+            let token: string | undefined;
+            if (typeof json.choices?.[0]?.delta?.content === "string") {
+              token = json.choices[0].delta.content;
+            } else if (typeof json.response === "string") {
+              token = json.response;
+            }
+            if (token) fullContent += token;
+          } catch {}
+        }
+      }
+    } catch (e) {
+      console.error("[/api/chat] stream error:", e);
+    } finally {
+      if (fullContent) {
+        // Save whatever we got
+        try {
+          await saveMessage(c.env.DB, {
+            id: crypto.randomUUID(),
+            conversation_id,
+            role: "assistant",
+            content: fullContent,
+            created_at: Date.now(),
+            model,
+          });
+          await updateConversationTimestamp(c.env.DB, conversation_id);
+        } catch (e) {
+          console.error("[/api/chat] failed to save message:", e);
+        }
+      }
+      reader.releaseLock();
+      try {
+        await writer.close();
+      } catch {}
+    }
+  };
+
+  c.executionCtx.waitUntil(processStream());
+
+  return new Response(readable, {
     headers: {
       "Content-Type": "text/event-stream",
       "Cache-Control": "no-cache",
@@ -242,57 +303,6 @@ app.post("/api/chat", async (c) => {
   });
 });
 
-async function saveAssistantMessage(
-  db: D1Database,
-  conversationId: string,
-  model: string,
-  stream: ReadableStream,
-): Promise<void> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let fullContent = "";
-  let buffer = "";
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed || !trimmed.startsWith("data: ")) continue;
-        if (trimmed === "data: [DONE]") continue;
-        try {
-          const json = JSON.parse(trimmed.slice(6));
-          let token: string | undefined;
-          if (typeof json.choices?.[0]?.delta?.content === "string") {
-            token = json.choices[0].delta.content;
-          } else if (typeof json.response === "string") {
-            token = json.response;
-          }
-          if (token) fullContent += token;
-        } catch {}
-      }
-    }
-  } catch (e) {
-    console.error("[saveAssistantMessage] stream error:", e);
-  } finally {
-    reader.releaseLock();
-  }
-
-  if (fullContent) {
-    // Re-use our saveMessage helper so the DB logic is centralized!
-    await saveMessage(db, {
-      id: crypto.randomUUID(),
-      conversation_id: conversationId,
-      role: "assistant",
-      content: fullContent,
-      created_at: Date.now(),
-      model,
-    });
-  }
-}
+// saveAssistantMessage is no longer needed as saving is handled inline with streaming
 
 export default app;


### PR DESCRIPTION

## Description
Implemented AbortController logic to stop model generation on user command. Added UI square button and logic to persist partial text.

Closes #44

## Checklist
- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)

---

## 1-Click Test Deployment
Want to test these changes live without setting up a local environment? Use the button below to deploy this exact branch directly to your own Cloudflare account. 

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/44-stop-generation)
