### PR TITLE
feat: enable moving conversations between Local and Cloud (#22)

### DIFF
--- a/migrations/0006_add_import_complete.sql
+++ b/migrations/0006_add_import_complete.sql
@@ -1,0 +1,1 @@
+ALTER TABLE conversations ADD COLUMN import_complete INTEGER;

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useRef } from "react";
 import { useChat } from "./hooks/useChat";
 import { useModels, DEFAULT_MODEL_ID } from "./hooks/useModels";
+import { useTransfer } from "./hooks/useTransfer";
 import type { StorageMode } from "./storage";
 import Sidebar from "./components/Sidebar";
 import MessageList from "./components/MessageList";
@@ -78,6 +79,8 @@ export default function App() {
     return savedStorageMode;
   });
 
+  const pendingSelectionRef = useRef<string | null>(null);
+
   const {
     conversations,
     activeConversation,
@@ -95,7 +98,15 @@ export default function App() {
     retryMessage,
     setActiveVersion,
     deleteMessage,
-  } = useChat(storageMode);
+  } = useChat(storageMode, pendingSelectionRef);
+
+  const {
+    transferState,
+    initiateMove,
+    executeMove,
+    cancelMove,
+    retryPendingCloudDeletes,
+  } = useTransfer();
 
   const { models } = useModels();
   const [model, setModel] = useState(
@@ -119,7 +130,8 @@ export default function App() {
 
   useEffect(() => {
     loadConversations();
-  }, [loadConversations]);
+    retryPendingCloudDeletes();
+  }, [loadConversations, retryPendingCloudDeletes]);
 
   // Sync System Prompt from Cloud if enabled
   useEffect(() => {
@@ -312,6 +324,32 @@ export default function App() {
     await loadConversations();
   };
 
+  const handleMoveConversation = async (conversationId: string) => {
+    const targetMode: StorageMode = storageMode === "cloud" ? "local" : "cloud";
+
+    try {
+      // Prefetch the source data
+      await initiateMove(conversationId, storageMode);
+
+      // Execute the move
+      const movedId = await executeMove(storageMode, targetMode);
+
+      // If the moved conversation was the active one, clear it
+      if (activeConversation?.id === conversationId) {
+        clearConversation();
+      }
+
+      // Set pending selection so useChat auto-selects after mode switch
+      pendingSelectionRef.current = movedId;
+
+      // Switch to target mode
+      handleStorageToggle(targetMode);
+    } catch (e) {
+      console.error("[handleMoveConversation] error:", e);
+      cancelMove();
+    }
+  };
+
   return (
     <div className="relative flex h-screen w-full overflow-hidden font-sans text-gray-900 dark:text-white/95">
       {/* Full-screen base layers */}
@@ -346,9 +384,12 @@ export default function App() {
           onSelect={handleSelectConversation}
           onNew={handleNew}
           onDelete={deleteConversation}
+          onMove={handleMoveConversation}
           onSettingsOpen={() => setSettingsOpen(true)}
           currentMode={storageMode}
           savedMode={savedStorageMode}
+          isStreaming={isStreaming}
+          movingConversationId={transferState.conversationId}
         />
 
         <main className="flex flex-col flex-1 min-w-0 h-full">

--- a/src/client/components/ConfirmModal.tsx
+++ b/src/client/components/ConfirmModal.tsx
@@ -5,6 +5,7 @@ interface ConfirmModalProps {
   title: string;
   description: string;
   confirmLabel?: string;
+  variant?: "destructive" | "neutral";
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -13,7 +14,8 @@ export default function ConfirmModal({
   open,
   title,
   description,
-  confirmLabel = "Delete",
+  confirmLabel = "Confirm",
+  variant = "destructive",
   onConfirm,
   onCancel,
 }: ConfirmModalProps) {
@@ -64,7 +66,11 @@ export default function ConfirmModal({
           </button>
           <button
             onClick={onConfirm}
-            className="flex-1 py-2 text-sm font-medium text-white bg-red-500 hover:bg-red-600 rounded-lg transition-colors"
+            className={`flex-1 py-2 text-sm font-medium text-white rounded-lg transition-colors ${
+              variant === "destructive"
+                ? "bg-red-500 hover:bg-red-600"
+                : "bg-[#0A84FF] hover:bg-[#0070E0]"
+            }`}
           >
             {confirmLabel}
           </button>

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -10,9 +10,12 @@ interface SidebarProps {
   onSelect: (id: string) => void;
   onNew: (mode?: StorageMode) => void;
   onDelete: (id: string) => void;
+  onMove: (id: string) => void;
   onSettingsOpen: () => void;
   currentMode: StorageMode;
   savedMode: StorageMode;
+  isStreaming: boolean;
+  movingConversationId: string | null;
 }
 
 export default function Sidebar({
@@ -23,11 +26,16 @@ export default function Sidebar({
   onSelect,
   onNew,
   onDelete,
+  onMove,
   onSettingsOpen,
   currentMode,
   savedMode, // Kept in props to satisfy the interface and App.tsx
+  isStreaming,
+  movingConversationId,
 }: SidebarProps) {
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
+  const [pendingMove, setPendingMove] = useState<Conversation | null>(null);
+  const targetMode: StorageMode = currentMode === "cloud" ? "local" : "cloud";
 
   return (
     <>
@@ -96,7 +104,11 @@ export default function Sidebar({
               No conversations yet
             </p>
           )}
-          {conversations.map((c) => (
+          {conversations.map((c) => {
+            const isMoving = movingConversationId === c.id;
+            const isMoveDisabled = isMoving || (activeId === c.id && isStreaming);
+
+            return (
             <div
               key={c.id}
               className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-[13px] md:text-sm transition-all duration-150 ${
@@ -109,31 +121,65 @@ export default function Sidebar({
               onClick={() => onSelect(c.id)}
             >
               <span className="truncate">{c.title}</span>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setPendingDelete(c);
-                }}
-                className={`p-1.5 rounded-md focus:outline-none transition-all ml-2 shrink-0 ${
-                  activeId === c.id
-                    ? currentMode === "cloud"
-                      ? "text-white/70 hover:text-white opacity-100"
-                      : "text-gray-900/60 hover:text-gray-900 opacity-100"
-                    : "text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 opacity-0 group-hover:opacity-100"
-                }`}
-                aria-label="Delete conversation"
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-4 h-4">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  ></path>
-                </svg>
-              </button>
+              <div className="flex items-center gap-0.5 shrink-0 ml-2">
+                {/* Move button */}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (!isMoveDisabled) setPendingMove(c);
+                  }}
+                  disabled={isMoveDisabled}
+                  className={`p-1.5 rounded-md focus:outline-none transition-all ${
+                    isMoveDisabled
+                      ? "opacity-30 cursor-not-allowed"
+                      : activeId === c.id
+                        ? currentMode === "cloud"
+                          ? "text-white/70 hover:text-white opacity-100"
+                          : "text-gray-900/60 hover:text-gray-900 opacity-100"
+                        : "text-gray-400 hover:text-brand-cloud dark:text-white/40 dark:hover:text-brand-cloud opacity-0 group-hover:opacity-100"
+                  }`}
+                  aria-label={`Move to ${targetMode}`}
+                  title={isMoveDisabled && isStreaming ? "Stop generation before moving" : `Move to ${targetMode}`}
+                >
+                  {isMoving ? (
+                    <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+                      <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" opacity="0.25" />
+                      <path d="M4 12a8 8 0 018-8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+                    </svg>
+                  ) : (
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-4 h-4">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M7 17L17 7M17 7H8M17 7v9" />
+                    </svg>
+                  )}
+                </button>
+                {/* Delete button */}
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setPendingDelete(c);
+                  }}
+                  className={`p-1.5 rounded-md focus:outline-none transition-all ${
+                    activeId === c.id
+                      ? currentMode === "cloud"
+                        ? "text-white/70 hover:text-white opacity-100"
+                        : "text-gray-900/60 hover:text-gray-900 opacity-100"
+                      : "text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 opacity-0 group-hover:opacity-100"
+                  }`}
+                  aria-label="Delete conversation"
+                >
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-4 h-4">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth="2"
+                      d="M6 18L18 6M6 6l12 12"
+                    ></path>
+                  </svg>
+                </button>
+              </div>
             </div>
-          ))}
+            );
+          })}
         </nav>
 
         <div className="p-4 border-t-[0.5px] border-black/10 dark:border-white/10 flex items-center gap-3">
@@ -171,11 +217,29 @@ export default function Sidebar({
         title="Delete conversation?"
         description={pendingDelete ? `"${pendingDelete.title}" will be permanently deleted.` : ""}
         confirmLabel="Delete"
+        variant="destructive"
         onConfirm={() => {
           if (pendingDelete) onDelete(pendingDelete.id);
           setPendingDelete(null);
         }}
         onCancel={() => setPendingDelete(null)}
+      />
+
+      <ConfirmModal
+        open={pendingMove !== null}
+        title={`Move to ${targetMode === "cloud" ? "Cloud" : "Local"}?`}
+        description={
+          pendingMove
+            ? `"${pendingMove.title}" will be moved to ${targetMode === "cloud" ? "Cloud (D1)" : "Local (Browser)"} storage and removed from ${currentMode === "cloud" ? "Cloud" : "Local"}.`
+            : ""
+        }
+        confirmLabel="Move"
+        variant="neutral"
+        onConfirm={() => {
+          if (pendingMove) onMove(pendingMove.id);
+          setPendingMove(null);
+        }}
+        onCancel={() => setPendingMove(null)}
       />
     </>
   );

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -78,7 +78,7 @@ export function useChat(
         });
       });
     }
-  });
+  }, [storage, storageMode, pendingSelectionRef]);
 
   const loadConversations = useCallback(async () => {
     try {

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -67,15 +67,12 @@ export function useChat(
       const id = pendingSelectionRef.current;
       pendingSelectionRef.current = null;
       selectAfterModeChangeRef.current = false;
-      // Load conversations first, then select
-      storage.getConversations().then((data) => {
-        setConversations(data);
-        storage.getConversation(id).then((result) => {
-          if (result) {
-            setActiveConversation(result.conversation);
-            setMessages(result.messages);
-          }
-        });
+      // Select the specific conversation (conversation list is loaded by App.tsx)
+      storage.getConversation(id).then((result) => {
+        if (result) {
+          setActiveConversation(result.conversation);
+          setMessages(result.messages);
+        }
       });
     }
   }, [storage, storageMode, pendingSelectionRef]);

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -32,7 +32,10 @@ interface UseChatReturn {
   deleteMessage: (messageId: string) => Promise<void>;
 }
 
-export function useChat(storageMode: StorageMode): UseChatReturn {
+export function useChat(
+  storageMode: StorageMode,
+  pendingSelectionRef?: React.RefObject<string | null>,
+): UseChatReturn {
   const storage = useMemo(() => createStorage(storageMode), [storageMode]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeConversation, setActiveConversation] = useState<Conversation | null>(null);
@@ -49,6 +52,33 @@ export function useChat(storageMode: StorageMode): UseChatReturn {
     setIsStreaming(false);
     setActiveVersions({});
   }, [storageMode]);
+
+  // After mode change: auto-select a conversation if pendingSelectionRef is set
+  const selectAfterModeChangeRef = useRef(false);
+  useEffect(() => {
+    selectAfterModeChangeRef.current = true;
+  }, [storageMode]);
+
+  useEffect(() => {
+    if (
+      selectAfterModeChangeRef.current &&
+      pendingSelectionRef?.current
+    ) {
+      const id = pendingSelectionRef.current;
+      pendingSelectionRef.current = null;
+      selectAfterModeChangeRef.current = false;
+      // Load conversations first, then select
+      storage.getConversations().then((data) => {
+        setConversations(data);
+        storage.getConversation(id).then((result) => {
+          if (result) {
+            setActiveConversation(result.conversation);
+            setMessages(result.messages);
+          }
+        });
+      });
+    }
+  });
 
   const loadConversations = useCallback(async () => {
     try {

--- a/src/client/hooks/useTransfer.ts
+++ b/src/client/hooks/useTransfer.ts
@@ -121,28 +121,27 @@ export function useTransfer(): UseTransferReturn {
           // Cloud → Local: write to localStorage, then delete from cloud
           const targetStorage = createStorage("local");
 
-          // Write conversation
+          // Write conversation (filter first to prevent duplicates on retry)
           const localConversations = JSON.parse(
             localStorage.getItem("waichat:conversations") ?? "[]",
           ) as Conversation[];
-          localConversations.push({
+          const filtered = localConversations.filter((c) => c.id !== conversation.id);
+          filtered.push({
             id: conversation.id,
             title: conversation.title,
             model: conversation.model,
             created_at: conversation.created_at,
             updated_at: conversation.updated_at,
           });
-          localStorage.setItem("waichat:conversations", JSON.stringify(localConversations));
+          localStorage.setItem("waichat:conversations", JSON.stringify(filtered));
 
           // Write messages
           localStorage.setItem(`waichat:messages:${conversation.id}`, JSON.stringify(messages));
 
           // Delete from cloud
           try {
-            const res = await fetch(`/api/conversations/${conversation.id}`, {
-              method: "DELETE",
-            });
-            if (!res.ok) throw new Error("DELETE failed");
+            const cloudStorage = createStorage("cloud");
+            await cloudStorage.deleteConversation(conversation.id);
           } catch {
             // Cloud delete failed - mark for retry on next app load
             const pending = JSON.parse(

--- a/src/client/hooks/useTransfer.ts
+++ b/src/client/hooks/useTransfer.ts
@@ -1,0 +1,231 @@
+import { useCallback, useRef, useState } from "react";
+import type { Conversation, Message, StorageMode } from "../storage";
+import { createStorage } from "../storage";
+
+const PENDING_CLOUD_DELETE_KEY = "waichat:pending-cloud-delete";
+
+interface TransferState {
+  /** The conversation being transferred (null = idle) */
+  conversationId: string | null;
+  /** Loading phase: 'prefetch' (reading source) or 'transfer' (writing target) */
+  phase: "idle" | "prefetch" | "transfer";
+  /** Pre-confirm data (used for size warning) */
+  prefetchedData: { conversation: Conversation; messages: Message[] } | null;
+  /** Estimated bytes for cloud→local size warning */
+  estimatedBytes: number;
+  /** Error message if transfer failed */
+  error: string | null;
+}
+
+interface UseTransferReturn {
+  /** Current transfer state */
+  transferState: TransferState;
+  /** Initiate a move - prefetches data, then caller should show confirm modal */
+  initiateMove: (conversationId: string, fromMode: StorageMode) => Promise<void>;
+  /** Execute the confirmed move */
+  executeMove: (fromMode: StorageMode, toMode: StorageMode) => Promise<string>;
+  /** Cancel / reset transfer state */
+  cancelMove: () => void;
+  /** Retry any pending cloud deletes from previous failed transfers */
+  retryPendingCloudDeletes: () => Promise<void>;
+}
+
+export function useTransfer(): UseTransferReturn {
+  const [transferState, setTransferState] = useState<TransferState>({
+    conversationId: null,
+    phase: "idle",
+    prefetchedData: null,
+    estimatedBytes: 0,
+    error: null,
+  });
+
+  // Keep prefetched data in a ref so async executeMove can access it
+  // without depending on stale state
+  const prefetchedRef = useRef<{ conversation: Conversation; messages: Message[] } | null>(null);
+
+  const initiateMove = useCallback(async (conversationId: string, fromMode: StorageMode) => {
+    setTransferState({
+      conversationId,
+      phase: "prefetch",
+      prefetchedData: null,
+      estimatedBytes: 0,
+      error: null,
+    });
+
+    try {
+      const sourceStorage = createStorage(fromMode);
+      const data = await sourceStorage.exportConversation(conversationId);
+
+      if (!data) {
+        setTransferState((prev) => ({
+          ...prev,
+          phase: "idle",
+          error: "Conversation not found",
+        }));
+        return;
+      }
+
+      const estimatedBytes = JSON.stringify(data).length;
+      prefetchedRef.current = data;
+
+      setTransferState({
+        conversationId,
+        phase: "idle", // Prefetch done, waiting for confirm
+        prefetchedData: data,
+        estimatedBytes,
+        error: null,
+      });
+    } catch (e) {
+      console.error("[useTransfer] prefetch error:", e);
+      setTransferState({
+        conversationId: null,
+        phase: "idle",
+        prefetchedData: null,
+        estimatedBytes: 0,
+        error: "Failed to read conversation",
+      });
+    }
+  }, []);
+
+  const executeMove = useCallback(
+    async (fromMode: StorageMode, toMode: StorageMode): Promise<string> => {
+      const data = prefetchedRef.current;
+      if (!data) throw new Error("No prefetched data");
+
+      const { conversation, messages } = data;
+
+      setTransferState((prev) => ({
+        ...prev,
+        phase: "transfer",
+        error: null,
+      }));
+
+      try {
+        if (toMode === "cloud") {
+          // Local → Cloud: POST to import endpoint
+          const res = await fetch("/api/conversations/import", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ conversation, messages }),
+          });
+
+          if (!res.ok) {
+            const errorData = (await res.json().catch(() => ({}))) as { error?: string };
+            throw new Error(errorData.error || "Import failed");
+          }
+
+          // Success - delete from localStorage
+          const sourceStorage = createStorage("local");
+          await sourceStorage.deleteConversation(conversation.id);
+        } else {
+          // Cloud → Local: write to localStorage, then delete from cloud
+          const targetStorage = createStorage("local");
+
+          // Write conversation
+          const localConversations = JSON.parse(
+            localStorage.getItem("waichat:conversations") ?? "[]",
+          ) as Conversation[];
+          localConversations.push({
+            id: conversation.id,
+            title: conversation.title,
+            model: conversation.model,
+            created_at: conversation.created_at,
+            updated_at: conversation.updated_at,
+          });
+          localStorage.setItem("waichat:conversations", JSON.stringify(localConversations));
+
+          // Write messages
+          localStorage.setItem(`waichat:messages:${conversation.id}`, JSON.stringify(messages));
+
+          // Delete from cloud
+          try {
+            const res = await fetch(`/api/conversations/${conversation.id}`, {
+              method: "DELETE",
+            });
+            if (!res.ok) throw new Error("DELETE failed");
+          } catch {
+            // Cloud delete failed - mark for retry on next app load
+            const pending = JSON.parse(
+              localStorage.getItem(PENDING_CLOUD_DELETE_KEY) ?? "[]",
+            ) as string[];
+            if (!pending.includes(conversation.id)) {
+              pending.push(conversation.id);
+              localStorage.setItem(PENDING_CLOUD_DELETE_KEY, JSON.stringify(pending));
+            }
+            console.warn(
+              "[useTransfer] Cloud delete failed, will retry on next load:",
+              conversation.id,
+            );
+          }
+        }
+
+        // Clean up state
+        prefetchedRef.current = null;
+        setTransferState({
+          conversationId: null,
+          phase: "idle",
+          prefetchedData: null,
+          estimatedBytes: 0,
+          error: null,
+        });
+
+        return conversation.id;
+      } catch (e) {
+        console.error("[useTransfer] transfer error:", e);
+        const errorMessage = e instanceof Error ? e.message : "Transfer failed";
+        setTransferState((prev) => ({
+          ...prev,
+          phase: "idle",
+          error: errorMessage,
+        }));
+        throw e;
+      }
+    },
+    [],
+  );
+
+  const cancelMove = useCallback(() => {
+    prefetchedRef.current = null;
+    setTransferState({
+      conversationId: null,
+      phase: "idle",
+      prefetchedData: null,
+      estimatedBytes: 0,
+      error: null,
+    });
+  }, []);
+
+  const retryPendingCloudDeletes = useCallback(async () => {
+    const pending = JSON.parse(localStorage.getItem(PENDING_CLOUD_DELETE_KEY) ?? "[]") as string[];
+
+    if (pending.length === 0) return;
+
+    const remaining: string[] = [];
+
+    for (const id of pending) {
+      try {
+        const res = await fetch(`/api/conversations/${id}`, { method: "DELETE" });
+        if (!res.ok && res.status !== 404) {
+          // 404 means already deleted (idempotent success)
+          remaining.push(id);
+        }
+      } catch {
+        remaining.push(id);
+      }
+    }
+
+    if (remaining.length > 0) {
+      localStorage.setItem(PENDING_CLOUD_DELETE_KEY, JSON.stringify(remaining));
+    } else {
+      localStorage.removeItem(PENDING_CLOUD_DELETE_KEY);
+    }
+  }, []);
+
+  return {
+    transferState,
+    initiateMove,
+    executeMove,
+    cancelMove,
+    retryPendingCloudDeletes,
+  };
+}

--- a/src/client/hooks/useTransfer.ts
+++ b/src/client/hooks/useTransfer.ts
@@ -101,48 +101,17 @@ export function useTransfer(): UseTransferReturn {
       }));
 
       try {
-        if (toMode === "cloud") {
-          // Local → Cloud: POST to import endpoint
-          const res = await fetch("/api/conversations/import", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ conversation, messages }),
-          });
+        const sourceStorage = createStorage(fromMode);
+        const targetStorage = createStorage(toMode);
 
-          if (!res.ok) {
-            const errorData = (await res.json().catch(() => ({}))) as { error?: string };
-            throw new Error(errorData.error || "Import failed");
-          }
+        // Write to target
+        await targetStorage.importConversation(conversation, messages);
 
-          // Success - delete from localStorage
-          const sourceStorage = createStorage("local");
+        // Delete from source
+        try {
           await sourceStorage.deleteConversation(conversation.id);
-        } else {
-          // Cloud → Local: write to localStorage, then delete from cloud
-          const targetStorage = createStorage("local");
-
-          // Write conversation (filter first to prevent duplicates on retry)
-          const localConversations = JSON.parse(
-            localStorage.getItem("waichat:conversations") ?? "[]",
-          ) as Conversation[];
-          const filtered = localConversations.filter((c) => c.id !== conversation.id);
-          filtered.push({
-            id: conversation.id,
-            title: conversation.title,
-            model: conversation.model,
-            created_at: conversation.created_at,
-            updated_at: conversation.updated_at,
-          });
-          localStorage.setItem("waichat:conversations", JSON.stringify(filtered));
-
-          // Write messages
-          localStorage.setItem(`waichat:messages:${conversation.id}`, JSON.stringify(messages));
-
-          // Delete from cloud
-          try {
-            const cloudStorage = createStorage("cloud");
-            await cloudStorage.deleteConversation(conversation.id);
-          } catch {
+        } catch {
+          if (fromMode === "cloud") {
             // Cloud delete failed - mark for retry on next app load
             const pending = JSON.parse(
               localStorage.getItem(PENDING_CLOUD_DELETE_KEY) ?? "[]",
@@ -155,6 +124,8 @@ export function useTransfer(): UseTransferReturn {
               "[useTransfer] Cloud delete failed, will retry on next load:",
               conversation.id,
             );
+          } else {
+            throw new Error("Failed to delete from local storage");
           }
         }
 

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -58,5 +58,16 @@ export class CloudStorage implements StorageAdapter {
   ): Promise<{ conversation: Conversation; messages: Message[] } | null> {
     return this.getConversation(id);
   }
-}
 
+  async importConversation(conversation: Conversation, messages: Message[]): Promise<void> {
+    const res = await fetch("/api/conversations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ conversation, messages }),
+    });
+    if (!res.ok) {
+      const errorData = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(errorData.error || "Import failed");
+    }
+  }
+}

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -52,5 +52,11 @@ export class CloudStorage implements StorageAdapter {
     const data = (await res.json()) as { deletedIds: string[]; softDeletedIds: string[] };
     return { deletedIds: data.deletedIds, softDeletedIds: data.softDeletedIds };
   }
+
+  async exportConversation(
+    id: string,
+  ): Promise<{ conversation: Conversation; messages: Message[] } | null> {
+    return this.getConversation(id);
+  }
 }
 

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -4,6 +4,7 @@ export interface Conversation {
   model: string;
   created_at: number;
   updated_at: number;
+  import_complete?: number | null;
 }
 
 export interface Message {
@@ -30,6 +31,7 @@ export interface StorageAdapter {
   saveMessage(message: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message>;
   updateConversationTitle(id: string, title: string): Promise<void>;
   deleteMessage(conversationId: string, messageId: string): Promise<DeleteMessageResult>;
+  exportConversation(id: string): Promise<{ conversation: Conversation; messages: Message[] } | null>;
 }
 
 export type StorageMode = "cloud" | "local";

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -32,6 +32,7 @@ export interface StorageAdapter {
   updateConversationTitle(id: string, title: string): Promise<void>;
   deleteMessage(conversationId: string, messageId: string): Promise<DeleteMessageResult>;
   exportConversation(id: string): Promise<{ conversation: Conversation; messages: Message[] } | null>;
+  importConversation(conversation: Conversation, messages: Message[]): Promise<void>;
 }
 
 export type StorageMode = "cloud" | "local";

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -163,4 +163,18 @@ export class LocalStorage implements StorageAdapter {
   ): Promise<{ conversation: Conversation; messages: Message[] } | null> {
     return this.getConversation(id);
   }
+
+  async importConversation(conversation: Conversation, messages: Message[]): Promise<void> {
+    // Filter out any existing entry with the same ID to prevent duplicates on retry
+    const existing = this.getConversationsRaw().filter((c) => c.id !== conversation.id);
+    existing.push({
+      id: conversation.id,
+      title: conversation.title,
+      model: conversation.model,
+      created_at: conversation.created_at,
+      updated_at: conversation.updated_at,
+    });
+    this.setConversations(existing);
+    this.setMessages(conversation.id, messages);
+  }
 }

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -157,4 +157,10 @@ export class LocalStorage implements StorageAdapter {
 
     return { deletedIds, softDeletedIds };
   }
+
+  async exportConversation(
+    id: string,
+  ): Promise<{ conversation: Conversation; messages: Message[] } | null> {
+    return this.getConversation(id);
+  }
 }

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -100,13 +100,101 @@ export async function softDeleteMessage(db: D1Database, id: string): Promise<voi
 }
 
 export async function getSetting(db: D1Database, key: string): Promise<string | null> {
-  const row = await db.prepare("SELECT value FROM settings WHERE key = ?").bind(key).first<{ value: string }>();
+  const row = await db
+    .prepare("SELECT value FROM settings WHERE key = ?")
+    .bind(key)
+    .first<{ value: string }>();
   return row?.value ?? null;
 }
 
 export async function setSetting(db: D1Database, key: string, value: string): Promise<void> {
   await db
-    .prepare("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at")
+    .prepare(
+      "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
     .bind(key, value, Date.now())
     .run();
+}
+
+export async function markImportComplete(db: D1Database, id: string): Promise<void> {
+  await db.prepare("UPDATE conversations SET import_complete = 1 WHERE id = ?").bind(id).run();
+}
+
+/**
+ * Bulk-import a conversation and its messages into D1.
+ * Uses chunked db.batch() calls (max 99 statements per batch).
+ * Idempotent: if the conversation already exists with import_complete=1, returns early.
+ * If it exists without import_complete, deletes the partial and re-imports.
+ */
+export async function importConversation(
+  db: D1Database,
+  conversation: Conversation,
+  messages: Message[],
+): Promise<void> {
+  // Idempotency check
+  const existing = await getConversation(db, conversation.id);
+  if (existing) {
+    if (existing.import_complete === 1) {
+      // Previous import completed successfully - idempotent success
+      return;
+    }
+    // Partial leftover from a failed import - clean up
+    await deleteConversation(db, conversation.id);
+  }
+
+  const BATCH_SIZE = 99;
+
+  // Build all message INSERT statements
+  const msgStatements = messages.map((m) =>
+    db
+      .prepare(
+        "INSERT INTO messages (id, conversation_id, role, content, created_at, model, parent_id, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+      )
+      .bind(
+        m.id,
+        m.conversation_id,
+        m.role,
+        m.content,
+        m.created_at,
+        m.model || null,
+        m.parent_id || null,
+        m.deleted_at || null,
+      ),
+  );
+
+  // First batch: conversation INSERT + first chunk of messages
+  const convInsert = db
+    .prepare(
+      "INSERT INTO conversations (id, title, model, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(
+      conversation.id,
+      conversation.title,
+      conversation.model,
+      conversation.created_at,
+      conversation.updated_at,
+    );
+
+  const firstChunk = msgStatements.slice(0, BATCH_SIZE);
+  await db.batch([convInsert, ...firstChunk]);
+
+  // Remaining batches
+  try {
+    for (let i = BATCH_SIZE; i < msgStatements.length; i += BATCH_SIZE) {
+      const chunk = msgStatements.slice(i, i + BATCH_SIZE);
+      await db.batch(chunk);
+    }
+  } catch (e) {
+    // Rollback: delete conversation (cascades to messages via FK)
+    try {
+      await deleteConversation(db, conversation.id);
+    } catch {
+      // Rollback failed - next retry will hit the idempotency check
+      // and clean up the partial via the import_complete=null path
+    }
+    throw e;
+  }
+
+  // Mark import as complete
+  await markImportComplete(db, conversation.id);
 }

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -9,6 +9,7 @@ import {
   getMessageById,
   getMessages,
   getSiblingCount,
+  importConversation,
   saveMessage,
   updateConversationTimestamp,
   updateConversationTitle,
@@ -166,6 +167,26 @@ app.get("/api/conversations/:id", async (c) => {
   if (!conversation) return c.json({ error: "Not found" }, 404);
   const messages = await getMessages(c.env.DB, conversation.id);
   return c.json({ conversation, messages });
+});
+
+// Import a full conversation + messages from local storage into D1
+app.post("/api/conversations/import", async (c) => {
+  try {
+    const { conversation, messages } = await c.req.json<{
+      conversation: { id: string; title: string; model: string; created_at: number; updated_at: number };
+      messages: { id: string; conversation_id: string; role: "user" | "assistant"; content: string; created_at: number; model?: string; parent_id?: string; deleted_at?: number }[];
+    }>();
+
+    if (!conversation?.id || !Array.isArray(messages)) {
+      return c.json({ success: false, error: "Invalid request body" }, 400);
+    }
+
+    await importConversation(c.env.DB, conversation, messages);
+    return c.json({ success: true, conversationId: conversation.id });
+  } catch (e) {
+    console.error("[POST /api/conversations/import] error:", e);
+    return c.json({ success: false, error: "Import failed" }, 500);
+  }
 });
 
 app.delete("/api/conversations", async (c) => {

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -11,6 +11,7 @@ export interface Conversation {
   model: string;
   created_at: number;
   updated_at: number;
+  import_complete?: number | null;
 }
 
 export interface Message {


### PR DESCRIPTION
## Description

Add bidirectional conversation transfer between localStorage and Cloudflare D1. Includes a new /api/conversations/import endpoint with chunked D1 batch inserts, idempotent retry via import_complete flag, and automatic cleanup of partial imports.

- New useTransfer hook orchestrating prefetch → transfer → cleanup
- Sidebar move button (↗) with streaming guard and spinner
- ConfirmModal variant prop for neutral (blue) confirmations
- Auto-select moved conversation after mode switch via pending ref
- Failed cloud DELETE auto-retry on next app load


**Closes #22**


## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `feat/22-move-chats-bw-local-n-cloud` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/22-move-chats-bw-local-n-cloud)
