### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ranajahanzaib/WaiChat/security/code-scanning/1](https://github.com/ranajahanzaib/WaiChat/security/code-scanning/1)

Add an explicit `permissions` block to the workflow, ideally at the root so it applies to all jobs unless overridden. For this CI workflow, the minimal required permission is `contents: read` (needed for `actions/checkout`). No write scopes are needed based on the shown steps.

Modify `.github/workflows/ci.yml` by inserting:

```yml
permissions:
  contents: read
```

directly under the `on:` trigger block (before `jobs:`), preserving existing behavior while enforcing least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
