### PR TITLE
feat: implement tree-based branching message history (Edit & Regenerate)

### DIFF
--- a/migrations/0007_migrate_parent_id.sql
+++ b/migrations/0007_migrate_parent_id.sql
@@ -1,0 +1,27 @@
+-- Step 1: Add a temporary column to store the new parent_id to avoid overriding data we still need
+ALTER TABLE messages ADD COLUMN new_parent_id TEXT;
+
+-- Step 2: Compute the new parent_id for messages that were in the main trunk (no parent_id)
+-- We use LAG() to get the ID of the immediately preceding message based on created_at and rowid.
+WITH RankedMessages AS (
+  SELECT id, LAG(id) OVER (PARTITION BY conversation_id ORDER BY created_at ASC, rowid ASC) as prev_id
+  FROM messages
+  WHERE parent_id IS NULL
+)
+UPDATE messages
+SET new_parent_id = (SELECT prev_id FROM RankedMessages WHERE RankedMessages.id = messages.id)
+WHERE parent_id IS NULL;
+
+-- Step 3: For assistant retries (parent_id IS NOT NULL), their new parent_id should be
+-- the new parent_id of the original message they were retrying.
+UPDATE messages
+SET new_parent_id = (
+  SELECT new_parent_id 
+  FROM messages m2 
+  WHERE m2.id = messages.parent_id
+)
+WHERE parent_id IS NOT NULL;
+
+-- Step 4: Swap columns
+ALTER TABLE messages DROP COLUMN parent_id;
+ALTER TABLE messages RENAME COLUMN new_parent_id TO parent_id;

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState, useRef } from "react";
-import { useChat } from "./hooks/useChat";
-import { useModels, DEFAULT_MODEL_ID } from "./hooks/useModels";
-import { useTransfer } from "./hooks/useTransfer";
-import type { StorageMode } from "./storage";
-import Sidebar from "./components/Sidebar";
-import MessageList from "./components/MessageList";
+import { useEffect, useRef, useState } from "react";
 import ChatInput from "./components/ChatInput";
+import MessageList from "./components/MessageList";
 import ModelPicker from "./components/ModelPicker";
 import SettingsModal from "./components/SettingsModal";
+import Sidebar from "./components/Sidebar";
+import { useChat } from "./hooks/useChat";
+import { DEFAULT_MODEL_ID, useModels } from "./hooks/useModels";
+import { useTransfer } from "./hooks/useTransfer";
+import type { StorageMode } from "./storage";
 
 const STORAGE_MODE_KEY = "waichat:storage-mode";
 const SYSTEM_PROMPT_KEY = "waichat:system-prompt";
