### PR TITLE
feat(ui): add visual mode indicators for Local vs Cloud

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -375,10 +375,10 @@ export default function App() {
 
               <div className={`flex items-center gap-2 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all ${
                 storageMode === "cloud"
-                  ? "bg-blue-500/10 hover:bg-blue-500/20 dark:bg-blue-500/15 dark:hover:bg-blue-500/25"
-                  : "bg-amber-500/10 hover:bg-amber-500/20 dark:bg-amber-500/15 dark:hover:bg-amber-500/25"
+                  ? "bg-brand-cloud/10 hover:bg-brand-cloud/20 dark:bg-brand-cloud/15 dark:hover:bg-brand-cloud/25"
+                  : "bg-brand-local/10 hover:bg-brand-local/20 dark:bg-brand-local/15 dark:hover:bg-brand-local/25"
               }`}>
-                <div className={`w-2 h-2 rounded-full ${storageMode === "cloud" ? "bg-[#0A84FF]" : "bg-[#FF9F0A]"}`}></div>
+                <div className={`w-2 h-2 rounded-full ${storageMode === "cloud" ? "bg-brand-cloud" : "bg-brand-local"}`}></div>
                 <div className="flex-1 min-w-0">
                   <ModelPicker
                     models={models}
@@ -398,9 +398,9 @@ export default function App() {
                   aria-expanded={storageDropdownOpen}
                 >
                   {storageMode === "cloud" ? (
-                    <div className="w-2 h-2 rounded-full bg-[#34C759] shadow-[0_0_4px_rgba(52,199,89,0.3)] dark:shadow-[0_0_4px_rgba(52,199,89,0.5)]"></div>
+                    <div className="w-2 h-2 rounded-full bg-brand-cloud shadow-sm shadow-brand-cloud/30 dark:shadow-brand-cloud/50"></div>
                   ) : (
-                    <div className="w-2 h-2 rounded-full bg-[#FF9F0A] shadow-[0_0_4px_rgba(255,159,10,0.3)] dark:shadow-[0_0_4px_rgba(255,159,10,0.5)]"></div>
+                    <div className="w-2 h-2 rounded-full bg-brand-local shadow-sm shadow-brand-local/30 dark:shadow-brand-local/50"></div>
                   )}
                   {storageMode === "cloud" ? "Cloud" : "Local"}
                   <svg className="w-3 h-3 ml-1" viewBox="0 0 12 12" fill="currentColor">
@@ -423,14 +423,18 @@ export default function App() {
                       onClick={() => handleStorageToggle(mode)}
                       className={`w-full flex flex-col items-start px-3 py-2.5 text-left rounded-xl transition-all duration-200 cursor-pointer ${
                         storageMode === mode
-                          ? "bg-[#0A84FF]/10 dark:bg-[#0A84FF]/20"
+                          ? mode === "cloud"
+                            ? "bg-brand-cloud/10 dark:bg-brand-cloud/20"
+                            : "bg-brand-local/10 dark:bg-brand-local/20"
                           : "hover:bg-black/5 dark:hover:bg-white/10"
                       }`}
                     >
                       <p
                         className={`text-[13px] md:text-sm font-medium ${
                           storageMode === mode
-                            ? "text-[#0A84FF] dark:text-[#3A9FFF]"
+                            ? mode === "cloud"
+                              ? "text-brand-cloud"
+                              : "text-brand-local"
                             : "text-gray-900 dark:text-white/95"
                         }`}
                       >
@@ -439,7 +443,9 @@ export default function App() {
                       <p
                         className={`text-[11px] md:text-xs mt-0.5 ${
                           storageMode === mode
-                            ? "text-[#0A84FF]/70 dark:text-[#3A9FFF]/70"
+                            ? mode === "cloud"
+                              ? "text-brand-cloud/70"
+                              : "text-brand-local/70"
                             : "text-gray-500 dark:text-white/40"
                         }`}
                       >

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -373,8 +373,12 @@ export default function App() {
                 </button>
               )}
 
-              <div className="flex items-center gap-2 bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all">
-                <div className="w-2 h-2 rounded-full bg-[#0A84FF]"></div>
+              <div className={`flex items-center gap-2 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all ${
+                storageMode === "cloud"
+                  ? "bg-blue-500/10 hover:bg-blue-500/20 dark:bg-blue-500/15 dark:hover:bg-blue-500/25"
+                  : "bg-amber-500/10 hover:bg-amber-500/20 dark:bg-amber-500/15 dark:hover:bg-amber-500/25"
+              }`}>
+                <div className={`w-2 h-2 rounded-full ${storageMode === "cloud" ? "bg-[#0A84FF]" : "bg-[#FF9F0A]"}`}></div>
                 <div className="flex-1 min-w-0">
                   <ModelPicker
                     models={models}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -33,7 +33,7 @@ export default function Sidebar({
     <>
       <aside
         className={`absolute md:relative z-30 flex flex-col w-[280px] h-full bg-white/60 dark:bg-[#141416]/60 border-r-[0.5px] border-r-black/10 dark:border-r-white/10 border-l-[3px] shrink-0 transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] ${
-          currentMode === "cloud" ? "border-l-[#0A84FF]" : "border-l-[#FF9F0A]"
+          currentMode === "cloud" ? "border-l-brand-cloud" : "border-l-brand-local"
         } ${
           isOpen
             ? "translate-x-0"
@@ -69,8 +69,8 @@ export default function Sidebar({
                 className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 ${
                   currentMode === mode
                     ? mode === "cloud"
-                      ? "bg-[#0A84FF] text-white shadow-sm cursor-default"
-                      : "bg-[#FF9F0A] text-white shadow-sm cursor-default"
+                      ? "bg-brand-cloud text-white shadow-sm cursor-default"
+                      : "bg-brand-local text-gray-900 shadow-sm cursor-default"
                     : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 cursor-pointer"
                 }`}
                 title={
@@ -101,7 +101,9 @@ export default function Sidebar({
               key={c.id}
               className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-[13px] md:text-sm transition-all duration-150 ${
                 activeId === c.id
-                  ? "bg-[#0A84FF] text-white font-medium"
+                  ? currentMode === "cloud"
+                    ? "bg-brand-cloud text-white font-medium"
+                    : "bg-brand-local text-gray-900 font-medium"
                   : "text-gray-600 hover:bg-black/5 hover:text-gray-900 dark:text-white/65 dark:hover:bg-white/5 dark:hover:text-white/95"
               }`}
               onClick={() => onSelect(c.id)}
@@ -114,7 +116,9 @@ export default function Sidebar({
                 }}
                 className={`p-1.5 rounded-md focus:outline-none transition-all ml-2 shrink-0 ${
                   activeId === c.id
-                    ? "text-white/70 hover:text-white opacity-100"
+                    ? currentMode === "cloud"
+                      ? "text-white/70 hover:text-white opacity-100"
+                      : "text-gray-900/60 hover:text-gray-900 opacity-100"
                     : "text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 opacity-0 group-hover:opacity-100"
                 }`}
                 aria-label="Delete conversation"

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -32,10 +32,12 @@ export default function Sidebar({
   return (
     <>
       <aside
-        className={`absolute md:relative z-30 flex flex-col w-[280px] h-full bg-white/60 dark:bg-[#141416]/60 border-r-[0.5px] border-black/10 dark:border-white/10 shrink-0 transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] ${
+        className={`absolute md:relative z-30 flex flex-col w-[280px] h-full bg-white/60 dark:bg-[#141416]/60 border-r-[0.5px] border-r-black/10 dark:border-r-white/10 border-l-[3px] shrink-0 transition-all duration-300 ease-[cubic-bezier(0.2,0.8,0.2,1)] ${
+          currentMode === "cloud" ? "border-l-[#0A84FF]" : "border-l-[#FF9F0A]"
+        } ${
           isOpen
             ? "translate-x-0"
-            : "-translate-x-full md:-ml-[280px] opacity-0 invisible md:visible border-none"
+            : "-translate-x-full md:-ml-[280px] opacity-0 invisible md:visible md:border-l-0 border-r-0"
         }`}
       >
         <div className="flex items-center justify-between px-5 pt-5 pb-4">
@@ -66,7 +68,9 @@ export default function Sidebar({
                 }}
                 className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 ${
                   currentMode === mode
-                    ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm cursor-default"
+                    ? mode === "cloud"
+                      ? "bg-[#0A84FF] text-white shadow-sm cursor-default"
+                      : "bg-[#FF9F0A] text-white shadow-sm cursor-default"
                     : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 cursor-pointer"
                 }`}
                 title={

--- a/src/client/index.css
+++ b/src/client/index.css
@@ -1,5 +1,10 @@
 @import "tailwindcss";
 
+@theme {
+  --color-brand-cloud: #0A84FF;
+  --color-brand-local: #FF9F0A;
+}
+
 /* Override default OS dark mode to look for the .dark class on the <html> tag instead */
 @custom-variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
## Description
**Fixes #28**

Color-coded toggle pill, model chip, and sidebar accent strip to provide immediate visual differentiation between Local and Cloud modes.

## Checklist
- [ ] Tests pass
- [ ] README updated if needed
- [ ] No breaking changes (or described below)

---

## 1-Click Test Deployment
Want to test these changes live without setting up a local environment? Use the button below to deploy this exact branch directly to your own Cloudflare account. 


[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/28-add-visual-mode-indicators-for-local-vs-cloud)
