### PR TITLE
feat: separate global default model from per-chat active model

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -92,6 +92,7 @@ export default function App() {
     selectConversation,
     newConversation,
     deleteConversation,
+    updateActiveModel,
     clearConversation,
     sendMessage,
     stopGeneration,
@@ -109,7 +110,7 @@ export default function App() {
   } = useTransfer();
 
   const { models } = useModels();
-  const [model, setModel] = useState(
+  const [defaultModel, setDefaultModel] = useState(
     () => localStorage.getItem(DEFAULT_MODEL_KEY) ?? DEFAULT_MODEL_ID,
   );
   const [systemPrompt, setSystemPrompt] = useState(
@@ -147,9 +148,27 @@ export default function App() {
             localStorage.setItem(SYSTEM_PROMPT_KEY, data.value);
           }
         })
-        .catch((err) => console.error("Cloud sync error:", err));
+        .catch((err) => console.error("Cloud sync error (system_prompt):", err));
     }
-  }, [syncSystemPrompt]); // fetch on mount or when toggled ON
+  }, [syncSystemPrompt]);
+
+  // Sync Default Model from Cloud if enabled
+  useEffect(() => {
+    if (syncSystemPrompt) {
+      fetch("/api/settings/default_model")
+        .then((res) => {
+          if (!res.ok) throw new Error("Failed to fetch default model");
+          return res.json() as Promise<{ value?: string }>;
+        })
+        .then((data) => {
+          if (data.value != null && data.value !== defaultModel) {
+            setDefaultModel(data.value);
+            localStorage.setItem(DEFAULT_MODEL_KEY, data.value);
+          }
+        })
+        .catch((err) => console.error("Cloud sync error (default_model):", err));
+    }
+  }, [syncSystemPrompt]);
 
   const initialLoadDone = useRef(false);
 
@@ -272,24 +291,45 @@ export default function App() {
         closeSidebarOnMobile();
         return;
       }
-      await newConversation(model);
+      await newConversation(defaultModel);
     }
     closeSidebarOnMobile();
   };
 
   const handleSend = async (content: string) => {
     if (isStreaming) return;
+    const currentModel = activeConversation?.model ?? defaultModel;
     if (!activeConversation) {
-      const convo = await newConversation(model);
-      await sendMessage(content, model, convo.id, storageMode, systemPrompt);
+      const convo = await newConversation(defaultModel);
+      await sendMessage(content, defaultModel, convo.id, storageMode, systemPrompt);
     } else {
-      await sendMessage(content, model, activeConversation.id, storageMode, systemPrompt);
+      await sendMessage(content, currentModel, activeConversation.id, storageMode, systemPrompt);
     }
   };
 