@@ -87,6 +87,7 @@ export default function App() {
     messages,
     isStreaming,
     error,
+    activeBranch,
     activeVersions,
     loadConversations,
     selectConversation,
@@ -95,19 +96,15 @@ export default function App() {
     updateActiveModel,
     clearConversation,
     sendMessage,
+    editMessage,
     stopGeneration,
     retryMessage,
     setActiveVersion,
     deleteMessage,
   } = useChat(storageMode, pendingSelectionRef);
 
-  const {
-    transferState,
-    initiateMove,
-    executeMove,
-    cancelMove,
-    retryPendingCloudDeletes,
-  } = useTransfer();
+  const { transferState, initiateMove, executeMove, cancelMove, retryPendingCloudDeletes } =
+    useTransfer();
 
   const { models } = useModels();
   const [defaultModel, setDefaultModel] = useState(
@@ -117,7 +114,9 @@ export default function App() {
     () => localStorage.getItem(SYSTEM_PROMPT_KEY) ?? "",
   );
   const [syncSettings, setSyncSettings] = useState(
-    () => (localStorage.getItem(SYNC_SETTINGS_KEY) ?? localStorage.getItem("waichat:sync-system-prompt")) === "true",
+    () =>
+      (localStorage.getItem(SYNC_SETTINGS_KEY) ??
+        localStorage.getItem("waichat:sync-system-prompt")) === "true",
   );
   const [settingsOpen, setSettingsOpen] = useState(false);
 
@@ -454,12 +453,16 @@ export default function App() {
                 </button>
               )}
 
-              <div className={`flex items-center gap-2 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all ${
-                storageMode === "cloud"
-                  ? "bg-brand-cloud/10 hover:bg-brand-cloud/20 dark:bg-brand-cloud/15 dark:hover:bg-brand-cloud/25"
-                  : "bg-brand-local/10 hover:bg-brand-local/20 dark:bg-brand-local/15 dark:hover:bg-brand-local/25"
-              }`}>
-                <div className={`w-2 h-2 rounded-full ${storageMode === "cloud" ? "bg-brand-cloud" : "bg-brand-local"}`}></div>
+              <div
+                className={`flex items-center gap-2 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all ${
+                  storageMode === "cloud"
+                    ? "bg-brand-cloud/10 hover:bg-brand-cloud/20 dark:bg-brand-cloud/15 dark:hover:bg-brand-cloud/25"
+                    : "bg-brand-local/10 hover:bg-brand-local/20 dark:bg-brand-local/15 dark:hover:bg-brand-local/25"
+                }`}
+              >
+                <div
+                  className={`w-2 h-2 rounded-full ${storageMode === "cloud" ? "bg-brand-cloud" : "bg-brand-local"}`}
+                ></div>
                 <div className="flex-1 min-w-0">
                   <ModelPicker
                     models={models}
@@ -563,9 +566,28 @@ export default function App() {
 
           <MessageList
             messages={messages}
+            activeBranch={activeBranch}
             isStreaming={isStreaming}
             onSelectPrompt={setPendingPrompt}
-            onRetry={(messageId) => retryMessage(messageId, activeConversation?.model ?? defaultModel, storageMode, systemPrompt)}
+            onRetry={(messageId) =>
+              retryMessage(
+                messageId,
+                activeConversation?.model ?? defaultModel,
+                storageMode,
+                systemPrompt,
+              )
+            }
+            onEdit={(messageId, content) =>
+              activeConversation &&
+              editMessage(
+                activeConversation.id,
+                activeConversation.model ?? defaultModel,
+                content,
+                messageId,
+                storageMode,
+                systemPrompt,
+              )
+            }
             onDelete={(messageId) => deleteMessage(messageId)}
             activeVersions={activeVersions}
             onVersionChange={setActiveVersion}

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -8,9 +8,11 @@ import ConfirmModal from "./ConfirmModal";
 
 interface MessageListProps {
   messages: Message[];
+  activeBranch: Message[];
   isStreaming: boolean;
   onSelectPrompt: (prompt: string) => void;
   onRetry?: (messageId: string) => void;
+  onEdit?: (messageId: string, content: string) => void;
   onDelete?: (messageId: string) => void;
   activeVersions: Record<string, string>;
   onVersionChange?: (parentId: string, messageId: string) => void;
@@ -283,9 +285,7 @@ function MarkdownRenderer({ content }: { content: string }) {
             {children}
           </a>
         ),
-        hr: () => (
-          <hr className="my-8 border-black/10 dark:border-white/10" />
-        ),
+        hr: () => <hr className="my-8 border-black/10 dark:border-white/10" />,
         blockquote: ({ children }) => (
           <blockquote className="border-l-4 border-black/20 dark:border-white/20 pl-4 py-1 my-3 text-gray-700 dark:text-white/70 italic">
             {children}
@@ -318,26 +318,19 @@ function MarkdownRenderer({ content }: { content: string }) {
   );
 }
 
-interface DisplayItem {
-  type: "user";
+interface DisplayEntry {
   message: Message;
-}
-
-interface AssistantGroup {
-  type: "assistant";
-  parentId: string;
   siblings: Message[];
-  activeMessage: Message;
   activeIndex: number;
 }
 
-type DisplayEntry = DisplayItem | AssistantGroup;
-
 export default function MessageList({
   messages,
+  activeBranch,
   isStreaming,
   onSelectPrompt,
   onRetry,
+  onEdit,
   onDelete,
   activeVersions,
   onVersionChange,
@@ -346,96 +339,56 @@ export default function MessageList({
   const scrollRef = useRef<HTMLDivElement>(null);
   const isUserScrolled = useRef(false);
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editContent, setEditContent] = useState("");
+  const editInputRef = useRef<HTMLTextAreaElement>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
     id: string;
     role: "user" | "assistant";
     isLastVersion: boolean;
   } | null>(null);
 
+  // Auto-focus edit input
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      editInputRef.current.focus();
+      // Move cursor to end
+      editInputRef.current.selectionStart = editInputRef.current.value.length;
+      editInputRef.current.selectionEnd = editInputRef.current.value.length;
+    }
+  }, [editingId]);
+
   // Keep track of how many message blocks exist
   const prevMessageCount = useRef(messages.length);
 
-  // Build the display list: group assistant siblings together
+  // Build the display list: map activeBranch and attach siblings
   const displayItems = useMemo((): DisplayEntry[] => {
     const items: DisplayEntry[] = [];
-    // Map: parentId -> list of sibling messages (including the original)
-    const siblingMap = new Map<string, Message[]>();
 
-    // First pass: identify all siblings and group them
+    // Pre-calculate siblings by parent_id
+    const siblingMap = new Map<string | null, Message[]>();
     for (const m of messages) {
-      if (m.role === "assistant" && m.parent_id) {
-        const group = siblingMap.get(m.parent_id) || [];
-        group.push(m);
-        siblingMap.set(m.parent_id, group);
-      }
+      if (m.deleted_at) continue;
+      const pId = m.parent_id || null;
+      const group = siblingMap.get(pId) || [];
+      group.push(m);
+      siblingMap.set(pId, group);
     }
 
-    // Track which parentIds we've already rendered
-    const rendered = new Set<string>();
-
-    for (const m of messages) {
-      if (m.role === "user") {
-        items.push({ type: "user", message: m });
-        continue;
-      }
-
-      // Assistant message
-      if (m.parent_id) {
-        // This is a retry sibling - skip it, it'll be rendered as part of the parent's group
-        if (!rendered.has(m.parent_id)) {
-          // Edge case: the parent might not exist in messages (shouldn't happen, but be safe)
-          // We'll handle it when we encounter the parent
-        }
-        continue;
-      }
-
-      // Original assistant message (no parent_id)
-      const parentId = m.id;
-
-      if (rendered.has(parentId)) continue;
-      rendered.add(parentId);
-
-      const retrySiblings = siblingMap.get(parentId) || [];
-      const allSiblings = [m, ...retrySiblings];
-
-      // Filter out soft-deleted siblings for display purposes
-      const visibleSiblings = allSiblings.filter((s) => !s.deleted_at);
-
-      // If ALL versions are deleted, skip rendering this group entirely
-      if (visibleSiblings.length === 0) continue;
-
-      // Determine active version (only among visible siblings)
-      const explicitActive = activeVersions[parentId];
-      let activeMessage: Message;
-      let activeIndex: number;
-
-      if (explicitActive) {
-        const idx = visibleSiblings.findIndex((s) => s.id === explicitActive);
-        if (idx >= 0) {
-          activeMessage = visibleSiblings[idx];
-          activeIndex = idx;
-        } else {
-          // Fallback to latest visible
-          activeMessage = visibleSiblings[visibleSiblings.length - 1];
-          activeIndex = visibleSiblings.length - 1;
-        }
-      } else {
-        // Default to latest visible
-        activeMessage = visibleSiblings[visibleSiblings.length - 1];
-        activeIndex = visibleSiblings.length - 1;
-      }
+    for (const m of activeBranch) {
+      const pId = m.parent_id || null;
+      const siblings = siblingMap.get(pId) || [];
+      const activeIndex = siblings.findIndex((s) => s.id === m.id);
 
       items.push({
-        type: "assistant",
-        parentId,
-        siblings: visibleSiblings,
-        activeMessage,
-        activeIndex,
+        message: m,
+        siblings,
+        activeIndex: activeIndex >= 0 ? activeIndex : 0,
       });
     }
 
     return items;
-  }, [messages, activeVersions]);
+  }, [messages, activeBranch]);
 
   // Detects when the user scrolls away from the bottom
   const handleScroll = () => {
@@ -480,7 +433,7 @@ export default function MessageList({
   // Pre-calculate the index of the last assistant entry to avoid O(N²) lookups
   const lastAssistantIndex = useMemo(() => {
     for (let i = displayItems.length - 1; i >= 0; i--) {
-      if (displayItems[i].type === "assistant") return i;
+      if (displayItems[i].message.role === "assistant") return i;
     }
     return -1;
   }, [displayItems]);
@@ -598,56 +551,216 @@ export default function MessageList({
       <div className="max-w-4xl mx-auto px-4 md:px-8 py-10 space-y-12">
         {displayItems.map((item, idx) => {
           const isLast = idx === displayItems.length - 1;
-          if (item.type === "user") {
-            const m = item.message;
+          const { message: m, siblings, activeIndex } = item;
+          const totalVersions = siblings.length;
+          const versionKey = m.parent_id || `${m.conversation_id}_root`;
+
+          if (m.role === "user") {
+            const isEditing = editingId === m.id;
             return (
-              <div key={m.id} className="group flex flex-col items-end">
-                <div className="max-w-[90%] rounded-2xl px-5 py-3.5 text-[15px] md:text-base leading-relaxed bg-black/5 dark:bg-white/5 text-gray-900 dark:text-white/95">
-                  <p className="whitespace-pre-wrap">{m.content}</p>
-                </div>
-                <div className="mt-2 flex items-center gap-1">
-                  {m.content && (
-                    <button
-                      onClick={() => handleCopy(m.id, m.content)}
-                      className={`p-1.5 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? 'md:opacity-100' : 'md:opacity-0 md:group-hover:opacity-100 focus:opacity-100'}`}
-                      aria-label="Copy message"
+              <div key={m.id} className="group flex flex-col items-end w-full">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-white/40">
+                    You
+                  </span>
+                  <div className="w-6 h-6 rounded-full bg-black dark:bg-white flex items-center justify-center">
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      className="w-3.5 h-3.5 stroke-[2.5] text-white dark:text-black"
                     >
-                      {copiedId === m.id ? (
-                        <span className="text-[#34C759] text-[10px] font-bold">✓</span>
-                      ) : (
-                        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2"
+                      />
+                      <circle cx="12" cy="7" r="4" />
+                    </svg>
+                  </div>
+                </div>
+
+                {isEditing ? (
+                  <div className="w-full max-w-3xl bg-white dark:bg-[#2d2d2d] border border-black/10 dark:border-white/10 rounded-2xl p-3 shadow-lg">
+                    <textarea
+                      ref={editInputRef}
+                      value={editContent}
+                      onChange={(e) => {
+                        setEditContent(e.target.value);
+                        e.target.style.height = "auto";
+                        e.target.style.height = `${e.target.scrollHeight}px`;
+                      }}
+                      className="w-full bg-transparent text-[15px] md:text-[16px] text-gray-900 dark:text-white/95 border-none outline-none resize-none min-h-[100px]"
+                      placeholder="Edit your message..."
+                    />
+                    <div className="flex justify-end gap-2 mt-3">
+                      <button
+                        onClick={() => setEditingId(null)}
+                        className="px-4 py-1.5 rounded-full text-sm font-medium text-gray-600 hover:bg-black/5 dark:text-white/70 dark:hover:bg-white/10 transition-colors"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        onClick={() => {
+                          if (editContent.trim() !== m.content && onEdit) {
+                            onEdit(m.id, editContent.trim());
+                          }
+                          setEditingId(null);
+                        }}
+                        disabled={!editContent.trim() || editContent.trim() === m.content}
+                        className="px-4 py-1.5 rounded-full text-sm font-medium bg-black text-white hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      >
+                        Save & Submit
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <div className="bg-[#f4f4f5] dark:bg-white/10 rounded-2xl rounded-tr-sm px-5 py-3.5 max-w-[85%] sm:max-w-[75%] text-[15px] md:text-[16px] leading-relaxed text-gray-900 dark:text-white/95">
+                    <MarkdownRenderer content={m.content} />
+                  </div>
+                )}
+
+                {!isEditing && (
+                  <div className="mt-2 flex items-center gap-1">
+                    {totalVersions > 1 && (
+                      <div className="flex items-center gap-0.5 mr-2 bg-black/5 dark:bg-white/5 rounded-md px-1 py-0.5">
+                        <button
+                          onClick={() => {
+                            if (activeIndex > 0) {
+                              onVersionChange?.(versionKey, siblings[activeIndex - 1].id);
+                            }
+                          }}
+                          disabled={activeIndex === 0}
+                          className="w-5 h-5 flex items-center justify-center rounded text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 disabled:opacity-30 transition-colors cursor-pointer"
+                        >
+                          <svg
+                            className="w-3 h-3"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            strokeWidth="2.5"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M15 19l-7-7 7-7"
+                            />
+                          </svg>
+                        </button>
+                        <span className="text-[10px] text-gray-400 dark:text-white/40 font-bold tabular-nums min-w-[2rem] text-center uppercase">
+                          {activeIndex + 1} / {totalVersions}
+                        </span>
+                        <button
+                          onClick={() => {
+                            if (activeIndex < totalVersions - 1) {
+                              onVersionChange?.(versionKey, siblings[activeIndex + 1].id);
+                            }
+                          }}
+                          disabled={activeIndex === totalVersions - 1}
+                          className="w-5 h-5 flex items-center justify-center rounded text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 disabled:opacity-30 transition-colors cursor-pointer"
+                        >
+                          <svg
+                            className="w-3 h-3"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            strokeWidth="2.5"
+                          >
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+                          </svg>
+                        </button>
+                      </div>
+                    )}
+
+                    {!isStreaming && (
+                      <button
+                        onClick={() => {
+                          setEditContent(m.content);
+                          setEditingId(m.id);
+                        }}
+                        className={`p-1.5 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? "md:opacity-100" : "md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"}`}
+                        aria-label="Edit message"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="2"
+                            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                          />
                         </svg>
-                      )}
-                    </button>
-                  )}
-                  {!isStreaming && onDelete && (
-                    <button
-                      onClick={() =>
-                        setDeleteTarget({ id: m.id, role: "user", isLastVersion: false })
-                      }
-                      className={`p-1.5 text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? 'md:opacity-100' : 'md:opacity-0 md:group-hover:opacity-100 focus:opacity-100'}`}
-                      aria-label="Delete message"
-                    >
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                      </svg>
-                    </button>
-                  )}
-                </div>
+                      </button>
+                    )}
+
+                    {m.content && (
+                      <button
+                        onClick={() => handleCopy(m.id, m.content)}
+                        className={`p-1.5 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? "md:opacity-100" : "md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"}`}
+                        aria-label="Copy message"
+                      >
+                        {copiedId === m.id ? (
+                          <span className="text-[#34C759] text-[10px] font-bold">✓</span>
+                        ) : (
+                          <svg
+                            className="w-4 h-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth="2"
+                              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                            />
+                          </svg>
+                        )}
+                      </button>
+                    )}
+                    {!isStreaming && onDelete && (
+                      <button
+                        onClick={() =>
+                          setDeleteTarget({ id: m.id, role: "user", isLastVersion: false })
+                        }
+                        className={`p-1.5 text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? "md:opacity-100" : "md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"}`}
+                        aria-label="Delete message"
+                      >
+                        <svg
+                          className="w-4 h-4"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="2"
+                            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          />
+                        </svg>
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
             );
           }
 
           // Assistant group
-          const { parentId, siblings, activeMessage: m, activeIndex } = item;
-          const totalVersions = siblings.length;
           const itemIndex = idx;
+          const lastAssistantIndex = displayItems.findLastIndex(
+            (i) => i.message.role === "assistant",
+          );
           const isCurrentlyStreaming =
             isStreaming && m.content === "" && itemIndex === lastAssistantIndex;
 
           return (
-            <div key={parentId} className="group flex flex-col items-start w-full">
+            <div key={m.id} className="group flex flex-col items-start w-full">
               <div className="flex items-center gap-2 mb-4">
                 <div className="w-6 h-6 rounded-full bg-black/5 dark:bg-white/10 flex items-center justify-center">
                   <img src="/waichat.webp" alt="WaiChat" className="w-4 h-4" />
@@ -675,7 +788,7 @@ export default function MessageList({
                     <button
                       onClick={() => {
                         if (activeIndex > 0) {
-                          onVersionChange?.(parentId, siblings[activeIndex - 1].id);
+                          onVersionChange?.(versionKey, siblings[activeIndex - 1].id);
                         }
                       }}
                       disabled={activeIndex === 0}
@@ -698,7 +811,7 @@ export default function MessageList({
                     <button
                       onClick={() => {
                         if (activeIndex < totalVersions - 1) {
-                          onVersionChange?.(parentId, siblings[activeIndex + 1].id);
+                          onVersionChange?.(versionKey, siblings[activeIndex + 1].id);
                         }
                       }}
                       disabled={activeIndex === totalVersions - 1}
@@ -721,14 +834,24 @@ export default function MessageList({
                 {m.content && (
                   <button
                     onClick={() => handleCopy(m.id, m.content)}
-                    className={`p-1.5 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? 'md:opacity-100' : 'md:opacity-0 md:group-hover:opacity-100 focus:opacity-100'}`}
+                    className={`p-1.5 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? "md:opacity-100" : "md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"}`}
                     aria-label="Copy message"
                   >
                     {copiedId === m.id ? (
                       <span className="text-[#34C759] text-[10px] font-bold">✓</span>
                     ) : (
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+                        />
                       </svg>
                     )}
                   </button>
@@ -737,11 +860,16 @@ export default function MessageList({
                 {m.content && !isStreaming && onRetry && (
                   <button
                     onClick={() => onRetry(m.id)}
-                    className={`p-1.5 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? 'md:opacity-100' : 'md:opacity-0 md:group-hover:opacity-100 focus:opacity-100'}`}
+                    className={`p-1.5 text-gray-400 hover:text-gray-600 dark:text-white/40 dark:hover:text-white/80 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? "md:opacity-100" : "md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"}`}
                     aria-label="Retry response"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                      />
                     </svg>
                   </button>
                 )}
@@ -755,11 +883,16 @@ export default function MessageList({
                         isLastVersion: totalVersions === 1 && !!m.parent_id,
                       })
                     }
-                    className={`p-1.5 text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? 'md:opacity-100' : 'md:opacity-0 md:group-hover:opacity-100 focus:opacity-100'}`}
+                    className={`p-1.5 text-gray-400 hover:text-red-500 dark:text-white/40 dark:hover:text-red-400 transition-opacity flex items-center justify-center cursor-pointer ${isLast ? "md:opacity-100" : "md:opacity-0 md:group-hover:opacity-100 focus:opacity-100"}`}
                     aria-label="Delete response"
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth="2"
+                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                      />
                     </svg>
                   </button>
                 )}

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -752,12 +752,8 @@ export default function MessageList({
           }
 
           // Assistant group
-          const itemIndex = idx;
-          const lastAssistantIndex = displayItems.findLastIndex(
-            (i) => i.message.role === "assistant",
-          );
           const isCurrentlyStreaming =
-            isStreaming && m.content === "" && itemIndex === lastAssistantIndex;
+            isStreaming && m.content === "" && idx === lastAssistantIndex;
 
           return (
             <div key={m.id} className="group flex flex-col items-start w-full">

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -590,7 +590,7 @@ export default function MessageList({
                         e.target.style.height = "auto";
                         e.target.style.height = `${e.target.scrollHeight}px`;
                       }}
-                      className="w-full bg-transparent text-[15px] md:text-[16px] text-gray-900 dark:text-white/95 border-none outline-none resize-none min-h-[100px]"
+                      className="w-full bg-transparent text-[15px] md:text-[16px] text-gray-900 dark:text-white/95 border-none outline-none resize-none min-h-[100px] max-h-[500px] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
                       placeholder="Edit your message..."
                     />
                     <div className="flex justify-end gap-2 mt-3">

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -563,12 +563,12 @@ export default function MessageList({
                   <span className="text-xs font-bold uppercase tracking-wider text-gray-500 dark:text-white/40">
                     You
                   </span>
-                  <div className="w-6 h-6 rounded-full bg-black dark:bg-white flex items-center justify-center">
+                  <div className="w-6 h-6 rounded-full bg-black/5 dark:bg-white/10 flex items-center justify-center">
                     <svg
                       viewBox="0 0 24 24"
                       fill="none"
                       stroke="currentColor"
-                      className="w-3.5 h-3.5 stroke-[2.5] text-white dark:text-black"
+                      className="w-3.5 h-3.5 stroke-[2.5] text-gray-500 dark:text-white/80"
                     >
                       <path
                         strokeLinecap="round"
@@ -608,7 +608,7 @@ export default function MessageList({
                           setEditingId(null);
                         }}
                         disabled={!editContent.trim() || editContent.trim() === m.content}
-                        className="px-4 py-1.5 rounded-full text-sm font-medium bg-black text-white hover:bg-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        className="px-4 py-1.5 rounded-full text-sm font-medium bg-black/5 dark:bg-white/10 text-gray-600 dark:text-white/80 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black disabled:opacity-50 disabled:hover:bg-black/5 disabled:hover:text-gray-600 dark:disabled:hover:bg-white/10 dark:disabled:hover:text-white/80 disabled:cursor-not-allowed transition-all duration-200"
                       >
                         Save & Submit
                       </button>

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -173,18 +173,18 @@ export function useChat(
     }
   }, []);
 
-  const setActiveVersionCb = useCallback(
-    (parentId: string, messageId: string) => {
-      setActiveVersions((prev) => {
-        const next = { ...prev, [parentId]: messageId };
-        if (activeConversation) {
-          localStorage.setItem(`waichat:versions:${activeConversation.id}`, JSON.stringify(next));
-        }
-        return next;
-      });
-    },
-    [activeConversation],
-  );
+  useEffect(() => {
+    if (activeConversation) {
+      localStorage.setItem(
+        `waichat:versions:${activeConversation.id}`,
+        JSON.stringify(activeVersions),
+      );
+    }
+  }, [activeVersions, activeConversation]);
+
+  const setActiveVersionCb = useCallback((parentId: string, messageId: string) => {
+    setActiveVersions((prev) => ({ ...prev, [parentId]: messageId }));
+  }, []);
 
   /**
    * Build the linear message history by traversing the tree.
@@ -208,6 +208,7 @@ export function useChat(
 
       const result: Message[] = [];
       let currentParentId: string | null = null;
+      const visited = new Set<string>();
 
       while (true) {
         const siblings = childrenMap.get(currentParentId);
@@ -227,6 +228,9 @@ export function useChat(
           // Since allMessages is sorted by created_at, the last one in siblings is the latest
           activeChild = siblings[siblings.length - 1];
         }
+
+        if (visited.has(activeChild.id)) break;
+        visited.add(activeChild.id);
 
         result.push(activeChild);
         currentParentId = activeChild.id;
@@ -375,9 +379,10 @@ export function useChat(
       setIsStreaming(true);
 
       try {
-        const contextMessages = [...activeBranch, userMessage]
-          .slice(-20) // context truncation strategy
-          .map((m) => ({ role: m.role, content: m.content }));
+        const contextMessages = [...activeBranch, userMessage].map((m) => ({
+          role: m.role,
+          content: m.content,
+        }));
 
         const fullContent = await streamResponse(
           contextMessages,
@@ -491,9 +496,10 @@ export function useChat(
         const targetIndex = activeBranch.findIndex((m) => m.id === targetMessageId);
         const priorBranch = targetIndex >= 0 ? activeBranch.slice(0, targetIndex) : [];
 
-        const contextMessages = [...priorBranch, userMessage]
-          .slice(-20) // truncate oldest first
-          .map((m) => ({ role: m.role, content: m.content }));
+        const contextMessages = [...priorBranch, userMessage].map((m) => ({
+          role: m.role,
+          content: m.content,
+        }));
 
         const fullContent = await streamResponse(
           contextMessages,
@@ -559,9 +565,7 @@ export function useChat(
         const targetUserIndex = activeBranch.findIndex((m) => m.id === assistantParentId);
         const priorBranch = targetUserIndex >= 0 ? activeBranch.slice(0, targetUserIndex + 1) : [];
 
-        const contextMessages = priorBranch
-          .slice(-20)
-          .map((m) => ({ role: m.role, content: m.content }));
+        const contextMessages = priorBranch.map((m) => ({ role: m.role, content: m.content }));
 
         const fullContent = await streamResponse(
           contextMessages,

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -521,6 +521,8 @@ export function useChat(
         setMessages((prev) =>
           prev.filter((m) => m.id !== assistantMessage.id && m.id !== userMessage.id),
         );
+        const rootKey = `${conversationId}_root`;
+        setActiveVersionCb(userParentId || rootKey, targetMessageId);
       } finally {
         setIsStreaming(false);
         abortControllerRef.current = null;
@@ -555,7 +557,8 @@ export function useChat(
       };
 
       // Set it as the active version
-      setActiveVersionCb(assistantParentId!, newAssistantMessage.id);
+      const rootKey = `${conversationId}_root`;
+      setActiveVersionCb(assistantParentId || rootKey, newAssistantMessage.id);
 
       setMessages((prev) => [...prev, newAssistantMessage]);
       setIsStreaming(true);
@@ -586,7 +589,8 @@ export function useChat(
         // Remove the failed placeholder
         setMessages((prev) => prev.filter((m) => m.id !== newAssistantMessage.id));
         // Revert active version to the one the user was viewing
-        setActiveVersionCb(assistantParentId!, messageId);
+        const rootKey = `${conversationId}_root`;
+        setActiveVersionCb(assistantParentId || rootKey, messageId);
       } finally {
         setIsStreaming(false);
         abortControllerRef.current = null;

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -6,6 +6,7 @@ interface UseChatReturn {
   conversations: Conversation[];
   activeConversation: Conversation | null;
   messages: Message[];
+  activeBranch: Message[];
   isStreaming: boolean;
   error: string | null;
   activeVersions: Record<string, string>;
@@ -20,6 +21,14 @@ interface UseChatReturn {
     model: string,
     conversationId: string,
     storageMode: StorageMode,
+    systemPrompt?: string,
+  ) => Promise<void>;
+  editMessage: (
+    conversationId: string,
+    model: string,
+    content: string,
+    targetMessageId: string,
+    storageMode: "local" | "cloud",
     systemPrompt?: string,
   ) => Promise<void>;
   stopGeneration: () => void;
@@ -61,10 +70,7 @@ export function useChat(
   }, [storageMode]);
 
   useEffect(() => {
-    if (
-      selectAfterModeChangeRef.current &&
-      pendingSelectionRef?.current
-    ) {
+    if (selectAfterModeChangeRef.current && pendingSelectionRef?.current) {
       const id = pendingSelectionRef.current;
       pendingSelectionRef.current = null;
       selectAfterModeChangeRef.current = false;
@@ -94,7 +100,12 @@ export function useChat(
         if (!data) return;
         setActiveConversation(data.conversation);
         setMessages(data.messages);
-        setActiveVersions({});
+        try {
+          const stored = localStorage.getItem(`waichat:versions:${id}`);
+          setActiveVersions(stored ? JSON.parse(stored) : {});
+        } catch {
+          setActiveVersions({});
+        }
       } catch {
         setError("Failed to load conversation");
       }
@@ -117,6 +128,7 @@ export function useChat(
   const deleteConversation = useCallback(
     async (id: string) => {
       await storage.deleteConversation(id);
+      localStorage.removeItem(`waichat:versions:${id}`);
       setConversations((prev) => prev.filter((c) => c.id !== id));
       if (activeConversation?.id === id) {
         setActiveConversation(null);
@@ -161,79 +173,75 @@ export function useChat(
     }
   }, []);
 
-  const setActiveVersionCb = useCallback((parentId: string, messageId: string) => {
-    setActiveVersions((prev) => ({ ...prev, [parentId]: messageId }));
-  }, []);
+  const setActiveVersionCb = useCallback(
+    (parentId: string, messageId: string) => {
+      setActiveVersions((prev) => {
+        const next = { ...prev, [parentId]: messageId };
+        if (activeConversation) {
+          localStorage.setItem(`waichat:versions:${activeConversation.id}`, JSON.stringify(next));
+        }
+        return next;
+      });
+    },
+    [activeConversation],
+  );
 
   /**
-   * Build the message history for the AI, using the active version of each assistant turn.
-   * Messages that are retry siblings (have parent_id) are excluded unless they are the active version.
+   * Build the linear message history by traversing the tree.
+   * Starts from the root (parent_id = null) and follows the active versions.
    */
-  const buildContextMessages = useCallback(
-    (allMessages: Message[], upToIndex: number, currentActiveVersions: Record<string, string>) => {
-      // Collect all sibling groups
-      const siblingGroups = new Map<string, Message[]>();
+  const getActiveBranch = useCallback(
+    (
+      allMessages: Message[],
+      currentActiveVersions: Record<string, string>,
+      rootKey: string,
+    ): Message[] => {
+      // Group messages by their parent_id
+      const childrenMap = new Map<string | null, Message[]>();
       for (const m of allMessages) {
-        if (m.parent_id) {
-          const group = siblingGroups.get(m.parent_id) || [];
-          group.push(m);
-          siblingGroups.set(m.parent_id, group);
-        }
+        if (m.deleted_at) continue; // skip soft-deleted
+        const pId = m.parent_id || null;
+        const group = childrenMap.get(pId) || [];
+        group.push(m);
+        childrenMap.set(pId, group);
       }
 
-      const result: { role: string; content: string }[] = [];
+      const result: Message[] = [];
+      let currentParentId: string | null = null;
 
-      for (let i = 0; i <= upToIndex; i++) {
-        const m = allMessages[i];
+      while (true) {
+        const siblings = childrenMap.get(currentParentId);
+        if (!siblings || siblings.length === 0) break;
 
-        if (m.role === "user") {
-          result.push({ role: m.role, content: m.content });
-          continue;
+        // Determine active child for this parent
+        const versionKey: string = currentParentId === null ? rootKey : currentParentId;
+        const activeId: string | undefined = currentActiveVersions[versionKey];
+
+        let activeChild: Message | undefined;
+        if (activeId) {
+          activeChild = siblings.find((s) => s.id === activeId);
         }
 
-        // Assistant message
-        // Skip retry siblings in the main loop; they are handled via their parent
-        if (m.parent_id) {
-          continue;
+        // Default to the most recently created sibling if none is explicitly selected
+        if (!activeChild) {
+          // Since allMessages is sorted by created_at, the last one in siblings is the latest
+          activeChild = siblings[siblings.length - 1];
         }
 
-        // Original assistant message (no parent_id)
-        const siblings = siblingGroups.get(m.id);
-        if (siblings && siblings.length > 0) {
-          // This message has retries. Check if one of the retries is the active version.
-          const activeId = currentActiveVersions[m.id];
-          if (activeId && activeId !== m.id) {
-            // A retry is active, the retry itself will be included when we encounter it
-            // But since retries come after in the array and we process in order,
-            // we need to include the active one here
-            const activeMsg = siblings.find((s) => s.id === activeId);
-            if (activeMsg) {
-              result.push({ role: activeMsg.role, content: activeMsg.content });
-            } else {
-              // Fallback to original
-              result.push({ role: m.role, content: m.content });
-            }
-          } else {
-            // Original is active (or no explicit selection - default to latest)
-            if (!activeId) {
-              // Default: use the latest sibling
-              const latest = siblings[siblings.length - 1];
-              result.push({ role: latest.role, content: latest.content });
-            } else {
-              // activeId === m.id, so original is explicitly selected
-              result.push({ role: m.role, content: m.content });
-            }
-          }
-        } else {
-          // No retries, just include it
-          result.push({ role: m.role, content: m.content });
-        }
+        result.push(activeChild);
+        currentParentId = activeChild.id;
       }
 
       return result;
     },
     [],
   );
+
+  const activeBranch = useMemo(() => {
+    if (!activeConversation) return [];
+    const rootKey = `${activeConversation.id}_root`;
+    return getActiveBranch(messages, activeVersions, rootKey);
+  }, [messages, activeVersions, activeConversation, getActiveBranch]);
 
   /**
    * Stream a response from the API, updating the placeholder message as tokens arrive.
@@ -249,6 +257,7 @@ export function useChat(
       systemPrompt?: string,
       parentId?: string,
       userMessageId?: string,
+      userParentId?: string,
     ) => {
       const abortController = new AbortController();
       abortControllerRef.current = abortController;
@@ -264,6 +273,7 @@ export function useChat(
           storage_mode: currentStorageMode,
           system_prompt: systemPrompt || undefined,
           parent_id: parentId || undefined,
+          user_parent_id: userParentId || undefined,
           user_message_id: userMessageId || undefined,
           assistant_message_id: assistantMessageId || undefined,
         }),
@@ -335,12 +345,16 @@ export function useChat(
       if (isStreaming) return;
       setError(null);
 
+      const userParentId =
+        activeBranch.length > 0 ? activeBranch[activeBranch.length - 1].id : undefined;
+
       const userMessage: Message = {
         id: crypto.randomUUID(),
         conversation_id: conversationId,
         role: "user",
         content,
         created_at: Date.now(),
+        parent_id: userParentId,
       };
 
       const assistantMessage: Message = {
@@ -350,23 +364,20 @@ export function useChat(
         content: "",
         created_at: Date.now(),
         model,
+        parent_id: userMessage.id,
       };
+
+      // Set it as active
+      const rootKey = `${conversationId}_root`;
+      setActiveVersionCb(userParentId || rootKey, userMessage.id);
 
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
       setIsStreaming(true);
 
       try {
-        const allMessages = [...messages, userMessage].map(({ role, content }) => ({
-          role,
-          content,
-        }));
-
-        // For context, we need to use buildContextMessages to respect active versions
-        // But for sendMessage the simple approach works since we're appending
-        const contextMessages = [
-          ...buildContextMessages(messages, messages.length - 1, activeVersions),
-          { role: userMessage.role, content: userMessage.content },
-        ];
+        const contextMessages = [...activeBranch, userMessage]
+          .slice(-20) // context truncation strategy
+          .map((m) => ({ role: m.role, content: m.content }));
 
         const fullContent = await streamResponse(
           contextMessages,
@@ -375,19 +386,14 @@ export function useChat(
           model,
           storageMode,
           systemPrompt,
-          undefined,
+          assistantMessage.parent_id,
           userMessage.id,
+          userMessage.parent_id,
         );
 
         // Save whatever we got (full or partial)
-        await storage.saveMessage({ id: userMessage.id, conversation_id: conversationId, role: "user", content });
-        await storage.saveMessage({
-          id: assistantMessage.id,
-          conversation_id: conversationId,
-          role: "assistant",
-          content: fullContent,
-          model,
-        });
+        await storage.saveMessage(userMessage);
+        await storage.saveMessage({ ...assistantMessage, content: fullContent });
 
         if (messages.length === 0 && storageMode === "local" && fullContent) {
           try {
@@ -433,7 +439,88 @@ export function useChat(
         abortControllerRef.current = null;
       }
     },
-    [isStreaming, messages, storage, activeVersions, buildContextMessages, streamResponse],
+    [isStreaming, messages, storage, activeBranch, setActiveVersionCb, streamResponse],
+  );
+
+  const editMessage = useCallback(
+    async (
+      conversationId: string,
+      model: string,
+      content: string,
+      targetMessageId: string,
+      storageMode: "local" | "cloud",
+      systemPrompt?: string,
+    ) => {
+      if (isStreaming) return;
+      setError(null);
+
+      const targetMsg = messages.find((m) => m.id === targetMessageId);
+      if (!targetMsg) return;
+
+      const userParentId = targetMsg.parent_id;
+
+      const userMessage: Message = {
+        id: crypto.randomUUID(),
+        conversation_id: conversationId,
+        role: "user",
+        content,
+        created_at: Date.now(),
+        parent_id: userParentId,
+      };
+
+      const assistantMessage: Message = {
+        id: crypto.randomUUID(),
+        conversation_id: conversationId,
+        role: "assistant",
+        content: "",
+        created_at: Date.now(),
+        model,
+        parent_id: userMessage.id,
+      };
+
+      // Set the newly created user message as the active version for its parent
+      const rootKey = `${conversationId}_root`;
+      const versionKey = userParentId || rootKey;
+      setActiveVersionCb(versionKey, userMessage.id);
+
+      setMessages((prev) => [...prev, userMessage, assistantMessage]);
+      setIsStreaming(true);
+
+      try {
+        // Calculate the branch up to this new message
+        const targetIndex = activeBranch.findIndex((m) => m.id === targetMessageId);
+        const priorBranch = targetIndex >= 0 ? activeBranch.slice(0, targetIndex) : [];
+
+        const contextMessages = [...priorBranch, userMessage]
+          .slice(-20) // truncate oldest first
+          .map((m) => ({ role: m.role, content: m.content }));
+
+        const fullContent = await streamResponse(
+          contextMessages,
+          assistantMessage.id,
+          conversationId,
+          model,
+          storageMode,
+          systemPrompt,
+          assistantMessage.parent_id,
+          userMessage.id,
+          userMessage.parent_id,
+        );
+
+        await storage.saveMessage(userMessage);
+        await storage.saveMessage({ ...assistantMessage, content: fullContent });
+      } catch (e) {
+        console.error("[editMessage] error:", e);
+        setError("Failed to edit message");
+        setMessages((prev) =>
+          prev.filter((m) => m.id !== assistantMessage.id && m.id !== userMessage.id),
+        );
+      } finally {
+        setIsStreaming(false);
+        abortControllerRef.current = null;
+      }
+    },
+    [isStreaming, messages, storage, activeBranch, setActiveVersionCb, streamResponse],
   );
 
   const retryMessage = useCallback(
@@ -447,24 +534,8 @@ export function useChat(
 
       const conversationId = targetMsg.conversation_id;
 
-      // Determine the parent_id for the new sibling
-      const parentId = targetMsg.parent_id || targetMsg.id;
-
-      // Find the user message that precedes this assistant turn.
-      // We need to find the index of the original (parent) message to locate its preceding user msg.
-      const originalId = targetMsg.parent_id || targetMsg.id;
-      const originalIndex = messages.findIndex((m) => m.id === originalId);
-      if (originalIndex < 0) return;
-
-      // The user message is the one right before the original assistant message
-      let userMsgIndex = originalIndex - 1;
-      while (userMsgIndex >= 0 && messages[userMsgIndex].role !== "user") {
-        userMsgIndex--;
-      }
-      if (userMsgIndex < 0) return;
-
-      // Build context: everything up to and including the user message
-      const contextMessages = buildContextMessages(messages, userMsgIndex, activeVersions);
+      // In the new tree model, the assistant message's parent is the preceding user message
+      const assistantParentId = targetMsg.parent_id;
 
       // Create new placeholder assistant message
       const newAssistantMessage: Message = {
@@ -474,16 +545,24 @@ export function useChat(
         content: "",
         created_at: Date.now(),
         model,
-        parent_id: parentId,
+        parent_id: assistantParentId,
       };
 
-      // Append the new sibling to messages (don't remove old ones)
-      setMessages((prev) => [...prev, newAssistantMessage]);
       // Set it as the active version
-      setActiveVersions((prev) => ({ ...prev, [parentId]: newAssistantMessage.id }));
+      setActiveVersionCb(assistantParentId!, newAssistantMessage.id);
+
+      setMessages((prev) => [...prev, newAssistantMessage]);
       setIsStreaming(true);
 
       try {
+        // Calculate the active branch up to the parent user message
+        const targetUserIndex = activeBranch.findIndex((m) => m.id === assistantParentId);
+        const priorBranch = targetUserIndex >= 0 ? activeBranch.slice(0, targetUserIndex + 1) : [];
+
+        const contextMessages = priorBranch
+          .slice(-20)
+          .map((m) => ({ role: m.role, content: m.content }));
+
         const fullContent = await streamResponse(
           contextMessages,
           newAssistantMessage.id,
@@ -491,34 +570,25 @@ export function useChat(
           model,
           storageMode,
           systemPrompt,
-          parentId,
+          newAssistantMessage.parent_id,
+          undefined,
           undefined,
         );
 
-        // Save the new retry version (local mode only - cloud saves server-side)
-        if (storageMode === "local") {
-          await storage.saveMessage({
-            id: newAssistantMessage.id,
-            conversation_id: conversationId,
-            role: "assistant",
-            content: fullContent,
-            model,
-            parent_id: parentId,
-          });
-        }
+        await storage.saveMessage({ ...newAssistantMessage, content: fullContent });
       } catch (e) {
         console.error("[retryMessage] error:", e);
         setError("Failed to retry message");
         // Remove the failed placeholder
         setMessages((prev) => prev.filter((m) => m.id !== newAssistantMessage.id));
         // Revert active version to the one the user was viewing
-        setActiveVersions((prev) => ({ ...prev, [parentId]: messageId }));
+        setActiveVersionCb(assistantParentId!, messageId);
       } finally {
         setIsStreaming(false);
         abortControllerRef.current = null;
       }
     },
-    [isStreaming, messages, storage, activeVersions, buildContextMessages, streamResponse],
+    [isStreaming, messages, storage, activeBranch, setActiveVersionCb, streamResponse],
   );
 
   const deleteMessageCb = useCallback(
@@ -562,6 +632,7 @@ export function useChat(
     conversations,
     activeConversation,
     messages,
+    activeBranch,
     isStreaming,
     error,
     activeVersions,
@@ -572,6 +643,7 @@ export function useChat(
     updateActiveModel,
     clearConversation,
     sendMessage,
+    editMessage,
     stopGeneration,
     retryMessage,
     setActiveVersion: setActiveVersionCb,

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -61,7 +61,7 @@ export class LocalStorage implements StorageAdapter {
     this.setConversations(conversations);
     localStorage.removeItem(MESSAGES_KEY(id));
   }
-  
+
   async updateConversationModel(id: string, model: string): Promise<void> {
     const conversations = this.getConversationsRaw().map((c) =>
       c.id === id ? { ...c, model, updated_at: Date.now() } : c,
@@ -99,55 +99,20 @@ export class LocalStorage implements StorageAdapter {
     const msg = messages.find((m) => m.id === messageId);
     if (!msg) return { deletedIds: [], softDeletedIds: [] };
 
-    const deletedIds: string[] = [];
-    const softDeletedIds: string[] = [];
-
-    if (msg.role === "user") {
-      // Cascade: also delete the assistant turn below
-      const userIdx = messages.findIndex((m) => m.id === messageId);
-      for (let i = userIdx + 1; i < messages.length; i++) {
-        const m = messages[i];
-        if (m.role === "user") break;
-        if (m.role === "assistant" && !m.parent_id) {
-          // Delete all retry siblings
-          const siblings = messages.filter((s) => s.parent_id === m.id);
-          for (const s of siblings) deletedIds.push(s.id);
-          deletedIds.push(m.id);
-          break;
+    const descendants = new Set<string>();
+    const findDescendants = (parentId: string) => {
+      for (const m of messages) {
+        if (m.parent_id === parentId) {
+          descendants.add(m.id);
+          findDescendants(m.id);
         }
       }
-      deletedIds.push(messageId);
-    } else {
-      // Assistant message
-      if (msg.parent_id) {
-        // Retry sibling - hard-delete
-        deletedIds.push(messageId);
+    };
 
-        // Check if parent is now orphaned
-        const remainingSiblings = messages.filter(
-          (m) => m.parent_id === msg.parent_id && m.id !== messageId,
-        );
-        if (remainingSiblings.length === 0) {
-          const parent = messages.find((m) => m.id === msg.parent_id);
-          if (parent && parent.deleted_at) {
-            deletedIds.push(parent.id);
-          }
-        }
-      } else {
-        // Parent assistant message
-        const siblingCount = messages.filter((m) => m.parent_id === msg.id).length;
-        if (siblingCount > 0) {
-          // Soft-delete
-          softDeletedIds.push(msg.id);
-        } else {
-          // Solo — hard-delete
-          deletedIds.push(msg.id);
-        }
-      }
-    }
+    descendants.add(messageId);
+    findDescendants(messageId);
 
-    // Apply deletions
-    messages = messages.filter((m) => !deletedIds.includes(m.id));
+    const softDeletedIds = Array.from(descendants);
 
     // Apply soft-deletes
     messages = messages.map((m) =>
@@ -162,7 +127,7 @@ export class LocalStorage implements StorageAdapter {
     );
     this.setConversations(conversations);
 
-    return { deletedIds, softDeletedIds };
+    return { deletedIds: [], softDeletedIds };
   }
 
   async exportConversation(

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -99,18 +99,23 @@ export class LocalStorage implements StorageAdapter {
     const msg = messages.find((m) => m.id === messageId);
     if (!msg) return { deletedIds: [], softDeletedIds: [] };
 
-    const descendants = new Set<string>();
-    const findDescendants = (parentId: string) => {
-      for (const m of messages) {
-        if (m.parent_id === parentId) {
-          descendants.add(m.id);
-          findDescendants(m.id);
-        }
-      }
-    };
+    const childrenMap = new Map<string | null, string[]>();
+    for (const m of messages) {
+      const pId = m.parent_id || null;
+      const children = childrenMap.get(pId) || [];
+      children.push(m.id);
+      childrenMap.set(pId, children);
+    }
 
-    descendants.add(messageId);
-    findDescendants(messageId);
+    const descendants = new Set<string>();
+    const stack = [messageId];
+    while (stack.length > 0) {
+      const currentId = stack.pop()!;
+      if (descendants.has(currentId)) continue;
+      descendants.add(currentId);
+      const children = childrenMap.get(currentId);
+      if (children) stack.push(...children);
+    }
 
     const softDeletedIds = Array.from(descendants);
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -261,18 +261,23 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
     }
 
     // Find all descendants in memory
-    const descendants = new Set<string>();
-    const findDescendants = (parentId: string) => {
-      for (const m of allMessages) {
-        if (m.parent_id === parentId) {
-          descendants.add(m.id);
-          findDescendants(m.id);
-        }
-      }
-    };
+    const childrenMap = new Map<string | null, string[]>();
+    for (const m of allMessages) {
+      const pId = m.parent_id || null;
+      const children = childrenMap.get(pId) || [];
+      children.push(m.id);
+      childrenMap.set(pId, children);
+    }
 
-    descendants.add(messageId);
-    findDescendants(messageId);
+    const descendants = new Set<string>();
+    const stack = [messageId];
+    while (stack.length > 0) {
+      const currentId = stack.pop()!;
+      if (descendants.has(currentId)) continue;
+      descendants.add(currentId);
+      const children = childrenMap.get(currentId);
+      if (children) stack.push(...children);
+    }
 
     const softDeletedIds = Array.from(descendants);
     const statements: D1PreparedStatement[] = [];

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -281,13 +281,25 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
 
     const softDeletedIds = Array.from(descendants);
     const now = Date.now();
-    const placeholders = softDeletedIds.map(() => "?").join(",");
-    const statements: D1PreparedStatement[] = [
-      db
-        .prepare("UPDATE messages SET content = '', deleted_at = ? WHERE id IN (" + placeholders + ")")
-        .bind(now, ...softDeletedIds),
+    const statements: D1PreparedStatement[] = [];
+
+    // Chunk soft-deletes to respect D1's 100-parameter limit per statement
+    const CHUNK_SIZE = 90;
+    for (let i = 0; i < softDeletedIds.length; i += CHUNK_SIZE) {
+      const chunk = softDeletedIds.slice(i, i + CHUNK_SIZE);
+      const placeholders = chunk.map(() => "?").join(",");
+      statements.push(
+        db
+          .prepare(
+            "UPDATE messages SET content = '', deleted_at = ? WHERE id IN (" + placeholders + ")",
+          )
+          .bind(now, ...chunk),
+      );
+    }
+
+    statements.push(
       db.prepare("UPDATE conversations SET updated_at = ? WHERE id = ?").bind(now, conversationId),
-    ];
+    );
     await db.batch(statements);
 
     return c.json({ success: true, deletedIds: [], softDeletedIds });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -6,16 +6,13 @@ import {
   deleteConversation,
   getConversation,
   getConversations,
-  getMessageById,
   getMessages,
-  getSiblingCount,
+  getSetting,
   importConversation,
   saveMessage,
+  setSetting,
   updateConversationTimestamp,
   updateConversationTitle,
-  updateConversationModel,
-  getSetting,
-  setSetting,
 } from "./db";
 import type { ChatRequest, Env } from "./types";
 
@@ -174,8 +171,23 @@ app.get("/api/conversations/:id", async (c) => {
 app.post("/api/conversations/import", async (c) => {
   try {
     const { conversation, messages } = await c.req.json<{
-      conversation: { id: string; title: string; model: string; created_at: number; updated_at: number };
-      messages: { id: string; conversation_id: string; role: "user" | "assistant"; content: string; created_at: number; model?: string; parent_id?: string; deleted_at?: number }[];
+      conversation: {
+        id: string;
+        title: string;
+        model: string;
+        created_at: number;
+        updated_at: number;
+      };
+      messages: {
+        id: string;
+        conversation_id: string;
+        role: "user" | "assistant";
+        content: string;
+        created_at: number;
+        model?: string;
+        parent_id?: string;
+        deleted_at?: number;
+      }[];
     }>();
 
     if (!conversation?.id || !Array.isArray(messages)) {
@@ -235,90 +247,49 @@ app.patch("/api/conversations/:id", async (c) => {
   return c.json({ success: true });
 });
 
-// Delete a single message (with cascade / soft-delete logic)
+// Delete a single message (with recursive soft-delete logic for its sub-tree)
 app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) => {
   const { conversationId, messageId } = c.req.param();
   const db = c.env.DB;
 
   try {
-    const msg = await getMessageById(db, messageId);
-    if (!msg || msg.conversation_id !== conversationId) {
+    const allMessages = await getMessages(db, conversationId);
+    const targetMsg = allMessages.find((m) => m.id === messageId);
+
+    if (!targetMsg) {
       return c.json({ error: "Message not found" }, 404);
     }
 
-    const deletedIds: string[] = [];
-    const softDeletedIds: string[] = [];
+    // Find all descendants in memory
+    const descendants = new Set<string>();
+    const findDescendants = (parentId: string) => {
+      for (const m of allMessages) {
+        if (m.parent_id === parentId) {
+          descendants.add(m.id);
+          findDescendants(m.id);
+        }
+      }
+    };
+
+    descendants.add(messageId);
+    findDescendants(messageId);
+
+    const softDeletedIds = Array.from(descendants);
     const statements: D1PreparedStatement[] = [];
+    const now = Date.now();
 
-    if (msg.role === "user") {
-      // Deleting a user message also removes the assistant turn below it.
-      const allMessages = await getMessages(db, conversationId);
-      const userIdx = allMessages.findIndex((m) => m.id === messageId);
-
-      // Find the next assistant original message (no parent_id) after this user message
-      for (let i = userIdx + 1; i < allMessages.length; i++) {
-        const m = allMessages[i];
-        if (m.role === "user") break; // hit the next user turn, stop
-        if (m.role === "assistant" && !m.parent_id) {
-          // Delete all retry siblings of this assistant message
-          const siblings = allMessages.filter((s) => s.parent_id === m.id);
-          for (const s of siblings) {
-            statements.push(db.prepare("DELETE FROM messages WHERE id = ?").bind(s.id));
-            deletedIds.push(s.id);
-          }
-          // Delete the parent assistant message itself
-          statements.push(db.prepare("DELETE FROM messages WHERE id = ?").bind(m.id));
-          deletedIds.push(m.id);
-          break;
-        }
-      }
-
-      // Delete the user message
-      statements.push(db.prepare("DELETE FROM messages WHERE id = ?").bind(messageId));
-      deletedIds.push(messageId);
-    } else {
-      // Assistant message
-      if (msg.parent_id) {
-        // This is a retry sibling - hard-delete it
-        statements.push(db.prepare("DELETE FROM messages WHERE id = ?").bind(messageId));
-        deletedIds.push(messageId);
-
-        // Check if the parent is now orphaned
-        const remaining = await getSiblingCount(db, msg.parent_id);
-        // remaining includes the message we're about to delete, so check <= 1
-        if (remaining <= 1) {
-          // Check if parent was soft-deleted
-          const parent = await getMessageById(db, msg.parent_id);
-          if (parent && parent.deleted_at) {
-            // Parent was soft-deleted and has no siblings left - fully remove it
-            statements.push(db.prepare("DELETE FROM messages WHERE id = ?").bind(msg.parent_id));
-            deletedIds.push(msg.parent_id);
-          }
-        }
-      } else {
-        // This is a parent (original) assistant message
-        const siblingCount = await getSiblingCount(db, msg.id);
-        if (siblingCount > 0) {
-          // Has retry siblings - soft-delete (preserve for parent_id references)
-          statements.push(
-            db.prepare("UPDATE messages SET content = '', deleted_at = ? WHERE id = ?").bind(Date.now(), msg.id),
-          );
-          softDeletedIds.push(msg.id);
-        } else {
-          // Solo message - hard-delete
-          statements.push(db.prepare("DELETE FROM messages WHERE id = ?").bind(msg.id));
-          deletedIds.push(msg.id);
-        }
-      }
+    for (const id of softDeletedIds) {
+      statements.push(
+        db.prepare("UPDATE messages SET content = '', deleted_at = ? WHERE id = ?").bind(now, id),
+      );
     }
 
-    // Execute all mutations in a single batch round-trip
     statements.push(
-      db.prepare("UPDATE conversations SET updated_at = ? WHERE id = ?").bind(Date.now(), conversationId),
+      db.prepare("UPDATE conversations SET updated_at = ? WHERE id = ?").bind(now, conversationId),
     );
     await db.batch(statements);
 
-    return c.json({ success: true, deletedIds, softDeletedIds });
+    return c.json({ success: true, deletedIds: [], softDeletedIds });
   } catch (e) {
     console.error("[DELETE /message] error:", e);
     return c.json({ error: "Failed to delete message" }, 500);
@@ -370,11 +341,11 @@ app.post("/api/chat", async (c) => {
     storage_mode,
     system_prompt,
     parent_id,
+    user_parent_id,
     user_message_id,
     assistant_message_id,
   } = body;
   const isCloud = storage_mode !== "local";
-  const isRetry = !!parent_id;
   const now = Date.now();
 
   // Prepend system message if provided
@@ -382,15 +353,16 @@ app.post("/api/chat", async (c) => {
     ? [{ role: "system" as const, content: system_prompt }, ...messages]
     : messages;
 
-  if (isCloud && !isRetry) {
-    // Save user message to D1 (only for new messages, not retries)
+  if (isCloud && user_message_id) {
+    // Save user message to D1 (only for new messages or edits, not retries)
     const userMsg = messages[messages.length - 1];
     await saveMessage(c.env.DB, {
-      id: user_message_id || crypto.randomUUID(),
+      id: user_message_id,
       conversation_id,
       role: "user",
       content: userMsg.content,
       created_at: now,
+      parent_id: user_parent_id || undefined,
     });
 
     // Auto-generate title from first user message
@@ -471,7 +443,7 @@ app.post("/api/chat", async (c) => {
             content: fullContent,
             created_at: Date.now(),
             model,
-            parent_id: parent_id || undefined,
+            parent_id: user_message_id || parent_id || undefined,
           });
           await updateConversationTimestamp(c.env.DB, conversation_id);
         } catch (e) {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -280,18 +280,14 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
     }
 
     const softDeletedIds = Array.from(descendants);
-    const statements: D1PreparedStatement[] = [];
     const now = Date.now();
-
-    for (const id of softDeletedIds) {
-      statements.push(
-        db.prepare("UPDATE messages SET content = '', deleted_at = ? WHERE id = ?").bind(now, id),
-      );
-    }
-
-    statements.push(
+    const placeholders = softDeletedIds.map(() => "?").join(",");
+    const statements: D1PreparedStatement[] = [
+      db
+        .prepare("UPDATE messages SET content = '', deleted_at = ? WHERE id IN (" + placeholders + ")")
+        .bind(now, ...softDeletedIds),
       db.prepare("UPDATE conversations SET updated_at = ? WHERE id = ?").bind(now, conversationId),
-    );
+    ];
     await db.batch(statements);
 
     return c.json({ success: true, deletedIds: [], softDeletedIds });

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -32,6 +32,7 @@ export interface ChatRequest {
   storage_mode: "cloud" | "local";
   system_prompt?: string;
   parent_id?: string;
+  user_parent_id?: string;
   user_message_id?: string;
   assistant_message_id?: string;
 }


### PR DESCRIPTION
## Description

- Refactored message data model to use a formal tree structure with `parent_id` linking all messages.
- Added D1 migration `0007` to deterministically reconstruct legacy linear threads into parent-child trees.
- Implemented recursive soft-deletes (`deleted_at`) in local and D1 adapters to hide orphaned sub-trees without causing data loss.
- Overhauled `useChat` state management to traverse the `activeBranch` rather than flat arrays, and added `localStorage` persistence for selected branch variants.
- Added inline editing (Pencil) to past user prompts to spawn new conversation branches.
- Updated `MessageList` UI to display sibling navigation controls (< 1/2 >) for traversing versions.


**Fixes #43**
**Fixes #47**


## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `feat/43-edit-n-regenerate` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.


[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/43-edit-n-regenerate)
