### PR TITLE
feat(chat): add retry option to model responses

### DIFF
--- a/migrations/0003_add_parent_id.sql
+++ b/migrations/0003_add_parent_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE messages ADD COLUMN parent_id TEXT;

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -83,6 +83,7 @@ export default function App() {
     messages,
     isStreaming,
     error,
+    activeVersions,
     loadConversations,
     selectConversation,
     newConversation,
@@ -90,6 +91,8 @@ export default function App() {
     clearConversation,
     sendMessage,
     stopGeneration,
+    retryMessage,
+    setActiveVersion,
   } = useChat(storageMode);
 
   const { models } = useModels();
@@ -433,6 +436,9 @@ export default function App() {
             messages={messages}
             isStreaming={isStreaming}
             onSelectPrompt={setPendingPrompt}
+            onRetry={(messageId) => retryMessage(messageId, model, storageMode, systemPrompt)}
+            activeVersions={activeVersions}
+            onVersionChange={setActiveVersion}
           />
           <ChatInput
             onSend={handleSend}

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import type { Message } from "../storage";
 
@@ -6,6 +6,9 @@ interface MessageListProps {
   messages: Message[];
   isStreaming: boolean;
   onSelectPrompt: (prompt: string) => void;
+  onRetry?: (messageId: string) => void;
+  activeVersions: Record<string, string>;
+  onVersionChange?: (parentId: string, messageId: string) => void;
 }
 
 function ThoughtParser({ content }: { content: string }) {
@@ -161,7 +164,29 @@ function MarkdownRenderer({ content }: { content: string }) {
   );
 }
 
-export default function MessageList({ messages, isStreaming, onSelectPrompt }: MessageListProps) {
+interface DisplayItem {
+  type: "user";
+  message: Message;
+}
+
+interface AssistantGroup {
+  type: "assistant";
+  parentId: string;
+  siblings: Message[];
+  activeMessage: Message;
+  activeIndex: number;
+}
+
+type DisplayEntry = DisplayItem | AssistantGroup;
+
+export default function MessageList({
+  messages,
+  isStreaming,
+  onSelectPrompt,
+  onRetry,
+  activeVersions,
+  onVersionChange,
+}: MessageListProps) {
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const isUserScrolled = useRef(false);
@@ -169,6 +194,82 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
 
   // Keep track of how many message blocks exist
   const prevMessageCount = useRef(messages.length);
+
+  // Build the display list: group assistant siblings together
+  const displayItems = useMemo((): DisplayEntry[] => {
+    const items: DisplayEntry[] = [];
+    // Map: parentId -> list of sibling messages (including the original)
+    const siblingMap = new Map<string, Message[]>();
+
+    // First pass: identify all siblings and group them
+    for (const m of messages) {
+      if (m.role === "assistant" && m.parent_id) {
+        const group = siblingMap.get(m.parent_id) || [];
+        group.push(m);
+        siblingMap.set(m.parent_id, group);
+      }
+    }
+
+    // Track which parentIds we've already rendered
+    const rendered = new Set<string>();
+
+    for (const m of messages) {
+      if (m.role === "user") {
+        items.push({ type: "user", message: m });
+        continue;
+      }
+
+      // Assistant message
+      if (m.parent_id) {
+        // This is a retry sibling - skip it, it'll be rendered as part of the parent's group
+        if (!rendered.has(m.parent_id)) {
+          // Edge case: the parent might not exist in messages (shouldn't happen, but be safe)
+          // We'll handle it when we encounter the parent
+        }
+        continue;
+      }
+
+      // Original assistant message (no parent_id)
+      const parentId = m.id;
+
+      if (rendered.has(parentId)) continue;
+      rendered.add(parentId);
+
+      const retrySiblings = siblingMap.get(parentId) || [];
+      const allSiblings = [m, ...retrySiblings];
+
+      // Determine active version
+      const explicitActive = activeVersions[parentId];
+      let activeMessage: Message;
+      let activeIndex: number;
+
+      if (explicitActive) {
+        const idx = allSiblings.findIndex((s) => s.id === explicitActive);
+        if (idx >= 0) {
+          activeMessage = allSiblings[idx];
+          activeIndex = idx;
+        } else {
+          // Fallback to latest
+          activeMessage = allSiblings[allSiblings.length - 1];
+          activeIndex = allSiblings.length - 1;
+        }
+      } else {
+        // Default to latest
+        activeMessage = allSiblings[allSiblings.length - 1];
+        activeIndex = allSiblings.length - 1;
+      }
+
+      items.push({
+        type: "assistant",
+        parentId,
+        siblings: allSiblings,
+        activeMessage,
+        activeIndex,
+      });
+    }
+
+    return items;
+  }, [messages, activeVersions]);
 
   // Detects when the user scrolls away from the bottom
   const handleScroll = () => {
@@ -320,67 +421,182 @@ export default function MessageList({ messages, isStreaming, onSelectPrompt }: M
       onScroll={handleScroll}
       className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full"
     >
-      {messages.map((m) => (
-        <div
-          key={m.id}
-          className={`group flex flex-col ${m.role === "user" ? "items-end" : "items-start"}`}
-        >
-          <div
-            className={`max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed ${
-              m.role === "user"
-                ? "bg-[#0A84FF] text-white rounded-br-sm"
-                : "bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-bl-sm backdrop-blur-md"
-            }`}
-          >
-            {m.role === "assistant" ? (
-              <ThoughtParser content={m.content} />
-            ) : (
-              <p className="whitespace-pre-wrap">{m.content}</p>
-            )}
+      {displayItems.map((item) => {
+        if (item.type === "user") {
+          const m = item.message;
+          return (
+            <div key={m.id} className="group flex flex-col items-end">
+              <div className="max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed bg-[#0A84FF] text-white rounded-br-sm">
+                <p className="whitespace-pre-wrap">{m.content}</p>
+              </div>
+              {m.content && (
+                <button
+                  onClick={() => handleCopy(m.id, m.content)}
+                  className="mt-2 px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1.5 cursor-pointer"
+                  aria-label="Copy message"
+                >
+                  {copiedId === m.id ? (
+                    <>
+                      <span className="text-[#34C759]">✓</span> Copied
+                    </>
+                  ) : (
+                    <>
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                        />
+                      </svg>
+                      Copy
+                    </>
+                  )}
+                </button>
+              )}
+            </div>
+          );
+        }
 
-            {m.role === "assistant" &&
-              (isStreaming && m.content === "" ? (
+        // Assistant group
+        const { parentId, siblings, activeMessage: m, activeIndex } = item;
+        const totalVersions = siblings.length;
+        const isLastAssistant =
+          displayItems.indexOf(item) === displayItems.length - 1 ||
+          displayItems.findIndex(
+            (d, i) => i > displayItems.indexOf(item) && d.type === "assistant",
+          ) === -1;
+        const isCurrentlyStreaming = isStreaming && m.content === "" && isLastAssistant;
+
+        return (
+          <div key={parentId} className="group flex flex-col items-start">
+            <div className="max-w-[85%] md:max-w-[75%] rounded-[20px] px-5 py-4 text-[15px] md:text-base leading-relaxed bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 text-gray-900 dark:text-white/95 rounded-bl-sm backdrop-blur-md">
+              {isCurrentlyStreaming ? (
                 <span className="inline-flex gap-1 mt-2">
                   <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:0ms]" />
                   <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:150ms]" />
                   <span className="w-1.5 h-1.5 bg-gray-400 dark:bg-white/40 rounded-full animate-bounce [animation-delay:300ms]" />
                 </span>
               ) : (
-                m.model && (
-                  <div className="mt-3 text-xs text-gray-400 dark:text-white/40 capitalize">
-                    {m.model.split("/").pop()?.replaceAll("-", " ")}
-                  </div>
-                )
-              ))}
-          </div>
+                <ThoughtParser content={m.content} />
+              )}
 
-          {m.content && (
-            <button
-              onClick={() => handleCopy(m.id, m.content)}
-              className="mt-2 px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1.5 cursor-pointer"
-              aria-label="Copy message"
-            >
-              {copiedId === m.id ? (
-                <>
-                  <span className="text-[#34C759]">✓</span> Copied
-                </>
-              ) : (
-                <>
+              {!isCurrentlyStreaming && m.model && (
+                <div className="mt-3 text-xs text-gray-400 dark:text-white/40 capitalize">
+                  {m.model.split("/").pop()?.replaceAll("-", " ")}
+                </div>
+              )}
+            </div>
+
+            {/* Action bar: version navigator + copy + retry */}
+            <div className="mt-2 flex items-center gap-1 flex-wrap">
+              {totalVersions > 1 && (
+                <div className="flex items-center gap-0.5 mr-1">
+                  <button
+                    onClick={() => {
+                      if (activeIndex > 0) {
+                        onVersionChange?.(parentId, siblings[activeIndex - 1].id);
+                      }
+                    }}
+                    disabled={activeIndex === 0}
+                    className="w-6 h-6 flex items-center justify-center rounded text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 disabled:opacity-30 disabled:cursor-default transition-colors cursor-pointer"
+                    aria-label="Previous version"
+                  >
+                    <svg
+                      className="w-3.5 h-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      strokeWidth="2.5"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+                    </svg>
+                  </button>
+                  <span className="text-xs text-gray-400 dark:text-white/40 font-medium tabular-nums min-w-[2.5rem] text-center select-none">
+                    {activeIndex + 1} / {totalVersions}
+                  </span>
+                  <button
+                    onClick={() => {
+                      if (activeIndex < totalVersions - 1) {
+                        onVersionChange?.(parentId, siblings[activeIndex + 1].id);
+                      }
+                    }}
+                    disabled={activeIndex === totalVersions - 1}
+                    className="w-6 h-6 flex items-center justify-center rounded text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 disabled:opacity-30 disabled:cursor-default transition-colors cursor-pointer"
+                    aria-label="Next version"
+                  >
+                    <svg
+                      className="w-3.5 h-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                      strokeWidth="2.5"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                </div>
+              )}
+
+              {/* Copy button */}
+              {m.content && (
+                <button
+                  onClick={() => handleCopy(m.id, m.content)}
+                  className="px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1.5 cursor-pointer"
+                  aria-label="Copy message"
+                >
+                  {copiedId === m.id ? (
+                    <>
+                      <span className="text-[#34C759]">✓</span> Copied
+                    </>
+                  ) : (
+                    <>
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                        />
+                      </svg>
+                      Copy
+                    </>
+                  )}
+                </button>
+              )}
+
+              {/* Retry button */}
+              {m.content && !isStreaming && onRetry && (
+                <button
+                  onClick={() => onRetry(m.id)}
+                  className="px-3 py-1.5 text-xs font-medium text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 md:opacity-0 md:group-hover:opacity-100 focus:opacity-100 transition-opacity flex items-center gap-1.5 cursor-pointer"
+                  aria-label="Retry response"
+                >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path
                       strokeLinecap="round"
                       strokeLinejoin="round"
                       strokeWidth="2"
-                      d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
                     />
                   </svg>
-                  Copy
-                </>
+                  Retry
+                </button>
               )}
-            </button>
-          )}
-        </div>
-      ))}
+            </div>
+          </div>
+        );
+      })}
       <div ref={bottomRef} />
     </div>
   );

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -311,6 +311,14 @@ export default function MessageList({
     }
   };
 
+  // Pre-calculate the index of the last assistant entry to avoid O(N²) lookups
+  const lastAssistantIndex = useMemo(() => {
+    for (let i = displayItems.length - 1; i >= 0; i--) {
+      if (displayItems[i].type === "assistant") return i;
+    }
+    return -1;
+  }, [displayItems]);
+
   // Empty State Hero Design
   if (messages.length === 0) {
     return (
@@ -415,13 +423,14 @@ export default function MessageList({
     );
   }
 
+
   return (
     <div
       ref={scrollRef}
       onScroll={handleScroll}
       className="flex-1 overflow-y-auto px-4 md:px-8 py-6 space-y-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full"
     >
-      {displayItems.map((item) => {
+      {displayItems.map((item, idx) => {
         if (item.type === "user") {
           const m = item.message;
           return (
@@ -466,12 +475,8 @@ export default function MessageList({
         // Assistant group
         const { parentId, siblings, activeMessage: m, activeIndex } = item;
         const totalVersions = siblings.length;
-        const isLastAssistant =
-          displayItems.indexOf(item) === displayItems.length - 1 ||
-          displayItems.findIndex(
-            (d, i) => i > displayItems.indexOf(item) && d.type === "assistant",
-          ) === -1;
-        const isCurrentlyStreaming = isStreaming && m.content === "" && isLastAssistant;
+        const itemIndex = idx;
+        const isCurrentlyStreaming = isStreaming && m.content === "" && itemIndex === lastAssistantIndex;
 
         return (
           <div key={parentId} className="group flex flex-col items-start">

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Conversation, Message, StorageMode } from "../storage";
 import { createStorage } from "../storage";
 
@@ -8,6 +8,7 @@ interface UseChatReturn {
   messages: Message[];
   isStreaming: boolean;
   error: string | null;
+  activeVersions: Record<string, string>;
   loadConversations: () => Promise<void>;
   selectConversation: (id: string) => Promise<void>;
   newConversation: (model: string) => Promise<Conversation>;
@@ -21,6 +22,13 @@ interface UseChatReturn {
     systemPrompt?: string,
   ) => Promise<void>;
   stopGeneration: () => void;
+  retryMessage: (
+    messageId: string,
+    model: string,
+    storageMode: StorageMode,
+    systemPrompt?: string,
+  ) => Promise<void>;
+  setActiveVersion: (parentId: string, messageId: string) => void;
 }
 
 export function useChat(storageMode: StorageMode): UseChatReturn {
@@ -30,6 +38,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [activeVersions, setActiveVersions] = useState<Record<string, string>>({});
   const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
@@ -37,6 +46,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     setMessages([]);
     setError(null);
     setIsStreaming(false);
+    setActiveVersions({});
   }, [storageMode]);
 
   const loadConversations = useCallback(async () => {
@@ -55,6 +65,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
         if (!data) return;
         setActiveConversation(data.conversation);
         setMessages(data.messages);
+        setActiveVersions({});
       } catch {
         setError("Failed to load conversation");
       }
@@ -68,6 +79,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
       setConversations((prev) => [conversation, ...prev]);
       setActiveConversation(conversation);
       setMessages([]);
+      setActiveVersions({});
       return conversation;
     },
     [storage],
@@ -80,6 +92,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
       if (activeConversation?.id === id) {
         setActiveConversation(null);
         setMessages([]);
+        setActiveVersions({});
       }
     },
     [storage, activeConversation],
@@ -89,6 +102,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     setActiveConversation(null);
     setMessages([]);
     setError(null);
+    setActiveVersions({});
   }, []);
 
   const stopGeneration = useCallback(() => {
@@ -97,6 +111,171 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
       abortControllerRef.current = null;
     }
   }, []);
+
+  const setActiveVersionCb = useCallback((parentId: string, messageId: string) => {
+    setActiveVersions((prev) => ({ ...prev, [parentId]: messageId }));
+  }, []);
+
+  /**
+   * Build the message history for the AI, using the active version of each assistant turn.
+   * Messages that are retry siblings (have parent_id) are excluded unless they are the active version.
+   */
+  const buildContextMessages = useCallback(
+    (allMessages: Message[], upToIndex: number, currentActiveVersions: Record<string, string>) => {
+      // Collect all sibling groups
+      const siblingGroups = new Map<string, Message[]>();
+      for (const m of allMessages) {
+        if (m.parent_id) {
+          const group = siblingGroups.get(m.parent_id) || [];
+          group.push(m);
+          siblingGroups.set(m.parent_id, group);
+        }
+      }
+
+      const result: { role: string; content: string }[] = [];
+
+      for (let i = 0; i <= upToIndex; i++) {
+        const m = allMessages[i];
+
+        if (m.role === "user") {
+          result.push({ role: m.role, content: m.content });
+          continue;
+        }
+
+        // Assistant message
+        if (m.parent_id) {
+          // This is a retry sibling - only include if it's the active version
+          const activeId = currentActiveVersions[m.parent_id];
+          if (activeId === m.id) {
+            result.push({ role: m.role, content: m.content });
+          }
+          // Otherwise skip
+          continue;
+        }
+
+        // Original assistant message (no parent_id)
+        const siblings = siblingGroups.get(m.id);
+        if (siblings && siblings.length > 0) {
+          // This message has retries. Check if one of the retries is the active version.
+          const activeId = currentActiveVersions[m.id];
+          if (activeId && activeId !== m.id) {
+            // A retry is active, the retry itself will be included when we encounter it
+            // But since retries come after in the array and we process in order,
+            // we need to include the active one here
+            const activeMsg = siblings.find((s) => s.id === activeId);
+            if (activeMsg) {
+              result.push({ role: activeMsg.role, content: activeMsg.content });
+            } else {
+              // Fallback to original
+              result.push({ role: m.role, content: m.content });
+            }
+          } else {
+            // Original is active (or no explicit selection - default to latest)
+            if (!activeId) {
+              // Default: use the latest sibling
+              const latest = siblings[siblings.length - 1];
+              result.push({ role: latest.role, content: latest.content });
+            } else {
+              // activeId === m.id, so original is explicitly selected
+              result.push({ role: m.role, content: m.content });
+            }
+          }
+        } else {
+          // No retries, just include it
+          result.push({ role: m.role, content: m.content });
+        }
+      }
+
+      return result;
+    },
+    [],
+  );
+
+  /**
+   * Stream a response from the API, updating the placeholder message as tokens arrive.
+   * Shared between sendMessage and retryMessage.
+   */
+  const streamResponse = useCallback(
+    async (
+      allMessages: { role: string; content: string }[],
+      assistantMessageId: string,
+      conversationId: string,
+      model: string,
+      currentStorageMode: StorageMode,
+      systemPrompt?: string,
+      parentId?: string,
+    ) => {
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      const res = await fetch("/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        signal: abortController.signal,
+        body: JSON.stringify({
+          conversation_id: conversationId,
+          model,
+          messages: allMessages,
+          storage_mode: currentStorageMode,
+          system_prompt: systemPrompt || undefined,
+          parent_id: parentId || undefined,
+        }),
+      });
+
+      if (!res.ok || !res.body) {
+        console.error("[streamResponse] bad response", res.status);
+        throw new Error("Chat request failed");
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let fullContent = "";
+      let buffer = "";
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() ?? "";
+
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed || !trimmed.startsWith("data: ")) continue;
+            if (trimmed === "data: [DONE]") continue;
+            try {
+              const json = JSON.parse(trimmed.slice(6));
+              let token: string | undefined;
+              if (typeof json.choices?.[0]?.delta?.content === "string") {
+                token = json.choices[0].delta.content;
+              } else if (typeof json.response === "string") {
+                token = json.response;
+              }
+              if (token) {
+                fullContent += token;
+                setMessages((prev) =>
+                  prev.map((m) =>
+                    m.id === assistantMessageId ? { ...m, content: fullContent } : m,
+                  ),
+                );
+              }
+            } catch {}
+          }
+        }
+      } catch (e) {
+        if (e instanceof Error && e.name === "AbortError") {
+          console.log("[streamResponse] stream aborted");
+        } else {
+          throw e;
+        }
+      }
+
+      return fullContent;
+    },
+    [],
+  );
 
   const sendMessage = useCallback(
     async (
@@ -135,71 +314,21 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
           content,
         }));
 
-        const abortController = new AbortController();
-        abortControllerRef.current = abortController;
+        // For context, we need to use buildContextMessages to respect active versions
+        // But for sendMessage the simple approach works since we're appending
+        const contextMessages = [
+          ...buildContextMessages(messages, messages.length - 1, activeVersions),
+          { role: userMessage.role, content: userMessage.content },
+        ];
 
-        const res = await fetch("/api/chat", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          signal: abortController.signal,
-          body: JSON.stringify({
-            conversation_id: conversationId,
-            model,
-            messages: allMessages,
-            storage_mode: storageMode,
-            system_prompt: systemPrompt || undefined,
-          }),
-        });
-
-        if (!res.ok || !res.body) {
-          console.error("[sendMessage] bad response", res.status);
-          throw new Error("Chat request failed");
-        }
-
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-        let fullContent = "";
-        let buffer = "";
-
-        try {
-          while (true) {
-            const { done, value } = await reader.read();
-            if (done) break;
-
-            buffer += decoder.decode(value, { stream: true });
-            const lines = buffer.split("\n");
-            buffer = lines.pop() ?? "";
-
-            for (const line of lines) {
-              const trimmed = line.trim();
-              if (!trimmed || !trimmed.startsWith("data: ")) continue;
-              if (trimmed === "data: [DONE]") continue;
-              try {
-                const json = JSON.parse(trimmed.slice(6));
-                let token: string | undefined;
-                if (typeof json.choices?.[0]?.delta?.content === "string") {
-                  token = json.choices[0].delta.content;
-                } else if (typeof json.response === "string") {
-                  token = json.response;
-                }
-                if (token) {
-                  fullContent += token;
-                  setMessages((prev) =>
-                    prev.map((m) =>
-                      m.id === assistantMessage.id ? { ...m, content: fullContent } : m,
-                    ),
-                  );
-                }
-              } catch {}
-            }
-          }
-        } catch (e) {
-          if (e instanceof Error && e.name === "AbortError") {
-            console.log("[sendMessage] stream aborted");
-          } else {
-            throw e;
-          }
-        }
+        const fullContent = await streamResponse(
+          contextMessages,
+          assistantMessage.id,
+          conversationId,
+          model,
+          storageMode,
+          systemPrompt,
+        );
 
         // Save whatever we got (full or partial)
         await storage.saveMessage({ conversation_id: conversationId, role: "user", content });
@@ -254,7 +383,90 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
         abortControllerRef.current = null;
       }
     },
-    [isStreaming, messages, storage],
+    [isStreaming, messages, storage, activeVersions, buildContextMessages, streamResponse],
+  );
+
+  const retryMessage = useCallback(
+    async (messageId: string, model: string, storageMode: StorageMode, systemPrompt?: string) => {
+      if (isStreaming) return;
+      setError(null);
+
+      // Find the target assistant message
+      const targetMsg = messages.find((m) => m.id === messageId);
+      if (!targetMsg || targetMsg.role !== "assistant") return;
+
+      const conversationId = targetMsg.conversation_id;
+
+      // Determine the parent_id for the new sibling
+      const parentId = targetMsg.parent_id || targetMsg.id;
+
+      // Find the user message that precedes this assistant turn.
+      // We need to find the index of the original (parent) message to locate its preceding user msg.
+      const originalId = targetMsg.parent_id || targetMsg.id;
+      const originalIndex = messages.findIndex((m) => m.id === originalId);
+      if (originalIndex < 0) return;
+
+      // The user message is the one right before the original assistant message
+      let userMsgIndex = originalIndex - 1;
+      while (userMsgIndex >= 0 && messages[userMsgIndex].role !== "user") {
+        userMsgIndex--;
+      }
+      if (userMsgIndex < 0) return;
+
+      // Build context: everything up to and including the user message
+      const contextMessages = buildContextMessages(messages, userMsgIndex, activeVersions);
+
+      // Create new placeholder assistant message
+      const newAssistantMessage: Message = {
+        id: crypto.randomUUID(),
+        conversation_id: conversationId,
+        role: "assistant",
+        content: "",
+        created_at: Date.now(),
+        model,
+        parent_id: parentId,
+      };
+
+      // Append the new sibling to messages (don't remove old ones)
+      setMessages((prev) => [...prev, newAssistantMessage]);
+      // Set it as the active version
+      setActiveVersions((prev) => ({ ...prev, [parentId]: newAssistantMessage.id }));
+      setIsStreaming(true);
+
+      try {
+        const fullContent = await streamResponse(
+          contextMessages,
+          newAssistantMessage.id,
+          conversationId,
+          model,
+          storageMode,
+          systemPrompt,
+          parentId,
+        );
+
+        // Save the new retry version (local mode only - cloud saves server-side)
+        if (storageMode === "local") {
+          await storage.saveMessage({
+            conversation_id: conversationId,
+            role: "assistant",
+            content: fullContent,
+            model,
+            parent_id: parentId,
+          });
+        }
+      } catch (e) {
+        console.error("[retryMessage] error:", e);
+        setError("Failed to retry message");
+        // Remove the failed placeholder
+        setMessages((prev) => prev.filter((m) => m.id !== newAssistantMessage.id));
+        // Revert active version to the one the user was viewing
+        setActiveVersions((prev) => ({ ...prev, [parentId]: messageId }));
+      } finally {
+        setIsStreaming(false);
+        abortControllerRef.current = null;
+      }
+    },
+    [isStreaming, messages, storage, activeVersions, buildContextMessages, streamResponse],
   );
 
   return {
@@ -263,6 +475,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     messages,
     isStreaming,
     error,
+    activeVersions,
     loadConversations,
     selectConversation,
     newConversation,
@@ -270,5 +483,7 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     clearConversation,
     sendMessage,
     stopGeneration,
+    retryMessage,
+    setActiveVersion: setActiveVersionCb,
   };
 }

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -143,13 +143,8 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
         }
 
         // Assistant message
+        // Skip retry siblings in the main loop; they are handled via their parent
         if (m.parent_id) {
-          // This is a retry sibling - only include if it's the active version
-          const activeId = currentActiveVersions[m.parent_id];
-          if (activeId === m.id) {
-            result.push({ role: m.role, content: m.content });
-          }
-          // Otherwise skip
           continue;
         }
 

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -13,6 +13,7 @@ export interface Message {
   content: string;
   created_at: number;
   model?: string;
+  parent_id?: string;
 }
 
 export interface StorageAdapter {

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -62,7 +62,7 @@ export async function getMessages(db: D1Database, conversationId: string): Promi
 export async function saveMessage(db: D1Database, message: Message): Promise<void> {
   await db
     .prepare(
-      "INSERT INTO messages (id, conversation_id, role, content, created_at, model) VALUES (?, ?, ?, ?, ?, ?)",
+      "INSERT INTO messages (id, conversation_id, role, content, created_at, model, parent_id) VALUES (?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(
       message.id,
@@ -71,6 +71,7 @@ export async function saveMessage(db: D1Database, message: Message): Promise<voi
       message.content,
       message.created_at,
       message.model || null,
+      message.parent_id || null,
     )
     .run();
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -183,8 +183,9 @@ app.post("/api/title", async (c) => {
 
 app.post("/api/chat", async (c) => {
   const body = await c.req.json<ChatRequest>();
-  const { conversation_id, model, messages, storage_mode, system_prompt } = body;
+  const { conversation_id, model, messages, storage_mode, system_prompt, parent_id } = body;
   const isCloud = storage_mode !== "local";
+  const isRetry = !!parent_id;
   const now = Date.now();
 
   // Prepend system message if provided
@@ -192,8 +193,8 @@ app.post("/api/chat", async (c) => {
     ? [{ role: "system" as const, content: system_prompt }, ...messages]
     : messages;
 
-  if (isCloud) {
-    // Save user message to D1
+  if (isCloud && !isRetry) {
+    // Save user message to D1 (only for new messages, not retries)
     const userMsg = messages[messages.length - 1];
     await saveMessage(c.env.DB, {
       id: crypto.randomUUID(),
@@ -281,6 +282,7 @@ app.post("/api/chat", async (c) => {
             content: fullContent,
             created_at: Date.now(),
             model,
+            parent_id: parent_id || undefined,
           });
           await updateConversationTimestamp(c.env.DB, conversation_id);
         } catch (e) {

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -20,6 +20,7 @@ export interface Message {
   content: string;
   created_at: number;
   model?: string;
+  parent_id?: string;
 }
 
 export interface ChatRequest {
@@ -28,4 +29,5 @@ export interface ChatRequest {
   messages: { role: "user" | "assistant"; content: string }[];
   storage_mode: "cloud" | "local";
   system_prompt?: string;
+  parent_id?: string;
 }


### PR DESCRIPTION
## Description
**Fixes #24**


Implemented a non-destructive retry mechanism that lets users regenerate any assistant response. All versions are preserved and navigable via `‹ 1/3 ›` arrows. Only the currently active version is used as AI context for follow-ups.

## Changes Made

### Database
- **[NEW]** `migrations/0003_add_parent_id.sql` - Adds nullable `parent_id TEXT` column to `messages` table. Links retry siblings to the original response.

### Worker (Backend)
- **`src/worker/types.ts`** - Added `parent_id?: string` to both `Message` and `ChatRequest` interfaces.
- **`src/worker/db.ts`** - Updated `saveMessage` INSERT to include the `parent_id` column (7th bind parameter).
- **`src/worker/index.ts`** - In `POST /api/chat`:
  - Extracts `parent_id` from request body.
  - Skips saving the user message when `parent_id` is present (it's a retry, the user message already exists).
  - Passes `parent_id` through when saving the assistant message.

### Client Storage
- **`src/client/storage/index.ts`** - Added `parent_id?: string` to the `Message` interface. No changes needed to `StorageAdapter` since `saveMessage` uses `Omit<Message, "id" | "created_at">`.

### `useChat` Hook
- **`src/client/hooks/useChat.ts`** - Major additions:
  - **`activeVersions`** state (`Record<string, string>`) - tracks which version is displayed per turn.
  - **`buildContextMessages()`** - walks the message list and selects the active version for each assistant turn when building AI context.
  - **`streamResponse()`** - extracted shared streaming logic (used by both `sendMessage` and `retryMessage`).
  - **`retryMessage(messageId, model, storageMode, systemPrompt?)`** - creates a new sibling message with `parent_id`, streams a fresh response, saves to storage.
  - **`setActiveVersion(parentId, messageId)`** - lets the UI switch between versions.

### UI
- **`src/client/components/MessageList.tsx`** - Rewrote rendering logic:
  - Groups assistant messages by `parent_id` into sibling groups.
  - Shows only the active version per group.
  - Renders `‹ 2/3 ›` version navigator when a group has multiple siblings.
  - Adds a ↻ **Retry** button next to the existing Copy button on assistant messages.
- **`src/client/App.tsx`** - Wired up `retryMessage`, `activeVersions`, and `setActiveVersion` to `<MessageList>`.

## Checklist
- [x] Tests pass
- [x] README updated if needed
- [x] No breaking changes (or described below)

---

## 1-Click Test Deployment
Want to test these changes live without setting up a local environment? Use the button below to deploy this exact branch directly to your own Cloudflare account. 

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/24-add-retry-btn)