-  const handleDefaultModelChange = (m: string) => {
-    setModel(m);
+  const handleDefaultModelChange = async (m: string) => {
+    setDefaultModel(m);
     localStorage.setItem(DEFAULT_MODEL_KEY, m);
+
+    if (syncSystemPrompt) {
+      try {
+        await fetch("/api/settings/default_model", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ value: m }),
+        });
+      } catch (err) {
+        console.error("Failed to sync default model to cloud:", err);
+      }
+    }
+  };
+
+  const handleModelChange = (m: string) => {
+    if (activeConversation) {
+      updateActiveModel(m);
+    } else {
+      handleDefaultModelChange(m);
+    }
   };
 
   const handleSystemPromptChange = async (prompt: string, sync: boolean) => {
@@ -423,8 +463,8 @@ export default function App() {
                 <div className="flex-1 min-w-0">
                   <ModelPicker
                     models={models}
-                    value={model}
-                    onChange={handleDefaultModelChange}
+                    value={activeConversation?.model ?? defaultModel}
+                    onChange={handleModelChange}
                     disabled={isStreaming}
                   />
                 </div>
@@ -525,7 +565,7 @@ export default function App() {
             messages={messages}
             isStreaming={isStreaming}
             onSelectPrompt={setPendingPrompt}
-            onRetry={(messageId) => retryMessage(messageId, model, storageMode, systemPrompt)}
+            onRetry={(messageId) => retryMessage(messageId, activeConversation?.model ?? defaultModel, storageMode, systemPrompt)}
             onDelete={(messageId) => deleteMessage(messageId)}
             activeVersions={activeVersions}
             onVersionChange={setActiveVersion}
@@ -544,7 +584,7 @@ export default function App() {
           onClose={() => setSettingsOpen(false)}
           storageMode={storageMode}
           onStorageModeChange={handleStorageToggle}
-          defaultModel={model}
+          defaultModel={defaultModel}
           onDefaultModelChange={handleDefaultModelChange}
           systemPrompt={systemPrompt}
           syncSystemPrompt={syncSystemPrompt}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -11,7 +11,7 @@ import SettingsModal from "./components/SettingsModal";
 
 const STORAGE_MODE_KEY = "waichat:storage-mode";
 const SYSTEM_PROMPT_KEY = "waichat:system-prompt";
-const SYNC_PROMPT_KEY = "waichat:sync-system-prompt";
+const SYNC_SETTINGS_KEY = "waichat:sync-settings";
 const DEFAULT_MODEL_KEY = "waichat:default-model";
 export const THEME_KEY = "waichat:theme";
 const MOBILE_BREAKPOINT = 768;
@@ -116,8 +116,8 @@ export default function App() {
   const [systemPrompt, setSystemPrompt] = useState(
     () => localStorage.getItem(SYSTEM_PROMPT_KEY) ?? "",
   );
-  const [syncSystemPrompt, setSyncSystemPrompt] = useState(
-    () => localStorage.getItem(SYNC_PROMPT_KEY) === "true",
+  const [syncSettings, setSyncSettings] = useState(
+    () => localStorage.getItem(SYNC_SETTINGS_KEY) === "true",
   );
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -136,7 +136,7 @@ export default function App() {
 
   // Sync System Prompt from Cloud if enabled
   useEffect(() => {
-    if (syncSystemPrompt) {
+    if (syncSettings) {
       fetch("/api/settings/system_prompt")
         .then((res) => {
           if (!res.ok) throw new Error("Failed to fetch system prompt");
@@ -150,11 +150,11 @@ export default function App() {
         })
         .catch((err) => console.error("Cloud sync error (system_prompt):", err));
     }
-  }, [syncSystemPrompt]);
+  }, [syncSettings]);
 
   // Sync Default Model from Cloud if enabled
   useEffect(() => {
-    if (syncSystemPrompt) {
+    if (syncSettings) {
       fetch("/api/settings/default_model")
         .then((res) => {
           if (!res.ok) throw new Error("Failed to fetch default model");
@@ -168,7 +168,7 @@ export default function App() {
         })
         .catch((err) => console.error("Cloud sync error (default_model):", err));
     }
-  }, [syncSystemPrompt]);
+  }, [syncSettings]);
 
   const initialLoadDone = useRef(false);
 
@@ -311,7 +311,7 @@ export default function App() {
     setDefaultModel(m);
     localStorage.setItem(DEFAULT_MODEL_KEY, m);
 
-    if (syncSystemPrompt) {
+    if (syncSettings) {
       try {
         await fetch("/api/settings/default_model", {
           method: "POST",
@@ -336,8 +336,8 @@ export default function App() {
     setSystemPrompt(prompt);
     localStorage.setItem(SYSTEM_PROMPT_KEY, prompt);
 
-    setSyncSystemPrompt(sync);
-    localStorage.setItem(SYNC_PROMPT_KEY, String(sync));
+    setSyncSettings(sync);
+    localStorage.setItem(SYNC_SETTINGS_KEY, String(sync));
 
     if (sync) {
       try {
@@ -587,7 +587,7 @@ export default function App() {
           defaultModel={defaultModel}
           onDefaultModelChange={handleDefaultModelChange}
           systemPrompt={systemPrompt}
-          syncSystemPrompt={syncSystemPrompt}
+          syncSettings={syncSettings}
           onSystemPromptChange={handleSystemPromptChange}
           models={models}
           onClearConversations={handleClearConversations}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -117,7 +117,7 @@ export default function App() {
     () => localStorage.getItem(SYSTEM_PROMPT_KEY) ?? "",
   );
   const [syncSettings, setSyncSettings] = useState(
-    () => localStorage.getItem(SYNC_SETTINGS_KEY) === "true",
+    () => (localStorage.getItem(SYNC_SETTINGS_KEY) ?? localStorage.getItem("waichat:sync-system-prompt")) === "true",
   );
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -307,11 +307,11 @@ export default function App() {
     }
   };
 
-  const handleDefaultModelChange = async (m: string) => {
+  const handleDefaultModelChange = async (m: string, sync: boolean = syncSettings) => {
     setDefaultModel(m);
     localStorage.setItem(DEFAULT_MODEL_KEY, m);
 
-    if (syncSettings) {
+    if (sync) {
       try {
         await fetch("/api/settings/default_model", {
           method: "POST",
@@ -328,7 +328,7 @@ export default function App() {
     if (activeConversation) {
       updateActiveModel(m);
     } else {
-      handleDefaultModelChange(m);
+      handleDefaultModelChange(m, syncSettings);
     }
   };
 

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -169,6 +169,9 @@ export default function SettingsModal({
                     className="w-full"
                   />
                 </div>
+                <p className="mt-1.5 text-xs text-gray-500 dark:text-white/40">
+                  Fallback for existing chats and default for new ones.
+                </p>
               </div>
               {/* System prompt */}
               <div>

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -11,7 +11,7 @@ interface SettingsModalProps {
   defaultModel: string;
   onDefaultModelChange: (model: string) => void;
   systemPrompt: string;
-  syncSystemPrompt: boolean;
+  syncSettings: boolean;
   onSystemPromptChange: (prompt: string, sync: boolean) => void;
   models: Model[];
   onClearConversations: (mode: StorageMode) => void;
@@ -27,7 +27,7 @@ export default function SettingsModal({
   defaultModel,
   onDefaultModelChange,
   systemPrompt,
-  syncSystemPrompt,
+  syncSettings,
   onSystemPromptChange,
   models,
   onClearConversations,
@@ -40,7 +40,7 @@ export default function SettingsModal({
   const [draftStorageMode, setDraftStorageMode] = useState<StorageMode>(storageMode);
   const [draftModel, setDraftModel] = useState(defaultModel);
   const [draftSystemPrompt, setDraftSystemPrompt] = useState(systemPrompt);
-  const [draftSyncSystemPrompt, setDraftSyncSystemPrompt] = useState(syncSystemPrompt);
+  const [draftSyncSettings, setDraftSyncSettings] = useState(syncSettings);
 
   // Sync draft with props when modal opens
   useEffect(() => {
@@ -48,9 +48,9 @@ export default function SettingsModal({
       setDraftStorageMode(storageMode);
       setDraftModel(defaultModel);
       setDraftSystemPrompt(systemPrompt);
-      setDraftSyncSystemPrompt(syncSystemPrompt);
+      setDraftSyncSettings(syncSettings);
     }
-  }, [open, storageMode, defaultModel, systemPrompt, syncSystemPrompt]);
+  }, [open, storageMode, defaultModel, systemPrompt, syncSettings]);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -65,7 +65,7 @@ export default function SettingsModal({
   const handleSave = () => {
     onStorageModeChange(draftStorageMode);
     onDefaultModelChange(draftModel);
-    onSystemPromptChange(draftSystemPrompt, draftSyncSystemPrompt);
+    onSystemPromptChange(draftSystemPrompt, draftSyncSettings);
     onClose();
   };
 
@@ -102,9 +102,25 @@ export default function SettingsModal({
         <div className="overflow-y-auto flex-1 px-6 py-6 space-y-8 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
           {/* Preferences */}
           <section>
-            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
-              Preferences
-            </h3>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40">
+                Preferences
+              </h3>
+              <label className="flex items-center gap-2 cursor-pointer group">
+                <div className="relative flex items-center justify-center">
+                  <input
+                    type="checkbox"
+                    checked={draftSyncSettings}
+                    onChange={(e) => setDraftSyncSettings(e.target.checked)}
+                    className="peer sr-only"
+                  />
+                  <div className="w-8 h-4 bg-black/10 dark:bg-white/10 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-[#0A84FF]"></div>
+                </div>
+                <span className="text-[11px] md:text-xs font-medium text-gray-500 dark:text-white/40 group-hover:text-gray-900 dark:group-hover:text-white/80 transition-colors">
+                  Sync Settings to Cloud
+                </span>
+              </label>
+            </div>
             <div className="space-y-5">
               {/* Theme Segmented Control */}
               <div>
@@ -178,20 +194,6 @@ export default function SettingsModal({
                 <div className="flex items-center justify-between mb-2">
                   <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80">
                     System Prompt
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer group">
-                    <div className="relative flex items-center justify-center">
-                      <input
-                        type="checkbox"
-                        checked={draftSyncSystemPrompt}
-                        onChange={(e) => setDraftSyncSystemPrompt(e.target.checked)}
-                        className="peer sr-only"
-                      />
-                      <div className="w-8 h-4 bg-black/10 dark:bg-white/10 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-[#0A84FF]"></div>
-                    </div>
-                    <span className="text-[11px] md:text-xs font-medium text-gray-500 dark:text-white/40 group-hover:text-gray-900 dark:group-hover:text-white/80 transition-colors">
-                      Sync to Cloud
-                    </span>
                   </label>
                 </div>
                 <textarea

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -9,7 +9,7 @@ interface SettingsModalProps {
   storageMode: StorageMode;
   onStorageModeChange: (mode: StorageMode) => void;
   defaultModel: string;
-  onDefaultModelChange: (model: string) => void;
+  onDefaultModelChange: (model: string, sync: boolean) => void;
   systemPrompt: string;
   syncSettings: boolean;
   onSystemPromptChange: (prompt: string, sync: boolean) => void;
@@ -64,7 +64,7 @@ export default function SettingsModal({
 
   const handleSave = () => {
     onStorageModeChange(draftStorageMode);
-    onDefaultModelChange(draftModel);
+    onDefaultModelChange(draftModel, draftSyncSettings);
     onSystemPromptChange(draftSystemPrompt, draftSyncSettings);
     onClose();
   };

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -130,11 +130,19 @@ export function useChat(
   const updateActiveModel = useCallback(
     async (model: string) => {
       if (!activeConversation) return;
-      await storage.updateConversationModel(activeConversation.id, model);
-      setActiveConversation((prev) => (prev ? { ...prev, model } : null));
-      setConversations((prev) =>
-        prev.map((c) => (c.id === activeConversation.id ? { ...c, model } : c)),
-      );
+      try {
+        await storage.updateConversationModel(activeConversation.id, model);
+        const now = Date.now();
+        setActiveConversation((prev) => (prev ? { ...prev, model, updated_at: now } : null));
+        setConversations((prev) =>
+          prev
+            .map((c) => (c.id === activeConversation.id ? { ...c, model, updated_at: now } : c))
+            .sort((a, b) => b.updated_at - a.updated_at),
+        );
+      } catch (err) {
+        console.error("Failed to update active model:", err);
+        setError("Failed to update conversation model");
+      }
     },
     [storage, activeConversation],
   );

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -13,6 +13,7 @@ interface UseChatReturn {
   selectConversation: (id: string) => Promise<void>;
   newConversation: (model: string) => Promise<Conversation>;
   deleteConversation: (id: string) => Promise<void>;
+  updateActiveModel: (model: string) => Promise<void>;
   clearConversation: () => void;
   sendMessage: (
     content: string,
@@ -122,6 +123,18 @@ export function useChat(
         setMessages([]);
         setActiveVersions({});
       }
+    },
+    [storage, activeConversation],
+  );
+
+  const updateActiveModel = useCallback(
+    async (model: string) => {
+      if (!activeConversation) return;
+      await storage.updateConversationModel(activeConversation.id, model);
+      setActiveConversation((prev) => (prev ? { ...prev, model } : null));
+      setConversations((prev) =>
+        prev.map((c) => (c.id === activeConversation.id ? { ...c, model } : c)),
+      );
     },
     [storage, activeConversation],
   );
@@ -548,6 +561,7 @@ export function useChat(
     selectConversation,
     newConversation,
     deleteConversation,
+    updateActiveModel,
     clearConversation,
     sendMessage,
     stopGeneration,

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -30,6 +30,15 @@ export class CloudStorage implements StorageAdapter {
     const res = await fetch(`/api/conversations/${id}`, { method: "DELETE" });
     if (!res.ok) throw new Error("Failed to delete conversation");
   }
+  
+  async updateConversationModel(id: string, model: string): Promise<void> {
+    const res = await fetch(`/api/conversations/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model }),
+    });
+    if (!res.ok) throw new Error("Failed to update conversation model");
+  }
 
   async saveMessage(msg: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message> {
     // Messages are saved server-side during /api/chat — nothing to do here

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -28,6 +28,7 @@ export interface StorageAdapter {
   getConversation(id: string): Promise<{ conversation: Conversation; messages: Message[] } | null>;
   createConversation(model: string): Promise<Conversation>;
   deleteConversation(id: string): Promise<void>;
+  updateConversationModel(id: string, model: string): Promise<void>;
   saveMessage(message: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message>;
   updateConversationTitle(id: string, title: string): Promise<void>;
   deleteMessage(conversationId: string, messageId: string): Promise<DeleteMessageResult>;

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -61,6 +61,13 @@ export class LocalStorage implements StorageAdapter {
     this.setConversations(conversations);
     localStorage.removeItem(MESSAGES_KEY(id));
   }
+  
+  async updateConversationModel(id: string, model: string): Promise<void> {
+    const conversations = this.getConversationsRaw().map((c) =>
+      c.id === id ? { ...c, model, updated_at: Date.now() } : c,
+    );
+    this.setConversations(conversations);
+  }
 
   async saveMessage(msg: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message> {
     const message: Message = {

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -40,6 +40,17 @@ export async function updateConversationTitle(
     .run();
 }
 
+export async function updateConversationModel(
+  db: D1Database,
+  id: string,
+  model: string,
+): Promise<void> {
+  await db
+    .prepare("UPDATE conversations SET model = ?, updated_at = ? WHERE id = ?")
+    .bind(model, Date.now(), id)
+    .run();
+}
+
 export async function updateConversationTimestamp(db: D1Database, id: string): Promise<void> {
   await db
     .prepare("UPDATE conversations SET updated_at = ? WHERE id = ?")

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -210,11 +210,26 @@ app.patch("/api/conversations/:id", async (c) => {
     return c.json({ error: "Conversation not found" }, 404);
   }
 
+  const updates: string[] = [];
+  const params: any[] = [];
+
   if (body.model) {
-    await updateConversationModel(db, id, body.model);
+    updates.push("model = ?");
+    params.push(body.model);
   }
   if (body.title) {
-    await updateConversationTitle(db, id, body.title);
+    updates.push("title = ?");
+    params.push(body.title);
+  }
+
+  if (updates.length > 0) {
+    updates.push("updated_at = ?");
+    params.push(Date.now());
+    params.push(id);
+    await db
+      .prepare(`UPDATE conversations SET ${updates.join(", ")} WHERE id = ?`)
+      .bind(...params)
+      .run();
   }
 
   return c.json({ success: true });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -13,6 +13,7 @@ import {
   saveMessage,
   updateConversationTimestamp,
   updateConversationTitle,
+  updateConversationModel,
   getSetting,
   setSetting,
 } from "./db";
@@ -199,6 +200,20 @@ app.delete("/api/conversations/:id", async (c) => {
   return c.json({ success: true });
 });
 
+app.patch("/api/conversations/:id", async (c) => {
+  const id = c.req.param("id");
+  const body = await c.req.json<{ model?: string; title?: string }>();
+
+  if (body.model) {
+    await updateConversationModel(c.env.DB, id, body.model);
+  }
+  if (body.title) {
+    await updateConversationTitle(c.env.DB, id, body.title);
+  }
+
+  return c.json({ success: true });
+});
+
 // Delete a single message (with cascade / soft-delete logic)
 app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) => {
   const { conversationId, messageId } = c.req.param();
@@ -290,14 +305,20 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
 });
 
 // Settings
-const ALLOWED_SETTING_KEYS = ["system_prompt"];
+const ALLOWED_SETTING_KEYS = ["system_prompt", "default_model"];
 
 app.get("/api/settings/:key", async (c) => {
   const key = c.req.param("key");
   if (!ALLOWED_SETTING_KEYS.includes(key)) {
     return c.json({ error: "Invalid setting key" }, 400);
   }
-  const value = await getSetting(c.env.DB, key);
+  let value = await getSetting(c.env.DB, key);
+
+  // Migration: If default_model is missing, try legacy "model" key
+  if (key === "default_model" && value === null) {
+    value = await getSetting(c.env.DB, "model");
+  }
+
   return c.json({ value });
 });
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -203,12 +203,18 @@ app.delete("/api/conversations/:id", async (c) => {
 app.patch("/api/conversations/:id", async (c) => {
   const id = c.req.param("id");
   const body = await c.req.json<{ model?: string; title?: string }>();
+  const db = c.env.DB;
+
+  const conversation = await getConversation(db, id);
+  if (!conversation) {
+    return c.json({ error: "Conversation not found" }, 404);
+  }
 
   if (body.model) {
-    await updateConversationModel(c.env.DB, id, body.model);
+    await updateConversationModel(db, id, body.model);
   }
   if (body.title) {
-    await updateConversationTitle(c.env.DB, id, body.title);
+    await updateConversationTitle(db, id, body.title);
   }
 
   return c.json({ success: true });


### PR DESCRIPTION
## Description

Refactors model selection logic to distinguish between a global user preference and an active model for specific conversations. Switching models mid-chat now persists the choice for that chat without affecting the global default.

- Add `PATCH /api/conversations/:id` to update conversation model in D1
- Implement `default_model` setting with legacy fallback migration logic
- Update `StorageAdapter` and hooks to support per-chat model persistence
- Make header `ModelPicker` context-aware (updates chat or global default)
- Sync `default_model` preference to cloud independently of other settings


**Fixes #25**


## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `fix/25-keep-separate-settings-for-default-model-n-lastused-model-in-chat` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/fix/25-keep-separate-settings-for-default-model-n-lastused-model-in-chat)
