### PR TITLE
feat(update): implement 2-step auto-update system with per-channel tracking

### DIFF
--- a/migrations/0006_add_update_tables.sql
+++ b/migrations/0006_add_update_tables.sql
@@ -1,0 +1,27 @@
+-- Auto-update system: tracks current version and update history
+CREATE TABLE IF NOT EXISTS update_state (
+  id INTEGER PRIMARY KEY,
+  current_version TEXT NOT NULL,
+  latest_version TEXT,
+  last_check TEXT NOT NULL,
+  last_attempt TEXT,
+  last_status TEXT NOT NULL DEFAULT 'up_to_date',
+  last_error TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Seed with the current version
+INSERT INTO update_state (id, current_version, last_check, last_status)
+VALUES (1, 'v0.1.0', datetime('now'), 'up_to_date');
+
+-- Historical log of all update attempts (audit trail)
+CREATE TABLE IF NOT EXISTS update_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  version TEXT,
+  attempted_at TEXT NOT NULL,
+  status TEXT NOT NULL,
+  error_message TEXT,
+  files_updated INTEGER,
+  duration_ms INTEGER,
+  created_at TEXT DEFAULT (datetime('now'))
+);

--- a/migrations/0007_update_state_per_channel.sql
+++ b/migrations/0007_update_state_per_channel.sql
@@ -1,0 +1,20 @@
+-- Restructure update_state to support per-channel tracking
+DROP TABLE IF EXISTS update_state;
+
+CREATE TABLE update_state (
+  channel TEXT PRIMARY KEY, -- 'stable' or 'pre-release'
+  current_version TEXT NOT NULL,
+  latest_version TEXT,
+  last_check TEXT NOT NULL,
+  last_attempt TEXT,
+  last_status TEXT NOT NULL DEFAULT 'up_to_date',
+  last_error TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+-- Seed both channels with the current version
+INSERT INTO update_state (channel, current_version, last_check, last_status)
+VALUES ('stable', 'v0.1.3-alpha', datetime('now'), 'up_to_date');
+
+INSERT INTO update_state (channel, current_version, last_check, last_status)
+VALUES ('pre-release', 'v0.1.3-alpha', datetime('now'), 'up_to_date');

--- a/migrations/0007_update_state_per_channel.sql
+++ b/migrations/0007_update_state_per_channel.sql
@@ -14,7 +14,7 @@ CREATE TABLE update_state (
 
 -- Seed both channels with the current version
 INSERT INTO update_state (channel, current_version, last_check, last_status)
-VALUES ('stable', 'v0.1.3-alpha', datetime('now'), 'up_to_date');
+VALUES ('stable', 'v0.1.4-alpha', datetime('now'), 'up_to_date');
 
 INSERT INTO update_state (channel, current_version, last_check, last_status)
-VALUES ('pre-release', 'v0.1.3-alpha', datetime('now'), 'up_to_date');
+VALUES ('pre-release', 'v0.1.4-alpha', datetime('now'), 'up_to_date');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "waichat",
-  "version": "0.1.0",
-  "description": "Your own AI chat app, deployed in one click on Cloudflare's free tier.",
+  "version": "v0.1.4-alpha",
+  "description": "Free, open-source AI chat that runs entirely on Cloudflare's free tier. 1-click deploy. Free to run, yours to own.",
   "main": "src/worker/index.ts",
   "scripts": {
     "dev:client": "vite --config vite.config.ts",

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import type { Model } from "../hooks/useModels";
 import type { StorageMode } from "../storage";
 import ModelPicker from "./ModelPicker";
+import UpdateStatus from "./UpdateStatus";
 
 interface SettingsModalProps {
   open: boolean;
@@ -36,7 +37,7 @@ export default function SettingsModal({
 }: SettingsModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
 
-  // Local draft state — only committed on Save
+  // Local draft state - only committed on Save
   const [draftStorageMode, setDraftStorageMode] = useState<StorageMode>(storageMode);
   const [draftModel, setDraftModel] = useState(defaultModel);
   const [draftSystemPrompt, setDraftSystemPrompt] = useState(systemPrompt);
@@ -255,6 +256,14 @@ export default function SettingsModal({
                 </button>
               </div>
             </div>
+          </section>
+
+          {/* Maintenance - App Updates */}
+          <section>
+            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
+              Maintenance
+            </h3>
+            <UpdateStatus />
           </section>
         </div>
 

--- a/src/client/components/UpdateStatus.tsx
+++ b/src/client/components/UpdateStatus.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useState } from "react";
+
+interface UpdateStatusData {
+  current_version: string;
+  latest_version: string | null;
+  last_check: string;
+  last_attempt: string | null;
+  status: "up_to_date" | "available" | "queued" | "success" | "failed";
+  last_error: string | null;
+  channel: "stable" | "pre-release";
+  is_configured: boolean;
+  recent_logs: {
+    id: number;
+    version: string | null;
+    attempted_at: string;
+    status: string;
+    files_updated: number | null;
+    duration_ms: number | null;
+    error_message: string | null;
+  }[];
+}
+
+export default function UpdateStatus() {
+  const [data, setData] = useState<UpdateStatusData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [checking, setChecking] = useState(false);
+  const [applying, setApplying] = useState(false);
+  const [changingChannel, setChangingChannel] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  const fetchStatus = async () => {
+    try {
+      const response = await fetch("/api/updates/status");
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error((body as { error?: string }).error || `HTTP ${response.status}`);
+      }
+      const json = (await response.json()) as UpdateStatusData;
+      setData(json);
+      setFetchError(null);
+    } catch (error) {
+      setFetchError(error instanceof Error ? error.message : "Failed to fetch update status");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStatus();
+    const interval = setInterval(fetchStatus, 60_000); // Poll every 60s
+    return () => clearInterval(interval);
+  }, []);
+
+  const handleCheckNow = async () => {
+    setChecking(true);
+    setFetchError(null);
+    try {
+      const response = await fetch("/api/updates/check", { method: "POST" });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error || `Check failed: HTTP ${response.status}`,
+        );
+      }
+      await fetchStatus();
+    } catch (error) {
+      setFetchError(error instanceof Error ? error.message : "Failed to trigger check");
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const handleUpdateNow = async () => {
+    setApplying(true);
+    setFetchError(null);
+    try {
+      const response = await fetch("/api/updates/apply", { method: "POST" });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(
+          (body as { error?: string }).error || `Update failed: HTTP ${response.status}`,
+        );
+      }
+      await fetchStatus();
+    } catch (error) {
+      setFetchError(error instanceof Error ? error.message : "Failed to start update");
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const handleChannelChange = async (newChannel: string) => {
+    if (!data) return;
+
+    // Optimistic update
+    const oldData = data;
+    setData({ ...data, channel: newChannel as any });
+    setChangingChannel(true);
+
+    try {
+      const response = await fetch(`/api/settings/update_channel`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ value: newChannel }),
+      });
+      if (!response.ok) throw new Error("Failed to save channel preference");
+      await fetchStatus();
+    } catch (error) {
+      setData(oldData); // Rollback on error
+      setFetchError(error instanceof Error ? error.message : "Failed to change channel");
+    } finally {
+      setChangingChannel(false);
+    }
+  };
+
+  // Loading state
+  if (loading) {
+    return (
+      <div className="py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
+        <div className="flex items-center gap-2">
+          <div className="w-3 h-3 rounded-full bg-black/10 dark:bg-white/10 animate-pulse" />
+          <span className="text-[13px] md:text-sm text-gray-500 dark:text-white/40">
+            Loading update status…
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  // Connection / migration error
+  if (fetchError && !data) {
+    return (
+      <div className="py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+            App Updates
+          </p>
+          <span className="text-[10px] font-mono text-gray-400 dark:text-white/30 uppercase tracking-wider">
+            Unavailable
+          </span>
+        </div>
+        <p className="text-xs text-gray-500 dark:text-white/40 leading-relaxed">{fetchError}</p>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const hasUpdate =
+    data.status === "available" &&
+    data.latest_version &&
+    data.current_version !== data.latest_version;
+
+  const lastCheckTime = (() => {
+    try {
+      if (!data.last_check) return "Never";
+      return new Date(data.last_check).toLocaleString();
+    } catch {
+      return data.last_check;
+    }
+  })();
+
+  // Main render
+  return (
+    <div className="py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+          App Updates
+        </p>
+        <span className="text-[10px] font-mono text-gray-400 dark:text-white/30 uppercase tracking-wider">
+          {data.current_version}
+        </span>
+      </div>
+
+      {/* Channel Selector */}
+      <div className="flex items-center justify-between gap-4">
+        <label className="text-[11px] font-medium text-gray-500 dark:text-white/40 uppercase tracking-tight">
+          Release Channel
+        </label>
+        <select
+          value={data.channel}
+          onChange={(e) => handleChannelChange(e.target.value)}
+          disabled={changingChannel || checking || data.status === "queued"}
+          className="bg-black/5 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 rounded-lg px-2 py-1 text-[12px] text-gray-700 dark:text-white/80 focus:outline-none transition-all cursor-pointer disabled:opacity-50"
+        >
+          <option value="stable">Stable</option>
+          <option value="pre-release">Pre-release</option>
+        </select>
+      </div>
+
+      {/* Configuration Warning */}
+      {!data.is_configured && (
+        <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-500/10 border-[0.5px] border-amber-200 dark:border-amber-500/20">
+          <p className="text-xs font-medium text-amber-800 dark:text-amber-400 mb-1">
+            Configuration Required
+          </p>
+          <p className="text-[11px] text-amber-600 dark:text-amber-400/80 leading-relaxed">
+            Update access is not fully configured. Go to your <b>Cloudflare Dashboard</b> →{" "}
+            <b>Workers & Pages</b> → <b>[Your Worker]</b> → <b>Settings</b> → <b>Variables</b> and
+            add your <code>GITHUB_TOKEN</code> (Secret) and <code>GITHUB_REPO</code> (Variable) to
+            enable updates.
+          </p>
+        </div>
+      )}
+
+      {/* Error state */}
+      {data.last_error && (
+        <div className="p-3 rounded-lg bg-red-50 dark:bg-red-500/10 border-[0.5px] border-red-200 dark:border-red-500/20">
+          <p className="text-xs font-medium text-red-800 dark:text-red-400 mb-1">Update Failed</p>
+          <p className="text-[11px] text-red-600 dark:text-red-400/80 leading-relaxed break-words">
+            {data.last_error}
+          </p>
+        </div>
+      )}
+
+      {/* Queued / In-progress state */}
+      {data.status === "queued" && (
+        <div className="p-3 rounded-lg bg-blue-50 dark:bg-blue-500/10 border-[0.5px] border-blue-200 dark:border-blue-500/20">
+          <div className="flex items-center gap-2">
+            <svg
+              className="w-3.5 h-3.5 text-blue-500 dark:text-blue-400 animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            <p className="text-xs font-medium text-blue-800 dark:text-blue-400">
+              Update in progress…
+            </p>
+          </div>
+          <p className="text-[11px] text-blue-600 dark:text-blue-400/80 mt-1 ml-5.5">
+            Fetching and applying files. This may take a minute.
+          </p>
+        </div>
+      )}
+
+      {/* Up-to-date state */}
+      {(data.status === "up_to_date" || data.status === "success") && !hasUpdate && (
+        <div className="p-3 rounded-lg bg-green-50 dark:bg-green-500/10 border-[0.5px] border-green-200 dark:border-green-500/20">
+          <div className="flex items-center gap-2">
+            <svg
+              className="w-3.5 h-3.5 text-green-600 dark:text-green-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2.5"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+            <p className="text-xs font-medium text-green-800 dark:text-green-400">Up to Date</p>
+          </div>
+          <p className="text-[11px] text-green-600 dark:text-green-400/80 mt-1 ml-5.5">
+            Last checked: {lastCheckTime}
+          </p>
+        </div>
+      )}
+
+      {/* Update available state */}
+      {hasUpdate && data.status !== "queued" && (
+        <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-500/10 border-[0.5px] border-amber-200 dark:border-amber-500/20">
+          <div className="flex items-center gap-2">
+            <svg
+              className="w-3.5 h-3.5 text-amber-600 dark:text-amber-400"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"
+              />
+            </svg>
+            <p className="text-xs font-medium text-amber-800 dark:text-amber-400">
+              Update Available
+            </p>
+          </div>
+          <p className="text-[11px] text-amber-600 dark:text-amber-400/80 mt-1 ml-5.5">
+            {data.current_version} → {data.latest_version}
+          </p>
+        </div>
+      )}
+
+      {/* Action Buttons */}
+      <div className="space-y-2">
+        {data.status === "available" && (
+          <button
+            onClick={handleUpdateNow}
+            disabled={applying || checking}
+            className="w-full py-2 text-[13px] md:text-sm font-semibold rounded-full transition-all duration-200 focus:outline-none disabled:opacity-40 disabled:cursor-not-allowed
+              bg-blue-600 hover:bg-blue-700 dark:bg-blue-500/20 dark:hover:bg-blue-500/30
+              text-white dark:text-blue-400
+              border-[0.5px] border-blue-700/10 dark:border-blue-500/20 shadow-sm"
+          >
+            {applying ? "Starting Update…" : "Update Now"}
+          </button>
+        )}
+
+        <button
+          onClick={handleCheckNow}
+          disabled={checking || applying || changingChannel || data.status === "queued"}
+          className="w-full py-2 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 focus:outline-none disabled:opacity-40 disabled:cursor-not-allowed
+            bg-black/5 hover:bg-black/10 dark:bg-white/5 dark:hover:bg-white/10
+            text-gray-700 hover:text-gray-900 dark:text-white/80 dark:hover:text-white/95
+            border-[0.5px] border-black/10 dark:border-white/10"
+        >
+          {checking ? "Checking…" : "Check for Updates"}
+        </button>
+      </div>
+
+      <p className="text-[10px] text-gray-400 dark:text-white/25 text-center leading-relaxed">
+        Automatic checks run daily at 2:00 AM UTC
+      </p>
+    </div>
+  );
+}

--- a/src/client/components/UpdateStatus.tsx
+++ b/src/client/components/UpdateStatus.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { UpdateChannel } from "../../worker/manifest";
 
 interface UpdateStatusData {
   current_version: string;
@@ -94,7 +95,7 @@ export default function UpdateStatus() {
 
     // Optimistic update
     const oldData = data;
-    setData({ ...data, channel: newChannel as any });
+    setData({ ...data, channel: newChannel as UpdateChannel });
     setChangingChannel(true);
 
     try {

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -1,4 +1,4 @@
-import type { StorageAdapter, Conversation, Message, DeleteMessageResult } from "./index";
+import type { Conversation, DeleteMessageResult, Message, StorageAdapter } from "./index";
 
 export class CloudStorage implements StorageAdapter {
   async getConversations(): Promise<Conversation[]> {
@@ -32,7 +32,7 @@ export class CloudStorage implements StorageAdapter {
   }
 
   async saveMessage(msg: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message> {
-    // Messages are saved server-side during /api/chat — nothing to do here
+    // Messages are saved server-side during /api/chat - nothing to do here
     return {
       ...msg,
       id: msg.id || crypto.randomUUID(),
@@ -41,7 +41,7 @@ export class CloudStorage implements StorageAdapter {
   }
 
   async updateConversationTitle(id: string, title: string): Promise<void> {
-    // Title is updated server-side after first message — nothing to do here
+    // Title is updated server-side after first message - nothing to do here
   }
 
   async deleteMessage(conversationId: string, messageId: string): Promise<DeleteMessageResult> {
@@ -53,4 +53,3 @@ export class CloudStorage implements StorageAdapter {
     return { deletedIds: data.deletedIds, softDeletedIds: data.softDeletedIds };
   }
 }
-

--- a/src/worker/github.ts
+++ b/src/worker/github.ts
@@ -1,0 +1,253 @@
+/**
+ * GitHub API integration for the auto-update system.
+ *
+ * Uses the Compare API to discover exactly which files changed between the
+ * user's current version tag and the latest release. This eliminates the need
+ * for a manually maintained file manifest - git history IS the manifest.
+ *
+ * Exclusion list: a small, stable set of paths that should never be overwritten
+ * (user configs, migrations, env files).
+ */
+
+import type { Env } from "./types";
+
+/** Paths that should NEVER be auto-updated (user-specific configs). */
+const EXCLUDED_PATHS = [
+  "wrangler.toml",
+  "wrangler.local.toml",
+  "wrangler.local.toml.example",
+  ".env",
+  ".env.local",
+  ".env.example",
+  ".dev.vars",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "tsconfig.json",
+  "vite.config.ts",
+  ".prettierrc",
+  ".gitignore",
+  "LICENSE",
+  "UPDATE_MANIFEST.json",
+];
+
+/** Path prefixes that should never be auto-updated. */
+const EXCLUDED_PREFIXES = [
+  "migrations/", // User's DB state - never overwrite applied migrations
+  ".git/",
+  "node_modules/",
+  "dist/",
+  ".wrangler/",
+  "docs/",
+  "scripts/", // Release tooling - not needed in user repos
+];
+
+const UPSTREAM_OWNER = "ranajahanzaib";
+const UPSTREAM_REPO = "waichat";
+
+export interface FileChange {
+  path: string;
+  status: "added" | "modified" | "removed" | "renamed";
+  downloadUrl: string;
+}
+
+export interface CommitFile {
+  path: string;
+  content: string;
+}
+
+function isExcluded(path: string): boolean {
+  if (EXCLUDED_PATHS.includes(path)) return true;
+  return EXCLUDED_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+/**
+ * Use the GitHub Compare API to get the exact list of files that changed
+ * between two version tags. Returns only files that aren't excluded.
+ *
+ * Compare API: GET /repos/{owner}/{repo}/compare/{base}...{head}
+ */
+export async function getChangedFiles(
+  env: Env,
+  fromTag: string,
+  toTag: string,
+): Promise<FileChange[]> {
+  const response = await fetch(
+    `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/compare/${fromTag}...${toTag}`,
+    {
+      headers: {
+        "User-Agent": "waichat-updater/1.0",
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `Compare API failed (${fromTag}...${toTag}): HTTP ${response.status} - ${body.substring(0, 200)}`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    files: {
+      filename: string;
+      status: "added" | "modified" | "removed" | "renamed";
+      raw_url: string;
+    }[];
+  };
+
+  if (!Array.isArray(data.files)) {
+    throw new Error("Compare API returned unexpected format: missing files array");
+  }
+
+  return data.files
+    .filter((f) => !isExcluded(f.filename))
+    .map((f) => ({
+      path: f.filename,
+      status: f.status,
+      downloadUrl: f.raw_url,
+    }));
+}
+
+/**
+ * Fetch file contents for all changed files (additions + modifications).
+ * Skips removed files - those are handled separately during commit.
+ */
+export async function fetchChangedFiles(env: Env, changes: FileChange[]): Promise<CommitFile[]> {
+  const filesToCommit: CommitFile[] = [];
+
+  for (const change of changes) {
+    if (change.status === "removed") continue; // Handled separately
+
+    const response = await fetch(change.downloadUrl, {
+      headers: { "User-Agent": "waichat-updater/1.0" },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${change.path}: HTTP ${response.status}`);
+    }
+
+    const content = await response.text();
+    filesToCommit.push({ path: change.path, content });
+  }
+
+  return filesToCommit;
+}
+
+/**
+ * Commit updated/added files and delete removed files in the user's GitHub repo.
+ * Uses the GitHub Contents API (one commit per file).
+ *
+ * Requires GITHUB_TOKEN with Contents read+write permission on the target repo.
+ */
+export async function commitChangesToGitHub(
+  env: Env,
+  filesToUpdate: CommitFile[],
+  filesToDelete: string[],
+  version: string,
+): Promise<number> {
+  const token = env.GITHUB_TOKEN;
+  const repo = env.GITHUB_REPO;
+
+  if (!token) {
+    throw new Error(
+      "GITHUB_TOKEN not configured. See WaiChat setup guide for auto-update token provisioning.",
+    );
+  }
+
+  if (!repo || !repo.includes("/")) {
+    throw new Error(`Invalid GITHUB_REPO format: "${repo}" (expected: owner/repo)`);
+  }
+
+  let totalCommitted = 0;
+
+  // 1. Update/create files
+  for (const file of filesToUpdate) {
+    const existingSha = await getFileSha(token, repo, file.path);
+
+    const body: Record<string, unknown> = {
+      message: `chore(auto-update): ${version} - update ${file.path}`,
+      content: btoa(file.content),
+      branch: "main",
+    };
+
+    if (existingSha) {
+      body.sha = existingSha;
+    }
+
+    const response = await fetch(`https://api.github.com/repos/${repo}/contents/${file.path}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "waichat-updater/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+        Accept: "application/vnd.github+json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as { message?: string };
+      throw new Error(
+        `GitHub API error for ${file.path}: ${error.message || response.statusText} (HTTP ${response.status})`,
+      );
+    }
+
+    totalCommitted++;
+  }
+
+  // 2. Delete removed files
+  for (const path of filesToDelete) {
+    const existingSha = await getFileSha(token, repo, path);
+    if (!existingSha) continue; // File doesn't exist in user's repo - skip
+
+    const response = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "waichat-updater/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+        Accept: "application/vnd.github+json",
+      },
+      body: JSON.stringify({
+        message: `chore(auto-update): ${version} - remove ${path}`,
+        sha: existingSha,
+        branch: "main",
+      }),
+    });
+
+    if (!response.ok) {
+      const error = (await response.json()) as { message?: string };
+      // Don't fail the whole update for a delete - log and continue
+      console.error(`[GitHub] Failed to delete ${path}: ${error.message || response.statusText}`);
+    } else {
+      totalCommitted++;
+    }
+  }
+
+  return totalCommitted;
+}
+
+/** Get a file's SHA from the user's repo (needed for updates and deletes). */
+async function getFileSha(token: string, repo: string, path: string): Promise<string | undefined> {
+  try {
+    const response = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "waichat-updater/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+        Accept: "application/vnd.github+json",
+      },
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as { sha: string };
+      return data.sha;
+    }
+    return undefined; // 404 = new file
+  } catch {
+    return undefined;
+  }
+}

--- a/src/worker/github.ts
+++ b/src/worker/github.ts
@@ -29,13 +29,14 @@ const UPSTREAM_REPO = "waichat";
 
 export interface FileChange {
   path: string;
+  previousPath?: string;
   status: "added" | "modified" | "removed" | "renamed";
   downloadUrl: string;
 }
 
 export interface CommitFile {
   path: string;
-  content: string;
+  content: Uint8Array;
 }
 
 export interface GitTreeItem {
@@ -57,9 +58,9 @@ function isExcluded(path: string): boolean {
 }
 
 /** UTF-8 safe Base64 encoding using Worker's nodejs_compat. */
-function toBase64(str: string): string {
+function toBase64(data: string | Uint8Array): string {
   // Use globalThis cast to avoid TypeScript errors without @types/node
-  return (globalThis as any).Buffer.from(str).toString("base64");
+  return (globalThis as any).Buffer.from(data).toString("base64");
 }
 
 /** Helper to process an array in chunks to respect subrequest limits. */
@@ -111,6 +112,7 @@ export async function getChangedFiles(
   const data = (await response.json()) as {
     files: {
       filename: string;
+      previous_filename?: string;
       status: "added" | "modified" | "removed" | "renamed";
       raw_url: string;
     }[];
@@ -132,6 +134,7 @@ export async function getChangedFiles(
     .filter((f) => !isExcluded(f.filename))
     .map((f) => ({
       path: f.filename,
+      previousPath: f.previous_filename,
       status: f.status,
       downloadUrl: f.raw_url,
     }));
@@ -156,7 +159,7 @@ export async function fetchChangedFiles(env: Env, changes: FileChange[]): Promis
       throw new Error(`Failed to fetch ${change.path}: HTTP ${response.status}`);
     }
 
-    const content = await response.text();
+    const content = new Uint8Array(await response.arrayBuffer());
     return { path: change.path, content };
   });
 }

--- a/src/worker/github.ts
+++ b/src/worker/github.ts
@@ -131,7 +131,16 @@ export async function getChangedFiles(
   }
 
   return data.files
-    .filter((f) => !isExcluded(f.filename))
+    .filter((f) => {
+      // Never overwrite or touch excluded paths
+      if (isExcluded(f.filename)) return false;
+
+      // SAFETY: If this is a rename, ensure we don't delete an excluded path
+      // (e.g. if the upstream repo renamed a file to something we treat as a secret)
+      if (f.previous_filename && isExcluded(f.previous_filename)) return false;
+
+      return true;
+    })
     .map((f) => ({
       path: f.filename,
       previousPath: f.previous_filename,

--- a/src/worker/github.ts
+++ b/src/worker/github.ts
@@ -15,25 +15,12 @@ import type { Env } from "./types";
 const EXCLUDED_PATHS = [
   "wrangler.toml",
   "wrangler.local.toml",
-  "wrangler.local.toml.example",
   ".env",
-  ".env.local",
-  ".env.example",
   ".dev.vars",
-  "package.json",
-  "pnpm-lock.yaml",
-  "pnpm-workspace.yaml",
-  "tsconfig.json",
-  "vite.config.ts",
-  ".prettierrc",
-  ".gitignore",
-  "LICENSE",
-  "UPDATE_MANIFEST.json",
 ];
 
 /** Path prefixes that should never be auto-updated. */
 const EXCLUDED_PREFIXES = [
-  "migrations/", // User's DB state - never overwrite applied migrations
   ".git/",
   "node_modules/",
   "dist/",
@@ -57,8 +44,24 @@ export interface CommitFile {
 }
 
 function isExcluded(path: string): boolean {
+  // Never overwrite secrets or infrastructure config
   if (EXCLUDED_PATHS.includes(path)) return true;
+
+  // Never overwrite local databases
+  if (path.endsWith(".sqlite") || path.endsWith(".db")) return true;
+
+  // Never touch internal folders
   return EXCLUDED_PREFIXES.some((prefix) => path.startsWith(prefix));
+}
+
+/** UTF-8 safe Base64 encoding for Workers. */
+function toBase64(str: string): string {
+  const bytes = new TextEncoder().encode(str);
+  let binary = "";
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
 }
 
 /**
@@ -116,24 +119,22 @@ export async function getChangedFiles(
  * Skips removed files - those are handled separately during commit.
  */
 export async function fetchChangedFiles(env: Env, changes: FileChange[]): Promise<CommitFile[]> {
-  const filesToCommit: CommitFile[] = [];
+  return Promise.all(
+    changes
+      .filter((change) => change.status !== "removed")
+      .map(async (change) => {
+        const response = await fetch(change.downloadUrl, {
+          headers: { "User-Agent": "waichat-updater/1.0" },
+        });
 
-  for (const change of changes) {
-    if (change.status === "removed") continue; // Handled separately
+        if (!response.ok) {
+          throw new Error(`Failed to fetch ${change.path}: HTTP ${response.status}`);
+        }
 
-    const response = await fetch(change.downloadUrl, {
-      headers: { "User-Agent": "waichat-updater/1.0" },
-    });
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch ${change.path}: HTTP ${response.status}`);
-    }
-
-    const content = await response.text();
-    filesToCommit.push({ path: change.path, content });
-  }
-
-  return filesToCommit;
+        const content = await response.text();
+        return { path: change.path, content };
+      }),
+  );
 }
 
 /**
@@ -169,7 +170,7 @@ export async function commitChangesToGitHub(
 
     const body: Record<string, unknown> = {
       message: `chore(auto-update): ${version} - update ${file.path}`,
-      content: btoa(file.content),
+      content: toBase64(file.content),
       branch: "main",
     };
 
@@ -232,22 +233,20 @@ export async function commitChangesToGitHub(
 
 /** Get a file's SHA from the user's repo (needed for updates and deletes). */
 async function getFileSha(token: string, repo: string, path: string): Promise<string | undefined> {
-  try {
-    const response = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "waichat-updater/1.0",
-        "X-GitHub-Api-Version": "2022-11-28",
-        Accept: "application/vnd.github+json",
-      },
-    });
+  const response = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "waichat-updater/1.0",
+      "X-GitHub-Api-Version": "2022-11-28",
+      Accept: "application/vnd.github+json",
+    },
+  });
 
-    if (response.ok) {
-      const data = (await response.json()) as { sha: string };
-      return data.sha;
-    }
-    return undefined; // 404 = new file
-  } catch {
-    return undefined;
+  if (response.status === 404) return undefined;
+  if (!response.ok) {
+    throw new Error(`GitHub API error getting SHA for ${path}: HTTP ${response.status}`);
   }
+
+  const data = (await response.json()) as { sha: string };
+  return data.sha;
 }

--- a/src/worker/github.ts
+++ b/src/worker/github.ts
@@ -12,12 +12,7 @@
 import type { Env } from "./types";
 
 /** Paths that should NEVER be auto-updated (user-specific configs). */
-const EXCLUDED_PATHS = [
-  "wrangler.toml",
-  "wrangler.local.toml",
-  ".env",
-  ".dev.vars",
-];
+const EXCLUDED_PATHS = ["wrangler.toml", "wrangler.local.toml", ".env", ".dev.vars"];
 
 /** Path prefixes that should never be auto-updated. */
 const EXCLUDED_PREFIXES = [
@@ -67,6 +62,21 @@ function toBase64(str: string): string {
   return (globalThis as any).Buffer.from(str).toString("base64");
 }
 
+/** Helper to process an array in chunks to respect subrequest limits. */
+async function processInChunks<T, R>(
+  items: T[],
+  chunkSize: number,
+  processor: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  for (let i = 0; i < items.length; i += chunkSize) {
+    const chunk = items.slice(i, i + chunkSize);
+    const chunkResults = await Promise.all(chunk.map(processor));
+    results.push(...chunkResults);
+  }
+  return results;
+}
+
 /**
  * Use the GitHub Compare API to get the exact list of files that changed
  * between two version tags. Returns only files that aren't excluded.
@@ -85,6 +95,8 @@ export async function getChangedFiles(
         "User-Agent": "waichat-updater/1.0",
         Accept: "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
+        // Use user's token even for upstream checks to avoid unauthenticated rate limits
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
       },
     },
   );
@@ -127,25 +139,26 @@ export async function getChangedFiles(
 
 /**
  * Fetch file contents for all changed files (additions + modifications).
- * Skips removed files - those are handled separately during commit.
+ * Processes in chunks of 10 to stay within Cloudflare subrequest limits.
  */
 export async function fetchChangedFiles(env: Env, changes: FileChange[]): Promise<CommitFile[]> {
-  return Promise.all(
-    changes
-      .filter((change) => change.status !== "removed")
-      .map(async (change) => {
-        const response = await fetch(change.downloadUrl, {
-          headers: { "User-Agent": "waichat-updater/1.0" },
-        });
+  const filteredChanges = changes.filter((change) => change.status !== "removed");
 
-        if (!response.ok) {
-          throw new Error(`Failed to fetch ${change.path}: HTTP ${response.status}`);
-        }
+  return processInChunks(filteredChanges, 10, async (change) => {
+    const response = await fetch(change.downloadUrl, {
+      headers: {
+        "User-Agent": "waichat-updater/1.0",
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+      },
+    });
 
-        const content = await response.text();
-        return { path: change.path, content };
-      }),
-  );
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${change.path}: HTTP ${response.status}`);
+    }
+
+    const content = await response.text();
+    return { path: change.path, content };
+  });
 }
 
 /**
@@ -171,52 +184,56 @@ export async function commitChangesToGitHub(
     Accept: "application/vnd.github+json",
   };
 
-  // 1. Detect default branch
+  // Detect default branch
   const repoInfo = await fetch(`https://api.github.com/repos/${repo}`, {
     headers: commonHeaders,
   });
   if (!repoInfo.ok) throw new Error(`Failed to fetch repo info: ${repoInfo.status}`);
   const { default_branch } = (await repoInfo.json()) as { default_branch: string };
 
-  // 2. Get latest commit SHA of default branch
-  const refInfo = await fetch(`https://api.github.com/repos/${repo}/git/refs/heads/${default_branch}`, {
-    headers: commonHeaders,
-  });
+  // Get latest commit SHA of default branch
+  const refInfo = await fetch(
+    `https://api.github.com/repos/${repo}/git/refs/heads/${default_branch}`,
+    {
+      headers: commonHeaders,
+    },
+  );
   if (!refInfo.ok) throw new Error(`Failed to fetch branch ref: ${refInfo.status}`);
   const { object } = (await refInfo.json()) as { object: { sha: string } };
   const baseCommitSha = object.sha;
 
-  // 3. Get the tree SHA from the base commit
-  const commitInfo = await fetch(`https://api.github.com/repos/${repo}/git/commits/${baseCommitSha}`, {
-    headers: commonHeaders,
-  });
+  // Get the tree SHA from the base commit
+  const commitInfo = await fetch(
+    `https://api.github.com/repos/${repo}/git/commits/${baseCommitSha}`,
+    {
+      headers: commonHeaders,
+    },
+  );
   if (!commitInfo.ok) throw new Error(`Failed to fetch base commit: ${commitInfo.status}`);
   const { tree } = (await commitInfo.json()) as { tree: { sha: string } };
   const baseTreeSha = tree.sha;
 
-  // 4. Create blobs for new/updated files in parallel
-  const treeItems: GitTreeItem[] = await Promise.all(
-    filesToUpdate.map(async (file) => {
-      const blobResponse = await fetch(`https://api.github.com/repos/${repo}/git/blobs`, {
-        method: "POST",
-        headers: commonHeaders,
-        body: JSON.stringify({
-          content: toBase64(file.content),
-          encoding: "base64",
-        }),
-      });
-      if (!blobResponse.ok) throw new Error(`Failed to create blob for ${file.path}`);
-      const { sha } = (await blobResponse.json()) as { sha: string };
-      return {
-        path: file.path,
-        mode: "100644",
-        type: "blob",
-        sha,
-      };
-    }),
-  );
+  // Create blobs for new/updated files in parallel (chunked)
+  const treeItems: GitTreeItem[] = await processInChunks(filesToUpdate, 10, async (file) => {
+    const blobResponse = await fetch(`https://api.github.com/repos/${repo}/git/blobs`, {
+      method: "POST",
+      headers: commonHeaders,
+      body: JSON.stringify({
+        content: toBase64(file.content),
+        encoding: "base64",
+      }),
+    });
+    if (!blobResponse.ok) throw new Error(`Failed to create blob for ${file.path}`);
+    const { sha } = (await blobResponse.json()) as { sha: string };
+    return {
+      path: file.path,
+      mode: "100644",
+      type: "blob",
+      sha,
+    };
+  });
 
-  // 5. Add deletions to the tree items
+  // Add deletions to the tree items
   // Setting sha: null in the tree API removes the file
   for (const path of filesToDelete) {
     treeItems.push({
@@ -229,7 +246,7 @@ export async function commitChangesToGitHub(
 
   if (treeItems.length === 0) return 0;
 
-  // 6. Create a new tree
+  // Create a new tree
   const newTreeResponse = await fetch(`https://api.github.com/repos/${repo}/git/trees`, {
     method: "POST",
     headers: commonHeaders,
@@ -238,7 +255,8 @@ export async function commitChangesToGitHub(
       tree: treeItems,
     }),
   });
-  if (!newTreeResponse.ok) throw new Error(`Failed to create new tree: ${await newTreeResponse.text()}`);
+  if (!newTreeResponse.ok)
+    throw new Error(`Failed to create new tree: ${await newTreeResponse.text()}`);
   const { sha: newTreeSha } = (await newTreeResponse.json()) as { sha: string };
 
   // 7. Create a commit
@@ -251,20 +269,24 @@ export async function commitChangesToGitHub(
       parents: [baseCommitSha],
     }),
   });
-  if (!newCommitResponse.ok) throw new Error(`Failed to create commit: ${await newCommitResponse.text()}`);
+  if (!newCommitResponse.ok)
+    throw new Error(`Failed to create commit: ${await newCommitResponse.text()}`);
   const { sha: newCommitSha } = (await newCommitResponse.json()) as { sha: string };
 
-  // 8. Update the branch reference
-  const updateRefResponse = await fetch(`https://api.github.com/repos/${repo}/git/refs/heads/${default_branch}`, {
-    method: "PATCH",
-    headers: commonHeaders,
-    body: JSON.stringify({
-      sha: newCommitSha,
-      force: false,
-    }),
-  });
-  if (!updateRefResponse.ok) throw new Error(`Failed to update ref: ${await updateRefResponse.text()}`);
+  // Update the branch reference
+  const updateRefResponse = await fetch(
+    `https://api.github.com/repos/${repo}/git/refs/heads/${default_branch}`,
+    {
+      method: "PATCH",
+      headers: commonHeaders,
+      body: JSON.stringify({
+        sha: newCommitSha,
+        force: false,
+      }),
+    },
+  );
+  if (!updateRefResponse.ok)
+    throw new Error(`Failed to update ref: ${await updateRefResponse.text()}`);
 
   return treeItems.length;
 }
-

--- a/src/worker/github.ts
+++ b/src/worker/github.ts
@@ -43,6 +43,13 @@ export interface CommitFile {
   content: string;
 }
 
+export interface GitTreeItem {
+  path: string;
+  mode: "100644" | "100755" | "040000" | "160000" | "120000";
+  type: "blob" | "tree" | "commit";
+  sha: string | null;
+}
+
 function isExcluded(path: string): boolean {
   // Never overwrite secrets or infrastructure config
   if (EXCLUDED_PATHS.includes(path)) return true;
@@ -99,6 +106,14 @@ export async function getChangedFiles(
 
   if (!Array.isArray(data.files)) {
     throw new Error("Compare API returned unexpected format: missing files array");
+  }
+
+  // GitHub Compare API limits the files array to 300.
+  // If we hit this, we must abort to prevent an incomplete/broken update.
+  if (data.files.length >= 300) {
+    throw new Error(
+      `Update too large: ${data.files.length} files changed. The auto-updater currently supports a maximum of 300 files per release to ensure integrity.`,
+    );
   }
 
   return data.files
@@ -180,7 +195,7 @@ export async function commitChangesToGitHub(
   const baseTreeSha = tree.sha;
 
   // 4. Create blobs for new/updated files in parallel
-  const treeItems = await Promise.all(
+  const treeItems: GitTreeItem[] = await Promise.all(
     filesToUpdate.map(async (file) => {
       const blobResponse = await fetch(`https://api.github.com/repos/${repo}/git/blobs`, {
         method: "POST",
@@ -208,7 +223,7 @@ export async function commitChangesToGitHub(
       path,
       mode: "100644",
       type: "blob",
-      sha: null as any,
+      sha: null,
     });
   }
 

--- a/src/worker/github.ts
+++ b/src/worker/github.ts
@@ -54,14 +54,10 @@ function isExcluded(path: string): boolean {
   return EXCLUDED_PREFIXES.some((prefix) => path.startsWith(prefix));
 }
 
-/** UTF-8 safe Base64 encoding for Workers. */
+/** UTF-8 safe Base64 encoding using Worker's nodejs_compat. */
 function toBase64(str: string): string {
-  const bytes = new TextEncoder().encode(str);
-  let binary = "";
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
+  // Use globalThis cast to avoid TypeScript errors without @types/node
+  return (globalThis as any).Buffer.from(str).toString("base64");
 }
 
 /**
@@ -138,10 +134,8 @@ export async function fetchChangedFiles(env: Env, changes: FileChange[]): Promis
 }
 
 /**
- * Commit updated/added files and delete removed files in the user's GitHub repo.
- * Uses the GitHub Contents API (one commit per file).
- *
- * Requires GITHUB_TOKEN with Contents read+write permission on the target repo.
+ * Commit all changes to the user's GitHub repo in a single atomic batch.
+ * Flow: Blobs -> Tree -> Commit -> Ref update.
  */
 export async function commitChangesToGitHub(
   env: Env,
@@ -152,101 +146,110 @@ export async function commitChangesToGitHub(
   const token = env.GITHUB_TOKEN;
   const repo = env.GITHUB_REPO;
 
-  if (!token) {
-    throw new Error(
-      "GITHUB_TOKEN not configured. See WaiChat setup guide for auto-update token provisioning.",
-    );
-  }
+  if (!token) throw new Error("GITHUB_TOKEN not configured");
+  if (!repo || !repo.includes("/")) throw new Error(`Invalid GITHUB_REPO: ${repo}`);
 
-  if (!repo || !repo.includes("/")) {
-    throw new Error(`Invalid GITHUB_REPO format: "${repo}" (expected: owner/repo)`);
-  }
+  const commonHeaders = {
+    Authorization: `Bearer ${token}`,
+    "User-Agent": "waichat-updater/1.0",
+    "X-GitHub-Api-Version": "2022-11-28",
+    Accept: "application/vnd.github+json",
+  };
 
-  let totalCommitted = 0;
-
-  // 1. Update/create files
-  for (const file of filesToUpdate) {
-    const existingSha = await getFileSha(token, repo, file.path);
-
-    const body: Record<string, unknown> = {
-      message: `chore(auto-update): ${version} - update ${file.path}`,
-      content: toBase64(file.content),
-      branch: "main",
-    };
-
-    if (existingSha) {
-      body.sha = existingSha;
-    }
-
-    const response = await fetch(`https://api.github.com/repos/${repo}/contents/${file.path}`, {
-      method: "PUT",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "waichat-updater/1.0",
-        "X-GitHub-Api-Version": "2022-11-28",
-        Accept: "application/vnd.github+json",
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      const error = (await response.json()) as { message?: string };
-      throw new Error(
-        `GitHub API error for ${file.path}: ${error.message || response.statusText} (HTTP ${response.status})`,
-      );
-    }
-
-    totalCommitted++;
-  }
-
-  // 2. Delete removed files
-  for (const path of filesToDelete) {
-    const existingSha = await getFileSha(token, repo, path);
-    if (!existingSha) continue; // File doesn't exist in user's repo - skip
-
-    const response = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
-      method: "DELETE",
-      headers: {
-        Authorization: `Bearer ${token}`,
-        "User-Agent": "waichat-updater/1.0",
-        "X-GitHub-Api-Version": "2022-11-28",
-        Accept: "application/vnd.github+json",
-      },
-      body: JSON.stringify({
-        message: `chore(auto-update): ${version} - remove ${path}`,
-        sha: existingSha,
-        branch: "main",
-      }),
-    });
-
-    if (!response.ok) {
-      const error = (await response.json()) as { message?: string };
-      // Don't fail the whole update for a delete - log and continue
-      console.error(`[GitHub] Failed to delete ${path}: ${error.message || response.statusText}`);
-    } else {
-      totalCommitted++;
-    }
-  }
-
-  return totalCommitted;
-}
-
-/** Get a file's SHA from the user's repo (needed for updates and deletes). */
-async function getFileSha(token: string, repo: string, path: string): Promise<string | undefined> {
-  const response = await fetch(`https://api.github.com/repos/${repo}/contents/${path}`, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      "User-Agent": "waichat-updater/1.0",
-      "X-GitHub-Api-Version": "2022-11-28",
-      Accept: "application/vnd.github+json",
-    },
+  // 1. Detect default branch
+  const repoInfo = await fetch(`https://api.github.com/repos/${repo}`, {
+    headers: commonHeaders,
   });
+  if (!repoInfo.ok) throw new Error(`Failed to fetch repo info: ${repoInfo.status}`);
+  const { default_branch } = (await repoInfo.json()) as { default_branch: string };
 
-  if (response.status === 404) return undefined;
-  if (!response.ok) {
-    throw new Error(`GitHub API error getting SHA for ${path}: HTTP ${response.status}`);
+  // 2. Get latest commit SHA of default branch
+  const refInfo = await fetch(`https://api.github.com/repos/${repo}/git/refs/heads/${default_branch}`, {
+    headers: commonHeaders,
+  });
+  if (!refInfo.ok) throw new Error(`Failed to fetch branch ref: ${refInfo.status}`);
+  const { object } = (await refInfo.json()) as { object: { sha: string } };
+  const baseCommitSha = object.sha;
+
+  // 3. Get the tree SHA from the base commit
+  const commitInfo = await fetch(`https://api.github.com/repos/${repo}/git/commits/${baseCommitSha}`, {
+    headers: commonHeaders,
+  });
+  if (!commitInfo.ok) throw new Error(`Failed to fetch base commit: ${commitInfo.status}`);
+  const { tree } = (await commitInfo.json()) as { tree: { sha: string } };
+  const baseTreeSha = tree.sha;
+
+  // 4. Create blobs for new/updated files in parallel
+  const treeItems = await Promise.all(
+    filesToUpdate.map(async (file) => {
+      const blobResponse = await fetch(`https://api.github.com/repos/${repo}/git/blobs`, {
+        method: "POST",
+        headers: commonHeaders,
+        body: JSON.stringify({
+          content: toBase64(file.content),
+          encoding: "base64",
+        }),
+      });
+      if (!blobResponse.ok) throw new Error(`Failed to create blob for ${file.path}`);
+      const { sha } = (await blobResponse.json()) as { sha: string };
+      return {
+        path: file.path,
+        mode: "100644",
+        type: "blob",
+        sha,
+      };
+    }),
+  );
+
+  // 5. Add deletions to the tree items
+  // Setting sha: null in the tree API removes the file
+  for (const path of filesToDelete) {
+    treeItems.push({
+      path,
+      mode: "100644",
+      type: "blob",
+      sha: null as any,
+    });
   }
 
-  const data = (await response.json()) as { sha: string };
-  return data.sha;
+  if (treeItems.length === 0) return 0;
+
+  // 6. Create a new tree
+  const newTreeResponse = await fetch(`https://api.github.com/repos/${repo}/git/trees`, {
+    method: "POST",
+    headers: commonHeaders,
+    body: JSON.stringify({
+      base_tree: baseTreeSha,
+      tree: treeItems,
+    }),
+  });
+  if (!newTreeResponse.ok) throw new Error(`Failed to create new tree: ${await newTreeResponse.text()}`);
+  const { sha: newTreeSha } = (await newTreeResponse.json()) as { sha: string };
+
+  // 7. Create a commit
+  const newCommitResponse = await fetch(`https://api.github.com/repos/${repo}/git/commits`, {
+    method: "POST",
+    headers: commonHeaders,
+    body: JSON.stringify({
+      message: `chore(auto-update): deploy ${version}`,
+      tree: newTreeSha,
+      parents: [baseCommitSha],
+    }),
+  });
+  if (!newCommitResponse.ok) throw new Error(`Failed to create commit: ${await newCommitResponse.text()}`);
+  const { sha: newCommitSha } = (await newCommitResponse.json()) as { sha: string };
+
+  // 8. Update the branch reference
+  const updateRefResponse = await fetch(`https://api.github.com/repos/${repo}/git/refs/heads/${default_branch}`, {
+    method: "PATCH",
+    headers: commonHeaders,
+    body: JSON.stringify({
+      sha: newCommitSha,
+      force: false,
+    }),
+  });
+  if (!updateRefResponse.ok) throw new Error(`Failed to update ref: ${await updateRefResponse.text()}`);
+
+  return treeItems.length;
 }
+

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -8,14 +8,25 @@ import {
   getConversations,
   getMessageById,
   getMessages,
+  getSetting,
   getSiblingCount,
   saveMessage,
+  setSetting,
   updateConversationTimestamp,
   updateConversationTitle,
-  getSetting,
-  setSetting,
 } from "./db";
-import type { ChatRequest, Env } from "./types";
+import { commitChangesToGitHub, fetchChangedFiles, getChangedFiles } from "./github";
+import type { UpdateChannel } from "./manifest";
+import { fetchLatestRelease } from "./manifest";
+import type { ChatRequest, Env, UpdateQueueMessage } from "./types";
+import {
+  getUpdateLog,
+  getUpdateState,
+  logUpdateAttempt,
+  updateAfterCommit,
+  updateCheckStatus,
+} from "./update-db";
+import { APP_VERSION } from "./version";
 
 function scoreModel(id: string): number {
   let score = 0;
@@ -102,7 +113,7 @@ const app = new Hono<{ Bindings: Env }>();
 
 app.use("/api/*", cors());
 
-// Models — fetched live from Cloudflare API if account ID is set, otherwise hardcoded fallback
+// Models - fetched live from Cloudflare API if account ID is set, otherwise hardcoded fallback
 app.get("/api/models", async (c) => {
   if (!c.env.CLOUDFLARE_ACCOUNT_ID) {
     return c.json(AVAILABLE_MODELS);
@@ -244,7 +255,9 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
         if (siblingCount > 0) {
           // Has retry siblings - soft-delete (preserve for parent_id references)
           statements.push(
-            db.prepare("UPDATE messages SET content = '', deleted_at = ? WHERE id = ?").bind(Date.now(), msg.id),
+            db
+              .prepare("UPDATE messages SET content = '', deleted_at = ? WHERE id = ?")
+              .bind(Date.now(), msg.id),
           );
           softDeletedIds.push(msg.id);
         } else {
@@ -257,7 +270,9 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
 
     // Execute all mutations in a single batch round-trip
     statements.push(
-      db.prepare("UPDATE conversations SET updated_at = ? WHERE id = ?").bind(Date.now(), conversationId),
+      db
+        .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")
+        .bind(Date.now(), conversationId),
     );
     await db.batch(statements);
 
@@ -269,7 +284,7 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
 });
 
 // Settings
-const ALLOWED_SETTING_KEYS = ["system_prompt"];
+const ALLOWED_SETTING_KEYS = ["system_prompt", "update_channel"];
 
 app.get("/api/settings/:key", async (c) => {
   const key = c.req.param("key");
@@ -434,4 +449,329 @@ app.post("/api/chat", async (c) => {
 
 // saveAssistantMessage is no longer needed as saving is handled inline with streaming
 
-export default app;
+// Auto-Update API Routes
+
+/** GET /api/updates/status - Current version, last check, recent logs. */
+app.get("/api/updates/status", async (c) => {
+  try {
+    const channel = ((await getSetting(c.env.DB, "update_channel")) || "stable") as UpdateChannel;
+    const state = await getUpdateState(c.env.DB, channel);
+    const recentLogs = await getUpdateLog(c.env.DB, 5);
+
+    const is_configured = !!(c.env.GITHUB_TOKEN && c.env.GITHUB_REPO);
+
+    return c.json({
+      current_version: APP_VERSION,
+      latest_version: state?.latest_version ?? null,
+      last_check: state?.last_check ?? null,
+      last_attempt: state?.last_attempt ?? null,
+      status: state?.last_status ?? "up_to_date",
+      last_error: state?.last_error ?? null,
+      channel,
+      is_configured,
+      recent_logs: recentLogs,
+    });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Unknown error" }, 500);
+  }
+});
+
+/** POST /api/updates/check - Manually check for updates (does NOT queue work). */
+app.post("/api/updates/check", async (c) => {
+  try {
+    // 1. Read channel preference, fetch latest release from upstream
+    const channel = ((await getSetting(c.env.DB, "update_channel")) || "stable") as UpdateChannel;
+    const release = await fetchLatestRelease(c.env, channel);
+    if (!release) {
+      // If no releases found on this channel, reset to up_to_date to clear stale "Available" messages
+      await updateCheckStatus(c.env.DB, channel, {
+        last_check: new Date().toISOString(),
+        last_status: "up_to_date",
+        latest_version: null,
+        last_error: null,
+      });
+      return c.json({
+        message: `No releases found on ${channel} channel`,
+        status: "up_to_date",
+        current_version: APP_VERSION,
+        latest_version: null,
+      });
+    }
+
+    // 2. Compare against running version
+    if (APP_VERSION === release.version) {
+      await updateCheckStatus(c.env.DB, channel, {
+        last_check: new Date().toISOString(),
+        last_status: "up_to_date",
+        latest_version: release.version,
+        last_error: null,
+      });
+      return c.json({
+        message: "Already up to date",
+        status: "up_to_date",
+        current_version: APP_VERSION,
+        latest_version: release.version,
+      });
+    }
+
+    // 3. Mark as update available
+    await updateCheckStatus(c.env.DB, channel, {
+      last_check: new Date().toISOString(),
+      last_status: "available",
+      latest_version: release.version,
+      last_error: null,
+    });
+
+    return c.json({
+      message: `Update available: ${release.version}`,
+      status: "available",
+      current_version: APP_VERSION,
+      latest_version: release.version,
+    });
+  } catch (error) {
+    return c.json(
+      { error: error instanceof Error ? error.message : "Failed to check for updates" },
+      500,
+    );
+  }
+});
+
+/** POST /api/updates/apply - Manually trigger the update process. */
+app.post("/api/updates/apply", async (c) => {
+  try {
+    const channel = ((await getSetting(c.env.DB, "update_channel")) || "stable") as UpdateChannel;
+    const state = await getUpdateState(c.env.DB, channel);
+    if (!state || state.last_status !== "available" || !state.latest_version) {
+      return c.json({ error: "No update available to apply" }, 400);
+    }
+
+    // 1. Queue the update job
+    await c.env.UPDATE_QUEUE.send({
+      type: "update",
+      fromVersion: APP_VERSION,
+      toVersion: state.latest_version,
+      channel,
+      triggeredAt: new Date().toISOString(),
+    });
+
+    // 2. Update state to "queued"
+    await updateCheckStatus(c.env.DB, channel, {
+      last_check: new Date().toISOString(),
+      last_status: "queued",
+      latest_version: state.latest_version,
+      last_error: null,
+    });
+
+    return c.json({
+      message: `Update to ${state.latest_version} queued`,
+      status: "queued",
+    });
+  } catch (error) {
+    return c.json(
+      { error: error instanceof Error ? error.message : "Failed to apply update" },
+      500,
+    );
+  }
+});
+
+/** POST /api/updates/rollback - Rollback to a previous version. */
+app.post("/api/updates/rollback", async (c) => {
+  try {
+    const body = await c.req.json<{ version: string }>();
+    const { version } = body;
+
+    if (!version) {
+      return c.json({ error: "version parameter required" }, 400);
+    }
+
+    // TODO: Implement rollback logic.
+    // This would fetch a specific release tag, create a commit, and update state.
+    return c.json({
+      message: `Rollback to ${version} queued`,
+      status: "queued",
+    });
+  } catch (error) {
+    return c.json({ error: error instanceof Error ? error.message : "Rollback failed" }, 500);
+  }
+});
+
+// Cron Trigger Handler
+
+async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+  const startTime = Date.now();
+  // Fetch channel first so it's available in the catch block for error logging
+  const channel = ((await getSetting(env.DB, "update_channel")) || "stable") as UpdateChannel;
+
+  try {
+    console.log("[Cron] Update check starting");
+
+    // 1. Fetch latest release from upstream
+    const release = await fetchLatestRelease(env, channel);
+    if (!release) {
+      console.log(`[Cron] No releases found on ${channel} channel`);
+      await updateCheckStatus(env.DB, channel, {
+        last_check: new Date().toISOString(),
+        last_status: "up_to_date",
+        latest_version: null,
+        last_error: null,
+      });
+      return;
+    }
+
+    // 2. Compare against running version
+    if (APP_VERSION === release.version) {
+      console.log(`[Cron] Up to date: ${APP_VERSION}`);
+      await updateCheckStatus(env.DB, channel, {
+        last_check: new Date().toISOString(),
+        last_status: "up_to_date",
+        latest_version: release.version,
+        last_error: null,
+      });
+      return;
+    }
+
+    console.log(`[Cron] Update available: ${APP_VERSION} → ${release.version}`);
+
+    // 3. Queue the update job
+    await env.UPDATE_QUEUE.send({
+      type: "update",
+      fromVersion: APP_VERSION,
+      toVersion: release.version,
+      channel,
+      triggeredAt: new Date().toISOString(),
+    });
+
+    // 5. Update state to "queued"
+    await updateCheckStatus(env.DB, channel, {
+      last_check: new Date().toISOString(),
+      last_status: "queued",
+      latest_version: release.version,
+      last_error: null,
+    });
+
+    const duration = Date.now() - startTime;
+    console.log(`[Cron] Job queued. Duration: ${duration}ms`);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    console.error("[Cron] Check failed:", errorMessage);
+
+    // Log failure but don't throw - cron should not fail
+    try {
+      await updateCheckStatus(env.DB, channel, {
+        last_check: new Date().toISOString(),
+        last_status: "failed",
+        last_error: errorMessage.substring(0, 500),
+      });
+    } catch (dbError) {
+      console.error("[Cron] Failed to log error to DB:", dbError);
+    }
+  }
+}
+
+// Queue Consumer Handler
+
+async function handleQueue(batch: MessageBatch<UpdateQueueMessage>, env: Env) {
+  for (const message of batch.messages) {
+    if (message.body.type === "update") {
+      try {
+        await performUpdate(env, message.body);
+        message.ack();
+      } catch (error) {
+        // Explicit retry (max 3 times via wrangler.toml max_retries)
+        message.retry();
+        console.error("[Queue] Update failed, will retry:", error);
+      }
+    }
+  }
+}
+
+async function performUpdate(env: Env, job: UpdateQueueMessage) {
+  const startTime = Date.now();
+  const { fromVersion, toVersion, triggeredAt } = job;
+
+  try {
+    console.log(`[Queue] Starting update: ${fromVersion} → ${toVersion}`);
+
+    // Get the diff between current and target version via Compare API
+    const changes = await getChangedFiles(env, fromVersion, toVersion);
+    console.log(`[Queue] Compare API found ${changes.length} changed files`);
+
+    if (changes.length === 0) {
+      console.log("[Queue] No applicable file changes (all excluded). Marking as success.");
+      const duration = Date.now() - startTime;
+      await updateAfterCommit(env.DB, job.channel, {
+        version: toVersion,
+        status: "commit_success",
+        files_updated: 0,
+        duration_ms: duration,
+      });
+      return;
+    }
+
+    // Fetch contents for added/modified files
+    const filesToCommit = await fetchChangedFiles(env, changes);
+    const filesToDelete = changes.filter((c) => c.status === "removed").map((c) => c.path);
+    console.log(
+      `[Queue] Fetched ${filesToCommit.length} files to update, ${filesToDelete.length} to delete`,
+    );
+
+    // Commit all changes to the user's GitHub repo
+    const totalCommitted = await commitChangesToGitHub(
+      env,
+      filesToCommit,
+      filesToDelete,
+      toVersion,
+    );
+    console.log(`[Queue] Committed ${totalCommitted} changes to GitHub`);
+
+    // Update DB with success
+    const duration = Date.now() - startTime;
+    await updateAfterCommit(env.DB, job.channel, {
+      version: toVersion,
+      status: "commit_success",
+      files_updated: totalCommitted,
+      duration_ms: duration,
+    });
+
+    console.log(`[Queue] Update to ${toVersion} complete. Duration: ${duration}ms`);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const duration = Date.now() - startTime;
+
+    console.error(`[Queue] Update failed: ${errorMessage}`);
+
+    // Log failure to DB
+    await logUpdateAttempt(env.DB, {
+      version: toVersion,
+      attempted_at: triggeredAt,
+      status: "commit_failed",
+      error_message: errorMessage.substring(0, 1000),
+      duration_ms: duration,
+    });
+
+    // Update main state to show failure in UI
+    await updateCheckStatus(env.DB, job.channel, {
+      last_check: new Date().toISOString(),
+      last_status: "failed",
+      last_error: errorMessage.substring(0, 500),
+    });
+
+    throw error; // Re-throw to trigger retry
+  }
+}
+
+// Module Worker Export
+// Changed from `export default app` (Hono-only) to the full module worker
+// format so we can handle cron triggers and queue consumers alongside HTTP.
+
+export default {
+  fetch: app.fetch,
+
+  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext) {
+    ctx.waitUntil(handleScheduled(event, env, ctx));
+  },
+
+  async queue(batch: MessageBatch<UpdateQueueMessage>, env: Env, ctx: ExecutionContext) {
+    ctx.waitUntil(handleQueue(batch, env));
+  },
+};

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -481,35 +481,33 @@ app.get("/api/updates/status", async (c) => {
  * Returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal.
  */
 function compareVersions(v1: string, v2: string): number {
-  const parse = (v: string) =>
-    v
-      .replace(/^v/, "")
-      .split(/[.-]/)
-      .map((s) => (isNaN(Number(s)) ? s : Number(s)));
-  const p1 = parse(v1);
-  const p2 = parse(v2);
-  const len = Math.max(p1.length, p2.length);
+  // Separate base version from pre-release tag
+  const [base1, pre1] = v1.replace(/^v/, "").split("-");
+  const [base2, pre2] = v2.replace(/^v/, "").split("-");
 
-  for (let i = 0; i < len; i++) {
-    const s1 = p1[i];
-    const s2 = p2[i];
+  // Compare base versions (x.y.z)
+  const b1 = base1.split(".").map((s) => Number(s) || 0);
+  const b2 = base2.split(".").map((s) => Number(s) || 0);
+  const maxLen = Math.max(b1.length, b2.length);
 
-    if (s1 === s2) continue;
-
-    // Pre-release precedence: 1.0.0 > 1.0.0-alpha
-    if (s1 === undefined) return typeof s2 === "string" ? 1 : -1;
-    if (s2 === undefined) return typeof s1 === "string" ? -1 : 1;
-
-    if (typeof s1 === "number" && typeof s2 === "number") {
-      if (s1 > s2) return 1;
-      if (s1 < s2) return -1;
-    } else {
-      const str1 = String(s1);
-      const str2 = String(s2);
-      if (str1 > str2) return 1;
-      if (str1 < str2) return -1;
-    }
+  for (let i = 0; i < maxLen; i++) {
+    const s1 = b1[i] ?? 0;
+    const s2 = b2[i] ?? 0;
+    if (s1 > s2) return 1;
+    if (s1 < s2) return -1;
   }
+
+  // Compare pre-releases if base versions are identical
+  // SemVer rule: a normal version has higher precedence than a pre-release
+  if (!pre1 && pre2) return 1; // v1 is stable, v2 is pre-release (v1 > v2)
+  if (pre1 && !pre2) return -1; // v1 is pre-release, v2 is stable (v1 < v2)
+
+  // Both have pre-releases, compare them as strings
+  if (pre1 && pre2) {
+    if (pre1 > pre2) return 1;
+    if (pre1 < pre2) return -1;
+  }
+
   return 0;
 }
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -586,10 +586,13 @@ app.post("/api/updates/rollback", async (c) => {
 
     // TODO: Implement rollback logic.
     // This would fetch a specific release tag, create a commit, and update state.
-    return c.json({
-      message: `Rollback to ${version} queued`,
-      status: "queued",
-    });
+    return c.json(
+      {
+        message: "Rollback is not yet implemented",
+        error: "Feature coming soon",
+      },
+      501,
+    );
   } catch (error) {
     return c.json({ error: error instanceof Error ? error.message : "Rollback failed" }, 500);
   }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -749,11 +749,11 @@ async function performUpdate(env: Env, job: UpdateQueueMessage) {
       duration_ms: duration,
     });
 
-    // Update main state to show failure in UI
+    // Update main state to show failure (with retry info) in UI
     await updateCheckStatus(env.DB, job.channel, {
       last_check: new Date().toISOString(),
-      last_status: "failed",
-      last_error: errorMessage.substring(0, 500),
+      last_status: "failed", // We keep "failed" but the error message will explain the retry
+      last_error: `${errorMessage.substring(0, 400)} (Retrying...)`,
     });
 
     throw error; // Re-throw to trigger retry

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -476,10 +476,41 @@ app.get("/api/updates/status", async (c) => {
   }
 });
 
+/**
+ * Compares two SemVer strings.
+ * Returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal.
+ */
+function compareVersions(v1: string, v2: string): number {
+  const parse = (v: string) =>
+    v
+      .replace(/^v/, "")
+      .split(/[.-]/)
+      .map((s) => (isNaN(Number(s)) ? s : Number(s)));
+  const p1 = parse(v1);
+  const p2 = parse(v2);
+  const len = Math.max(p1.length, p2.length);
+
+  for (let i = 0; i < len; i++) {
+    const s1 = p1[i] ?? 0;
+    const s2 = p2[i] ?? 0;
+    if (typeof s1 === "number" && typeof s2 === "number") {
+      if (s1 > s2) return 1;
+      if (s1 < s2) return -1;
+    } else {
+      // String comparison for pre-release tags like 'alpha', 'beta'
+      const str1 = String(s1);
+      const str2 = String(s2);
+      if (str1 > str2) return 1;
+      if (str1 < str2) return -1;
+    }
+  }
+  return 0;
+}
+
 /** POST /api/updates/check - Manually check for updates (does NOT queue work). */
 app.post("/api/updates/check", async (c) => {
   try {
-    // 1. Read channel preference, fetch latest release from upstream
+    // Read channel preference, fetch latest release from upstream
     const channel = ((await getSetting(c.env.DB, "update_channel")) || "stable") as UpdateChannel;
     const release = await fetchLatestRelease(c.env, channel);
     if (!release) {
@@ -498,8 +529,9 @@ app.post("/api/updates/check", async (c) => {
       });
     }
 
-    // 2. Compare against running version
-    if (APP_VERSION === release.version) {
+    // Compare against running version: only available if upstream is strictly newer
+    const isAvailable = compareVersions(release.version, APP_VERSION) > 0;
+    if (!isAvailable) {
       await updateCheckStatus(c.env.DB, channel, {
         last_check: new Date().toISOString(),
         last_status: "up_to_date",
@@ -507,14 +539,17 @@ app.post("/api/updates/check", async (c) => {
         last_error: null,
       });
       return c.json({
-        message: "Already up to date",
+        message:
+          release.version === APP_VERSION
+            ? "Already up to date"
+            : `Local version (${APP_VERSION}) is newer than upstream (${release.version})`,
         status: "up_to_date",
         current_version: APP_VERSION,
         latest_version: release.version,
       });
     }
 
-    // 3. Mark as update available
+    // Mark as update available
     await updateCheckStatus(c.env.DB, channel, {
       last_check: new Date().toISOString(),
       last_status: "available",
@@ -608,7 +643,7 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
   try {
     console.log("[Cron] Update check starting");
 
-    // 1. Fetch latest release from upstream
+    // Fetch latest release from upstream
     const release = await fetchLatestRelease(env, channel);
     if (!release) {
       console.log(`[Cron] No releases found on ${channel} channel`);
@@ -621,9 +656,10 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
       return;
     }
 
-    // 2. Compare against running version
-    if (APP_VERSION === release.version) {
-      console.log(`[Cron] Up to date: ${APP_VERSION}`);
+    // Compare against running version: only available if upstream is strictly newer
+    const isAvailable = compareVersions(release.version, APP_VERSION) > 0;
+    if (!isAvailable) {
+      console.log(`[Cron] Up to date (Local: ${APP_VERSION}, Upstream: ${release.version})`);
       await updateCheckStatus(env.DB, channel, {
         last_check: new Date().toISOString(),
         last_status: "up_to_date",
@@ -635,7 +671,7 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
 
     console.log(`[Cron] Update available: ${APP_VERSION} → ${release.version}`);
 
-    // 3. Queue the update job
+    // Queue the update job
     await env.UPDATE_QUEUE.send({
       type: "update",
       fromVersion: APP_VERSION,
@@ -644,7 +680,7 @@ async function handleScheduled(event: ScheduledEvent, env: Env, ctx: ExecutionCo
       triggeredAt: new Date().toISOString(),
     });
 
-    // 5. Update state to "queued"
+    // Update state to "queued"
     await updateCheckStatus(env.DB, channel, {
       last_check: new Date().toISOString(),
       last_status: "queued",

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -491,13 +491,19 @@ function compareVersions(v1: string, v2: string): number {
   const len = Math.max(p1.length, p2.length);
 
   for (let i = 0; i < len; i++) {
-    const s1 = p1[i] ?? 0;
-    const s2 = p2[i] ?? 0;
+    const s1 = p1[i];
+    const s2 = p2[i];
+
+    if (s1 === s2) continue;
+
+    // Pre-release precedence: 1.0.0 > 1.0.0-alpha
+    if (s1 === undefined) return typeof s2 === "string" ? 1 : -1;
+    if (s2 === undefined) return typeof s1 === "string" ? -1 : 1;
+
     if (typeof s1 === "number" && typeof s2 === "number") {
       if (s1 > s2) return 1;
       if (s1 < s2) return -1;
     } else {
-      // String comparison for pre-release tags like 'alpha', 'beta'
       const str1 = String(s1);
       const str2 = String(s2);
       if (str1 > str2) return 1;
@@ -749,7 +755,14 @@ async function performUpdate(env: Env, job: UpdateQueueMessage) {
 
     // Fetch contents for added/modified files
     const filesToCommit = await fetchChangedFiles(env, changes);
-    const filesToDelete = changes.filter((c) => c.status === "removed").map((c) => c.path);
+    // Identify exactly what needs to be deleted (removed or renamed files)
+    const filesToDelete = changes.flatMap((c) =>
+      c.status === "removed"
+        ? [c.path]
+        : c.status === "renamed" && c.previousPath
+          ? [c.previousPath]
+          : [],
+    );
     console.log(
       `[Queue] Fetched ${filesToCommit.length} files to update, ${filesToDelete.length} to delete`,
     );

--- a/src/worker/manifest.ts
+++ b/src/worker/manifest.ts
@@ -1,0 +1,113 @@
+/**
+ * Version discovery via GitHub Releases API.
+ *
+ * Supports two update channels:
+ *   - "stable"     → GET /releases/latest (skips drafts and pre-releases)
+ *   - "pre-release" → GET /releases (includes alpha, beta, rc tags)
+ *
+ * Release workflow is just: create a GitHub Release (mark as pre-release or not).
+ * No manifest file, no generation script needed.
+ */
+
+import type { Env } from "./types";
+
+const UPSTREAM_OWNER = "ranajahanzaib";
+const UPSTREAM_REPO = "waichat";
+
+export type UpdateChannel = "stable" | "pre-release";
+
+export interface LatestRelease {
+  version: string;
+  tag: string;
+  releaseNotes: string;
+  publishedAt: string;
+  prerelease: boolean;
+}
+
+/**
+ * Fetch the latest release from the upstream repo for the given channel.
+ *
+ * - "stable": Uses /releases/latest (only non-draft, non-prerelease)
+ * - "pre-release": Uses /releases and picks the first entry (most recent,
+ *   including pre-releases, but excluding drafts)
+ */
+export async function fetchLatestRelease(
+  env: Env,
+  channel: UpdateChannel = "stable",
+): Promise<LatestRelease | null> {
+  try {
+    const headers = {
+      "User-Agent": "waichat-updater/1.0",
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    };
+
+    if (channel === "stable") {
+      // /releases/latest returns only the most recent non-draft, non-prerelease
+      const response = await fetch(
+        `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases/latest`,
+        { headers },
+      );
+
+      if (response.status === 404) {
+        console.log("[Manifest] No stable releases found");
+        return null;
+      }
+
+      if (!response.ok) {
+        throw new Error(`GitHub Releases API failed: HTTP ${response.status}`);
+      }
+
+      const release = (await response.json()) as {
+        tag_name: string;
+        body: string;
+        published_at: string;
+        prerelease: boolean;
+      };
+
+      return {
+        version: release.tag_name,
+        tag: release.tag_name,
+        releaseNotes: release.body || "",
+        publishedAt: release.published_at || "",
+        prerelease: release.prerelease,
+      };
+    }
+
+    // "pre-release" channel: list all releases, pick the most recent (first)
+    const response = await fetch(
+      `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases?per_page=5`,
+      { headers },
+    );
+
+    if (!response.ok) {
+      throw new Error(`GitHub Releases API failed: HTTP ${response.status}`);
+    }
+
+    const releases = (await response.json()) as {
+      tag_name: string;
+      body: string;
+      published_at: string;
+      prerelease: boolean;
+      draft: boolean;
+    }[];
+
+    // Filter out drafts, take the first (most recent)
+    const latest = releases.find((r) => !r.draft);
+    if (!latest) {
+      console.log("[Manifest] No releases found (all drafts or empty)");
+      return null;
+    }
+
+    return {
+      version: latest.tag_name,
+      tag: latest.tag_name,
+      releaseNotes: latest.body || "",
+      publishedAt: latest.published_at || "",
+      prerelease: latest.prerelease,
+    };
+  } catch (error) {
+    console.error("[Manifest] Failed to fetch latest release:", error);
+    return null;
+  }
+}

--- a/src/worker/manifest.ts
+++ b/src/worker/manifest.ts
@@ -40,6 +40,7 @@ export async function fetchLatestRelease(
       "User-Agent": "waichat-updater/1.0",
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
+      Authorization: `Bearer ${env.GITHUB_TOKEN}`,
     };
 
     if (channel === "stable") {

--- a/src/worker/manifest.ts
+++ b/src/worker/manifest.ts
@@ -76,7 +76,7 @@ export async function fetchLatestRelease(
 
     // "pre-release" channel: list all releases, pick the most recent (first)
     const response = await fetch(
-      `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases?per_page=5`,
+      `https://api.github.com/repos/${UPSTREAM_OWNER}/${UPSTREAM_REPO}/releases?per_page=30`,
       { headers },
     );
 

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -1,8 +1,16 @@
+import type { UpdateChannel } from "./manifest";
+// Core Chat Types
+
 export interface Env {
   AI: Ai;
   DB: D1Database;
   CLOUDFLARE_ACCOUNT_ID?: string;
   CLOUDFLARE_API_TOKEN?: string;
+
+  // Auto-update bindings
+  UPDATE_QUEUE: Queue<UpdateQueueMessage>;
+  GITHUB_TOKEN: string;
+  GITHUB_REPO: string; // "owner/repo"
 }
 
 export interface Conversation {
@@ -33,4 +41,14 @@ export interface ChatRequest {
   parent_id?: string;
   user_message_id?: string;
   assistant_message_id?: string;
+}
+
+// Auto-Update Types
+
+export interface UpdateQueueMessage {
+  type: "update";
+  fromVersion: string;
+  toVersion: string;
+  channel: UpdateChannel;
+  triggeredAt: string;
 }

--- a/src/worker/update-db.ts
+++ b/src/worker/update-db.ts
@@ -1,0 +1,140 @@
+/**
+ * Database helpers for the auto-update system.
+ * Operates on the `update_state` and `update_log` tables.
+ */
+import type { UpdateChannel } from "./manifest";
+
+export interface UpdateState {
+  channel: UpdateChannel;
+  current_version: string;
+  latest_version: string | null;
+  last_check: string;
+  last_attempt: string | null;
+  last_status: "up_to_date" | "available" | "queued" | "success" | "failed";
+  last_error: string | null;
+}
+
+export interface UpdateLogEntry {
+  id: number;
+  version: string | null;
+  attempted_at: string;
+  status: string;
+  error_message: string | null;
+  files_updated: number | null;
+  duration_ms: number | null;
+}
+
+/** Read the update state for a specific channel. */
+export async function getUpdateState(
+  db: D1Database,
+  channel: UpdateChannel,
+): Promise<UpdateState | null> {
+  const result = await db
+    .prepare("SELECT * FROM update_state WHERE channel = ?")
+    .bind(channel)
+    .first<UpdateState>();
+  return result || null;
+}
+
+/** Update state after a version check (cron or manual). */
+export async function updateCheckStatus(
+  db: D1Database,
+  channel: UpdateChannel,
+  update: {
+    last_check: string;
+    last_status: string;
+    latest_version?: string | null;
+    last_error?: string | null;
+  },
+) {
+  await db
+    .prepare(
+      `UPDATE update_state
+       SET last_check = ?, last_status = ?, latest_version = ?, last_error = ?
+       WHERE channel = ?`,
+    )
+    .bind(
+      update.last_check,
+      update.last_status,
+      update.latest_version ?? null,
+      update.last_error ?? null,
+      channel,
+    )
+    .run();
+}
+
+/** Update state + log after a successful commit. */
+export async function updateAfterCommit(
+  db: D1Database,
+  channel: UpdateChannel,
+  log: {
+    version: string;
+    status: string;
+    files_updated: number;
+    duration_ms: number;
+  },
+) {
+  const now = new Date().toISOString();
+
+  // Update main state
+  await db
+    .prepare(
+      `UPDATE update_state
+       SET current_version = ?, latest_version = ?, last_status = 'success', last_error = NULL, last_attempt = ?
+       WHERE channel = ?`,
+    )
+    .bind(log.version, log.version, now, channel)
+    .run();
+
+  // Log the event
+  await logUpdateAttempt(db, {
+    version: log.version,
+    attempted_at: now,
+    status: "commit_success",
+    files_updated: log.files_updated,
+    duration_ms: log.duration_ms,
+  });
+}
+
+/** Insert a row into the update_log audit table. */
+export async function logUpdateAttempt(
+  db: D1Database,
+  log: {
+    version: string;
+    attempted_at: string;
+    status: string;
+    error_message?: string | null;
+    files_updated?: number | null;
+    duration_ms?: number | null;
+  },
+) {
+  await db
+    .prepare(
+      `INSERT INTO update_log
+       (version, attempted_at, status, error_message, files_updated, duration_ms)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      log.version,
+      log.attempted_at,
+      log.status,
+      log.error_message ?? null,
+      log.files_updated ?? null,
+      log.duration_ms ?? null,
+    )
+    .run();
+}
+
+/** Fetch recent update log entries for UI display. */
+export async function getUpdateLog(db: D1Database, limit = 10): Promise<UpdateLogEntry[]> {
+  const results = await db
+    .prepare(
+      `SELECT id, version, attempted_at, status, error_message, files_updated, duration_ms
+       FROM update_log
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .bind(limit)
+    .all<UpdateLogEntry>();
+  return results.results || [];
+}

--- a/src/worker/version.ts
+++ b/src/worker/version.ts
@@ -1,0 +1,15 @@
+/**
+ * Single source of truth for the running application version.
+ *
+ * This is imported from package.json at build time (both esbuild for the worker
+ * and Vite for the client resolve JSON imports). The auto-update system uses this
+ * to compare against the latest upstream release.
+ *
+ * The DB `update_state.current_version` is NOT the source of truth for the running
+ * version - it tracks what the updater last committed to GitHub, which may differ
+ * from the code actually running (e.g., after a manual deploy or local edit).
+ */
+
+import pkg from "../../package.json";
+
+export const APP_VERSION: string = pkg.version;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -36,3 +36,28 @@ binding = "DB"
 database_name = "waichat-db"
 database_id = ""
 migrations_dir = "migrations"
+
+# Auto-Update System
+# Requires Cloudflare Workers Paid plan ($5/month) for Queue support.
+# Set GITHUB_TOKEN secret via: wrangler secret put GITHUB_TOKEN
+# Set GITHUB_REPO to "owner/repo" format for the user's deployed repo.
+
+[vars]
+GITHUB_REPO = ""
+
+# Queue producer: sends update jobs from cron/manual check
+[[queues.producers]]
+queue = "waichat-update-queue"
+binding = "UPDATE_QUEUE"
+
+# Queue consumer: processes update jobs (fetch files, verify, commit)
+[[queues.consumers]]
+queue = "waichat-update-queue"
+max_batch_size = 1
+max_batch_timeout = 30
+max_retries = 3
+dead_letter_queue = "waichat-update-dlq"
+
+# Cron trigger: daily update check at 2:00 AM UTC
+[triggers]
+crons = ["0 2 * * *"]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,7 +38,6 @@ database_id = ""
 migrations_dir = "migrations"
 
 # Auto-Update System
-# Requires Cloudflare Workers Paid plan ($5/month) for Queue support.
 # Set GITHUB_TOKEN secret via: wrangler secret put GITHUB_TOKEN
 # Set GITHUB_REPO to "owner/repo" format for the user's deployed repo.
 


### PR DESCRIPTION
## Description

Implement 2-step auto-update system with per-channel tracking and add queue-based deployment and GitHub Compare API integration.

- Added support for 'stable' and 'pre-release' update channels
- Implemented per-channel status persistence in D1 database
- Added a two-step manual update flow (Check -> Apply)
- Integrated Cloudflare Queues for reliable background file commits
- Added security exclusion lists to protect critical user configs
- Improved UI with dashboard-centric configuration guidance

**Fixes #72**

## Requirements & Setup

The following configuration is required in the Cloudflare Dashboard:

1. **`GITHUB_TOKEN` (Secret)**: 
   - A Personal Access Token (PAT) with `contents: write` permissions.
   - Set this in **Worker → Settings → Variables → Secrets**.
2. **`GITHUB_REPO` (Variable)**:
   - Your repository path, e.g., `"your-username/WaiChat"`.
   - Set this in **Worker → Settings → Variables → Environment Variables**.
3. **Queue Binding**:
   - Ensure you have a queue named `UPDATE_QUEUE` bound to your worker.


## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---


## How to Test This PR


Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/72-implement-new-update-system)
