### PR TITLE
feat(ui): sync system prompt to cloud

### DIFF
--- a/migrations/0005_add_settings.sql
+++ b/migrations/0005_add_settings.sql
@@ -1,0 +1,5 @@
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL,
+  updated_at INTEGER NOT NULL
+);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -130,7 +130,7 @@ export default function App() {
           return res.json() as Promise<{ value?: string }>;
         })
         .then((data) => {
-          if (data.value && data.value !== systemPrompt) {
+          if (data.value != null && data.value !== systemPrompt) {
             setSystemPrompt(data.value);
             localStorage.setItem(SYSTEM_PROMPT_KEY, data.value);
           }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -10,6 +10,7 @@ import SettingsModal from "./components/SettingsModal";
 
 const STORAGE_MODE_KEY = "waichat:storage-mode";
 const SYSTEM_PROMPT_KEY = "waichat:system-prompt";
+const SYNC_PROMPT_KEY = "waichat:sync-system-prompt";
 const DEFAULT_MODEL_KEY = "waichat:default-model";
 export const THEME_KEY = "waichat:theme";
 const MOBILE_BREAKPOINT = 768;
@@ -103,6 +104,9 @@ export default function App() {
   const [systemPrompt, setSystemPrompt] = useState(
     () => localStorage.getItem(SYSTEM_PROMPT_KEY) ?? "",
   );
+  const [syncSystemPrompt, setSyncSystemPrompt] = useState(
+    () => localStorage.getItem(SYNC_PROMPT_KEY) === "true",
+  );
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   // Storage dropdown state for mobile-friendly click toggling
@@ -116,6 +120,24 @@ export default function App() {
   useEffect(() => {
     loadConversations();
   }, [loadConversations]);
+
+  // Sync System Prompt from Cloud if enabled
+  useEffect(() => {
+    if (syncSystemPrompt) {
+      fetch("/api/settings/system_prompt")
+        .then((res) => {
+          if (!res.ok) throw new Error("Failed to fetch system prompt");
+          return res.json() as Promise<{ value?: string }>;
+        })
+        .then((data) => {
+          if (data.value && data.value !== systemPrompt) {
+            setSystemPrompt(data.value);
+            localStorage.setItem(SYSTEM_PROMPT_KEY, data.value);
+          }
+        })
+        .catch((err) => console.error("Cloud sync error:", err));
+    }
+  }, [syncSystemPrompt]); // fetch on mount or when toggled ON
 
   const initialLoadDone = useRef(false);
 
@@ -258,9 +280,24 @@ export default function App() {
     localStorage.setItem(DEFAULT_MODEL_KEY, m);
   };
 
-  const handleSystemPromptChange = (prompt: string) => {
+  const handleSystemPromptChange = async (prompt: string, sync: boolean) => {
     setSystemPrompt(prompt);
     localStorage.setItem(SYSTEM_PROMPT_KEY, prompt);
+
+    setSyncSystemPrompt(sync);
+    localStorage.setItem(SYNC_PROMPT_KEY, String(sync));
+
+    if (sync) {
+      try {
+        await fetch("/api/settings/system_prompt", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ value: prompt }),
+        });
+      } catch (err) {
+        console.error("Failed to sync system prompt to cloud:", err);
+      }
+    }
   };
 
   const handleClearConversations = async (mode: StorageMode) => {
@@ -459,6 +496,7 @@ export default function App() {
           defaultModel={model}
           onDefaultModelChange={handleDefaultModelChange}
           systemPrompt={systemPrompt}
+          syncSystemPrompt={syncSystemPrompt}
           onSystemPromptChange={handleSystemPromptChange}
           models={models}
           onClearConversations={handleClearConversations}

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -11,7 +11,8 @@ interface SettingsModalProps {
   defaultModel: string;
   onDefaultModelChange: (model: string) => void;
   systemPrompt: string;
-  onSystemPromptChange: (prompt: string) => void;
+  syncSystemPrompt: boolean;
+  onSystemPromptChange: (prompt: string, sync: boolean) => void;
   models: Model[];
   onClearConversations: (mode: StorageMode) => void;
   theme: "system" | "light" | "dark";
@@ -26,6 +27,7 @@ export default function SettingsModal({
   defaultModel,
   onDefaultModelChange,
   systemPrompt,
+  syncSystemPrompt,
   onSystemPromptChange,
   models,
   onClearConversations,
@@ -38,6 +40,7 @@ export default function SettingsModal({
   const [draftStorageMode, setDraftStorageMode] = useState<StorageMode>(storageMode);
   const [draftModel, setDraftModel] = useState(defaultModel);
   const [draftSystemPrompt, setDraftSystemPrompt] = useState(systemPrompt);
+  const [draftSyncSystemPrompt, setDraftSyncSystemPrompt] = useState(syncSystemPrompt);
 
   // Sync draft with props when modal opens
   useEffect(() => {
@@ -45,8 +48,9 @@ export default function SettingsModal({
       setDraftStorageMode(storageMode);
       setDraftModel(defaultModel);
       setDraftSystemPrompt(systemPrompt);
+      setDraftSyncSystemPrompt(syncSystemPrompt);
     }
-  }, [open, storageMode, defaultModel, systemPrompt]);
+  }, [open, storageMode, defaultModel, systemPrompt, syncSystemPrompt]);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -61,7 +65,7 @@ export default function SettingsModal({
   const handleSave = () => {
     onStorageModeChange(draftStorageMode);
     onDefaultModelChange(draftModel);
-    onSystemPromptChange(draftSystemPrompt);
+    onSystemPromptChange(draftSystemPrompt, draftSyncSystemPrompt);
     onClose();
   };
 
@@ -168,9 +172,25 @@ export default function SettingsModal({
               </div>
               {/* System prompt */}
               <div>
-                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
-                  System Prompt
-                </label>
+                <div className="flex items-center justify-between mb-2">
+                  <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80">
+                    System Prompt
+                  </label>
+                  <label className="flex items-center gap-2 cursor-pointer group">
+                    <div className="relative flex items-center justify-center">
+                      <input
+                        type="checkbox"
+                        checked={draftSyncSystemPrompt}
+                        onChange={(e) => setDraftSyncSystemPrompt(e.target.checked)}
+                        className="peer sr-only"
+                      />
+                      <div className="w-8 h-4 bg-black/10 dark:bg-white/10 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-[#0A84FF]"></div>
+                    </div>
+                    <span className="text-[11px] md:text-xs font-medium text-gray-500 dark:text-white/40 group-hover:text-gray-900 dark:group-hover:text-white/80 transition-colors">
+                      Sync to Cloud
+                    </span>
+                  </label>
+                </div>
                 <textarea
                   value={draftSystemPrompt}
                   onChange={(e) => setDraftSystemPrompt(e.target.value)}

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -98,3 +98,15 @@ export async function softDeleteMessage(db: D1Database, id: string): Promise<voi
     .bind(Date.now(), id)
     .run();
 }
+
+export async function getSetting(db: D1Database, key: string): Promise<string | null> {
+  const row = await db.prepare("SELECT value FROM settings WHERE key = ?").bind(key).first<{ value: string }>();
+  return row?.value ?? null;
+}
+
+export async function setSetting(db: D1Database, key: string, value: string): Promise<void> {
+  await db
+    .prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at")
+    .bind(key, value, Date.now())
+    .run();
+}

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -12,6 +12,8 @@ import {
   saveMessage,
   updateConversationTimestamp,
   updateConversationTitle,
+  getSetting,
+  setSetting,
 } from "./db";
 import type { ChatRequest, Env } from "./types";
 
@@ -264,6 +266,18 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
     console.error("[DELETE /message] error:", e);
     return c.json({ error: "Failed to delete message" }, 500);
   }
+});
+
+// Settings
+app.get("/api/settings/:key", async (c) => {
+  const value = await getSetting(c.env.DB, c.req.param("key"));
+  return c.json({ value });
+});
+
+app.post("/api/settings/:key", async (c) => {
+  const { value } = await c.req.json<{ value: string }>();
+  await setSetting(c.env.DB, c.req.param("key"), value);
+  return c.json({ success: true });
 });
 
 // Title generation (used by local mode)

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -269,14 +269,25 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
 });
 
 // Settings
+const ALLOWED_SETTING_KEYS = ["system_prompt"];
+
 app.get("/api/settings/:key", async (c) => {
-  const value = await getSetting(c.env.DB, c.req.param("key"));
+  const key = c.req.param("key");
+  if (!ALLOWED_SETTING_KEYS.includes(key)) {
+    return c.json({ error: "Invalid setting key" }, 400);
+  }
+  const value = await getSetting(c.env.DB, key);
   return c.json({ value });
 });
 
 app.post("/api/settings/:key", async (c) => {
+  const key = c.req.param("key");
+  if (!ALLOWED_SETTING_KEYS.includes(key)) {
+    return c.json({ error: "Invalid setting key" }, 400);
+  }
   const { value } = await c.req.json<{ value: string }>();
-  await setSetting(c.env.DB, c.req.param("key"), value);
+  if (typeof value !== "string") return c.json({ error: "Invalid value" }, 400);
+  await setSetting(c.env.DB, key, value);
   return c.json({ success: true });
 });
 


### PR DESCRIPTION
## Description
**Fixes #26**

Implement the feature to synchronize system prompts to the cloud.


### Database Layer
- Created a new SQL migration (`migrations/0005_add_settings.sql`) to add a simple key-value `settings` table to your Cloudflare D1 database.
- Added `getSetting` and `setSetting` database helper functions in `src/worker/db.ts` to manage setting keys securely.

### API Layer
- Added `GET /api/settings/:key` and `POST /api/settings/:key` endpoints to the worker router (`src/worker/index.ts`) allowing the frontend to read and write settings independently of conversations.

### Client Layer
- Updated `SettingsModal.tsx` to include a visually consistent "Sync to Cloud" toggle right next to the System Prompt text area.
- Updated `App.tsx` with a new `syncSystemPrompt` state backed by localStorage (`waichat:sync-system-prompt`).
- Wired it all together so that if the toggle is enabled, it pushes your prompt to the cloud on Save, and fetches it automatically on app load.



## Checklist
- [ ] Tests pass
- [ ] README updated if needed
- [ ] No breaking changes (or described below)

---

## 1-Click Test Deployment
Want to test these changes live without setting up a local environment? Use the button below to deploy this exact branch directly to your own Cloudflare account. 


[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/26-sync-system-prompt-to-cloud)
