### PR TITLE
feat: implement workspace export and import with scope selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-dom": "^19.2.5",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^16.1.1",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "fflate": "^0.8.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260411.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      fflate:
+        specifier: ^0.8.2
+        version: 0.8.2
       hono:
         specifier: ^4.12.14
         version: 4.12.14
@@ -809,6 +812,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -1861,6 +1867,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.8.2: {}
 
   format@0.2.2: {}
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -421,9 +421,18 @@ export default function App() {
       if (scope === "local" || scope === "both") {
         const currentStorage = createStorage("local");
         const conversations = await currentStorage.getConversations();
-        const messages = (
-          await Promise.all(conversations.map((conv) => currentStorage.getConversation(conv.id)))
-        ).flatMap((data) => data?.messages || []);
+
+        // Fetch conversation details in batches to avoid overwhelming the adapter
+        const messages: Message[] = [];
+        const BATCH_SIZE = 10;
+        for (let i = 0; i < conversations.length; i += BATCH_SIZE) {
+          const chunk = conversations.slice(i, i + BATCH_SIZE);
+          const results = await Promise.all(chunk.map((c) => currentStorage.getConversation(c.id)));
+          results.forEach((data) => {
+            if (data) messages.push(...data.messages);
+          });
+        }
+
         exportData.local = { conversations, messages };
       }
 
@@ -506,6 +515,16 @@ export default function App() {
           data.external.messages,
           "Importing",
         );
+      }
+
+      // Apply imported settings if they exist
+      if (data.settings) {
+        if (data.settings.system_prompt) {
+          await handleSystemPromptChange(data.settings.system_prompt, syncSettings);
+        }
+        if (data.settings.default_model) {
+          await handleDefaultModelChange(data.settings.default_model, syncSettings);
+        }
       }
 
       await loadConversations();

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -7,7 +7,10 @@ import Sidebar from "./components/Sidebar";
 import { useChat } from "./hooks/useChat";
 import { DEFAULT_MODEL_ID, useModels } from "./hooks/useModels";
 import { useTransfer } from "./hooks/useTransfer";
-import type { StorageMode } from "./storage";
+import type { Conversation, Message, StorageMode } from "./storage";
+import { createStorage } from "./storage";
+import { exportWorkspace } from "./utils/exportUtils";
+import { parseImportFile } from "./utils/importUtils";
 
 const STORAGE_MODE_KEY = "waichat:storage-mode";
 const SYSTEM_PROMPT_KEY = "waichat:system-prompt";
@@ -389,6 +392,115 @@ export default function App() {
     }
   };
 
+  const handleExportWorkspace = async (scope: "local" | "cloud" | "both") => {
+    try {
+      const exportData: {
+        local?: { conversations: Conversation[]; messages: Message[] };
+        cloud?: { conversations: Conversation[]; messages: Message[] };
+        settings: Record<string, string>;
+      } = {
+        settings: {
+          system_prompt: localStorage.getItem(SYSTEM_PROMPT_KEY) || "",
+          default_model: localStorage.getItem(DEFAULT_MODEL_KEY) || "",
+        },
+      };
+
+      if (scope === "cloud" || scope === "both") {
+        const res = await fetch("/api/export");
+        if (!res.ok) throw new Error("Failed to export from cloud");
+        const cloudData = (await res.json()) as {
+          conversations: Conversation[];
+          messages: Message[];
+        };
+        exportData.cloud = { conversations: cloudData.conversations, messages: cloudData.messages };
+      }
+
+      if (scope === "local" || scope === "both") {
+        const currentStorage = createStorage("local");
+        const conversations = await currentStorage.getConversations();
+        const messages: Message[] = [];
+        for (const conv of conversations) {
+          const data = await currentStorage.getConversation(conv.id);
+          if (data) messages.push(...data.messages);
+        }
+        exportData.local = { conversations, messages };
+      }
+
+      await exportWorkspace(scope, exportData);
+    } catch (e) {
+      console.error(e);
+      alert("Failed to export workspace");
+    }
+  };
+
+  const handleImportWorkspace = async (file: File, onProgress: (msg: string) => void) => {
+    try {
+      const data = await parseImportFile(file);
+
+      const importToMode = async (
+        mode: StorageMode,
+        convs: Conversation[],
+        msgs: Message[],
+        prefix: string,
+      ) => {
+        const adapter = createStorage(mode);
+        const total = convs.length;
+        for (let i = 0; i < total; i++) {
+          const conv = convs[i];
+          const convMessages = msgs.filter((m) => m.conversation_id === conv.id);
+          onProgress(`${prefix} ${i + 1}/${total}...`);
+          try {
+            await adapter.deleteConversation(conv.id);
+          } catch (e) {}
+          await adapter.importConversation(conv, convMessages);
+        }
+      };
+
+      if (data.scope === "both") {
+        if (data.local)
+          await importToMode(
+            "local",
+            data.local.conversations,
+            data.local.messages,
+            "Importing Local",
+          );
+        if (data.cloud)
+          await importToMode(
+            "cloud",
+            data.cloud.conversations,
+            data.cloud.messages,
+            "Importing Cloud",
+          );
+      } else if (data.scope === "local" && data.local) {
+        await importToMode(
+          "local",
+          data.local.conversations,
+          data.local.messages,
+          "Importing Local",
+        );
+      } else if (data.scope === "cloud" && data.cloud) {
+        await importToMode(
+          "cloud",
+          data.cloud.conversations,
+          data.cloud.messages,
+          "Importing Cloud",
+        );
+      } else if (data.scope === "external" && data.external) {
+        await importToMode(
+          storageMode,
+          data.external.conversations,
+          data.external.messages,
+          "Importing",
+        );
+      }
+
+      await loadConversations();
+    } catch (e: any) {
+      console.error(e);
+      throw e;
+    }
+  };
+
   return (
     <div className="relative flex h-screen w-full overflow-hidden font-sans text-gray-900 dark:text-white/95">
       {/* Full-screen base layers */}
@@ -613,6 +725,8 @@ export default function App() {
           onSystemPromptChange={handleSystemPromptChange}
           models={models}
           onClearConversations={handleClearConversations}
+          onExportWorkspace={handleExportWorkspace}
+          onImportWorkspace={handleImportWorkspace}
           theme={theme}
           onThemeChange={setTheme}
         />

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -411,8 +411,11 @@ export default function App() {
         const cloudData = (await res.json()) as {
           conversations: Conversation[];
           messages: Message[];
+          settings: Record<string, string>;
         };
         exportData.cloud = { conversations: cloudData.conversations, messages: cloudData.messages };
+        // Merge cloud settings into exportData
+        exportData.settings = { ...exportData.settings, ...cloudData.settings };
       }
 
       if (scope === "local" || scope === "both") {
@@ -452,14 +455,18 @@ export default function App() {
         );
 
         const total = convs.length;
-        for (let i = 0; i < total; i++) {
-          const conv = convs[i];
-          const convMessages = messagesByConv[conv.id] || [];
-          onProgress(`${prefix} ${i + 1}/${total}...`);
-          try {
-            await adapter.deleteConversation(conv.id);
-          } catch (e) {}
-          await adapter.importConversation(conv, convMessages);
+        const BATCH_SIZE = 5; // Import 5 conversations at once
+        for (let i = 0; i < total; i += BATCH_SIZE) {
+          const chunk = convs.slice(i, i + BATCH_SIZE);
+          await Promise.all(
+            chunk.map(async (conv, index) => {
+              const currentIdx = i + index;
+              const convMessages = messagesByConv[conv.id] || [];
+              onProgress(`${prefix} ${currentIdx + 1}/${total}...`);
+              // adapter.importConversation is now an upsert
+              await adapter.importConversation(conv, convMessages);
+            }),
+          );
         }
       };
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -418,11 +418,9 @@ export default function App() {
       if (scope === "local" || scope === "both") {
         const currentStorage = createStorage("local");
         const conversations = await currentStorage.getConversations();
-        const messages: Message[] = [];
-        for (const conv of conversations) {
-          const data = await currentStorage.getConversation(conv.id);
-          if (data) messages.push(...data.messages);
-        }
+        const messages = (
+          await Promise.all(conversations.map((conv) => currentStorage.getConversation(conv.id)))
+        ).flatMap((data) => data?.messages || []);
         exportData.local = { conversations, messages };
       }
 
@@ -444,10 +442,19 @@ export default function App() {
         prefix: string,
       ) => {
         const adapter = createStorage(mode);
+        const messagesByConv = msgs.reduce(
+          (acc, m) => {
+            if (!acc[m.conversation_id]) acc[m.conversation_id] = [];
+            acc[m.conversation_id].push(m);
+            return acc;
+          },
+          {} as Record<string, Message[]>,
+        );
+
         const total = convs.length;
         for (let i = 0; i < total; i++) {
           const conv = convs[i];
-          const convMessages = msgs.filter((m) => m.conversation_id === conv.id);
+          const convMessages = messagesByConv[conv.id] || [];
           onProgress(`${prefix} ${i + 1}/${total}...`);
           try {
             await adapter.deleteConversation(conv.id);

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -138,7 +138,7 @@ export default function SettingsModal({
         if (e.target === overlayRef.current) handleCancel();
       }}
     >
-      <div className="w-full max-w-md bg-white/95 dark:bg-[#1e1e20]/95 backdrop-blur-2xl border-[0.5px] border-black/10 dark:border-white/10 rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.1)] dark:shadow-[0_20px_40px_rgba(0,0,0,0.5)] overflow-hidden max-h-[90vh] flex flex-col">
+      <div className="w-full max-w-3xl bg-white/95 dark:bg-[#1e1e20]/95 backdrop-blur-2xl border-[0.5px] border-black/10 dark:border-white/10 rounded-2xl shadow-[0_20px_40px_rgba(0,0,0,0.1)] dark:shadow-[0_20px_40px_rgba(0,0,0,0.5)] overflow-hidden max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b-[0.5px] border-black/10 dark:border-white/10 shrink-0">
           <h2 className="text-base md:text-lg font-semibold text-gray-900 dark:text-white/95 tracking-tight">
@@ -156,9 +156,11 @@ export default function SettingsModal({
         </div>
 
         {/* Scrollable body */}
-        <div className="overflow-y-auto flex-1 px-6 py-6 space-y-8 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
-          {/* Preferences */}
-          <section>
+        <div className="overflow-y-auto flex-1 px-6 py-6 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
+          <div className="flex flex-col md:flex-row gap-10">
+            {/* Left Column: Preferences */}
+            <div className="flex-[1.3] space-y-8">
+              <section>
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40">
                 Preferences
@@ -228,24 +230,6 @@ export default function SettingsModal({
                 </p>
               </div>
 
-              {/* Default model */}
-              <div>
-                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
-                  Default Model
-                </label>
-                {/* Wrapper provides the input-box styling, ModelPicker stays transparent inside! */}
-                <div className="w-full bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 focus-within:border-[#0A84FF] focus-within:bg-white dark:focus-within:bg-black/30 transition-colors">
-                  <ModelPicker
-                    models={models}
-                    value={draftModel}
-                    onChange={setDraftModel}
-                    className="w-full"
-                  />
-                </div>
-                <p className="mt-1.5 text-xs text-gray-500 dark:text-white/40">
-                  Fallback for existing chats and default for new ones.
-                </p>
-              </div>
               {/* System prompt */}
               <div>
                 <div className="flex items-center justify-between mb-2">
@@ -257,7 +241,7 @@ export default function SettingsModal({
                   value={draftSystemPrompt}
                   onChange={(e) => setDraftSystemPrompt(e.target.value)}
                   placeholder="You are a helpful assistant..."
-                  rows={4}
+                  rows={10}
                   className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
                 />
                 <p className="mt-1.5 text-xs text-gray-500 dark:text-white/40">
@@ -265,10 +249,34 @@ export default function SettingsModal({
                 </p>
               </div>
             </div>
-          </section>
+              </section>
+            </div>
 
-          {/* Conversations */}
-          <section>
+            {/* Vertical Divider */}
+            <div className="hidden md:block w-[1px] bg-black/10 dark:bg-white/10 shrink-0" />
+
+            {/* Right Column: Model, Conversations & Data Management */}
+            <div className="flex-1 space-y-8">
+              {/* Default Model */}
+              <section>
+                <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
+                  Default Model
+                </h3>
+                <div className="w-full bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 focus-within:border-[#0A84FF] focus-within:bg-white dark:focus-within:bg-black/30 transition-colors">
+                  <ModelPicker
+                    models={models}
+                    value={draftModel}
+                    onChange={setDraftModel}
+                    className="w-full"
+                  />
+                </div>
+                <p className="mt-1.5 text-xs text-gray-500 dark:text-white/40">
+                  Fallback for existing chats and default for new ones.
+                </p>
+              </section>
+
+              {/* Conversations */}
+              <section>
             <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
               Conversations
             </h3>
@@ -375,7 +383,7 @@ export default function SettingsModal({
                           </span>
                         </label>
                       ))}
-                      <div className="flex gap-2 mt-2">
+                      <div className="flex justify-end gap-2 mt-2">
                         <button
                           onClick={confirmExport}
                           className="text-[11px] md:text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 rounded-full px-3 py-1 transition-colors"
@@ -433,7 +441,7 @@ export default function SettingsModal({
                     <p className="text-xs text-red-600 dark:text-red-400 font-medium mb-2">
                       This will overwrite any existing conversations with matching IDs. Continue?
                     </p>
-                    <div className="flex gap-2">
+                    <div className="flex justify-end gap-2">
                       <button
                         onClick={confirmImport}
                         className="text-[11px] md:text-xs font-medium text-white bg-red-500 hover:bg-red-600 rounded-full px-3 py-1 transition-colors"
@@ -451,20 +459,22 @@ export default function SettingsModal({
                 )}
               </div>
             </div>
-          </section>
+              </section>
+            </div>
+          </div>
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t-[0.5px] border-black/10 dark:border-white/10 flex gap-3 shrink-0 bg-black/[0.02] dark:bg-white/[0.02]">
+        <div className="px-6 py-4 border-t-[0.5px] border-black/10 dark:border-white/10 flex justify-end gap-3 shrink-0 bg-black/[0.01] dark:bg-white/[0.01]">
           <button
             onClick={handleCancel}
-            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:bg-white dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white/95 rounded-full transition-all focus:outline-none"
+            className="px-5 py-2 text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 hover:bg-white dark:hover:bg-white/10 hover:text-gray-900 dark:hover:text-white/95 rounded-full transition-all focus:outline-none"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
-            className="flex-1 py-2.5 text-[13px] md:text-sm font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] rounded-full shadow-[0_2px_8px_rgba(10,132,255,0.2)] dark:shadow-[0_2px_8px_rgba(10,132,255,0.3)] transition-all focus:outline-none"
+            className="px-8 py-2 text-[13px] md:text-sm font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] rounded-full shadow-[0_2px_8px_rgba(10,132,255,0.2)] dark:shadow-[0_2px_8px_rgba(10,132,255,0.3)] transition-all focus:outline-none"
           >
             Save
           </button>

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -122,6 +122,7 @@ export default function SettingsModal({
     } catch (e: any) {
       setImportProgress(null);
       setPendingImportFile(null);
+      alert(e.message || "Failed to import workspace");
     }
   };
 
@@ -161,94 +162,94 @@ export default function SettingsModal({
             {/* Left Column: Preferences */}
             <div className="flex-[1.3] space-y-8">
               <section>
-            <div className="flex items-center justify-between mb-4">
-              <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40">
-                Preferences
-              </h3>
-              <label className="flex items-center gap-2 cursor-pointer group">
-                <div className="relative flex items-center justify-center">
-                  <input
-                    type="checkbox"
-                    checked={draftSyncSettings}
-                    onChange={(e) => setDraftSyncSettings(e.target.checked)}
-                    className="peer sr-only"
-                  />
-                  <div className="w-8 h-4 bg-black/10 dark:bg-white/10 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-[#0A84FF]"></div>
-                </div>
-                <span className="text-[11px] md:text-xs font-medium text-gray-500 dark:text-white/40 group-hover:text-gray-900 dark:group-hover:text-white/80 transition-colors">
-                  Sync Settings to Cloud
-                </span>
-              </label>
-            </div>
-            <div className="space-y-5">
-              {/* Theme Segmented Control */}
-              <div>
-                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
-                  Theme
-                </label>
-                <div className="flex rounded-full bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
-                  {(["system", "light", "dark"] as const).map((t) => (
-                    <button
-                      key={t}
-                      onClick={() => onThemeChange(t)}
-                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 capitalize ${
-                        theme === t
-                          ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
-                          : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
-                      }`}
-                    >
-                      {t}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              {/* Storage mode Segmented Control */}
-              <div>
-                <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
-                  Storage Mode
-                </label>
-                <div className="flex rounded-full bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
-                  {(["cloud", "local"] as StorageMode[]).map((mode) => (
-                    <button
-                      key={mode}
-                      onClick={() => setDraftStorageMode(mode)}
-                      className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 ${
-                        draftStorageMode === mode
-                          ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
-                          : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
-                      }`}
-                    >
-                      {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
-                    </button>
-                  ))}
-                </div>
-                <p className="mt-2 text-xs text-gray-500 dark:text-white/40 leading-relaxed">
-                  {draftStorageMode === "cloud"
-                    ? "Conversations saved to Cloudflare D1. Persists across devices."
-                    : "Conversations saved in your browser. Never leaves your device."}
-                </p>
-              </div>
-
-              {/* System prompt */}
-              <div>
-                <div className="flex items-center justify-between mb-2">
-                  <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80">
-                    System Prompt
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40">
+                    Preferences
+                  </h3>
+                  <label className="flex items-center gap-2 cursor-pointer group">
+                    <div className="relative flex items-center justify-center">
+                      <input
+                        type="checkbox"
+                        checked={draftSyncSettings}
+                        onChange={(e) => setDraftSyncSettings(e.target.checked)}
+                        className="peer sr-only"
+                      />
+                      <div className="w-8 h-4 bg-black/10 dark:bg-white/10 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:bg-[#0A84FF]"></div>
+                    </div>
+                    <span className="text-[11px] md:text-xs font-medium text-gray-500 dark:text-white/40 group-hover:text-gray-900 dark:group-hover:text-white/80 transition-colors">
+                      Sync Settings to Cloud
+                    </span>
                   </label>
                 </div>
-                <textarea
-                  value={draftSystemPrompt}
-                  onChange={(e) => setDraftSystemPrompt(e.target.value)}
-                  placeholder="You are a helpful assistant..."
-                  rows={10}
-                  className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
-                />
-                <p className="mt-1.5 text-xs text-gray-500 dark:text-white/40">
-                  Applied to all new conversations.
-                </p>
-              </div>
-            </div>
+                <div className="space-y-5">
+                  {/* Theme Segmented Control */}
+                  <div>
+                    <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
+                      Theme
+                    </label>
+                    <div className="flex rounded-full bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
+                      {(["system", "light", "dark"] as const).map((t) => (
+                        <button
+                          key={t}
+                          onClick={() => onThemeChange(t)}
+                          className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 capitalize ${
+                            theme === t
+                              ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
+                              : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
+                          }`}
+                        >
+                          {t}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Storage mode Segmented Control */}
+                  <div>
+                    <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80 mb-2">
+                      Storage Mode
+                    </label>
+                    <div className="flex rounded-full bg-black/5 dark:bg-black/20 p-1 border-[0.5px] border-black/5 dark:border-white/10">
+                      {(["cloud", "local"] as StorageMode[]).map((mode) => (
+                        <button
+                          key={mode}
+                          onClick={() => setDraftStorageMode(mode)}
+                          className={`flex-1 py-1.5 text-[13px] md:text-sm font-medium rounded-full transition-all duration-200 ${
+                            draftStorageMode === mode
+                              ? "bg-white dark:bg-white/15 text-gray-900 dark:text-white/95 shadow-sm"
+                              : "text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5"
+                          }`}
+                        >
+                          {mode === "cloud" ? "Cloud (D1)" : "Local (Browser)"}
+                        </button>
+                      ))}
+                    </div>
+                    <p className="mt-2 text-xs text-gray-500 dark:text-white/40 leading-relaxed">
+                      {draftStorageMode === "cloud"
+                        ? "Conversations saved to Cloudflare D1. Persists across devices."
+                        : "Conversations saved in your browser. Never leaves your device."}
+                    </p>
+                  </div>
+
+                  {/* System prompt */}
+                  <div>
+                    <div className="flex items-center justify-between mb-2">
+                      <label className="block text-[13px] md:text-sm font-medium text-gray-700 dark:text-white/80">
+                        System Prompt
+                      </label>
+                    </div>
+                    <textarea
+                      value={draftSystemPrompt}
+                      onChange={(e) => setDraftSystemPrompt(e.target.value)}
+                      placeholder="You are a helpful assistant..."
+                      rows={10}
+                      className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
+                    />
+                    <p className="mt-1.5 text-xs text-gray-500 dark:text-white/40">
+                      Applied to all new conversations.
+                    </p>
+                  </div>
+                </div>
               </section>
             </div>
 
@@ -277,188 +278,189 @@ export default function SettingsModal({
 
               {/* Conversations */}
               <section>
-            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
-              Conversations
-            </h3>
-            <div className="space-y-3">
-              {/* Cloud */}
-              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
-                <div>
-                  <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
-                    Cloud (D1)
-                  </p>
-                  <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
-                    Stored in Cloudflare D1
-                  </p>
-                </div>
-                <button
-                  onClick={() => {
-                    if (confirm("Delete all cloud conversations? This cannot be undone.")) {
-                      onClearConversations("cloud");
-                    }
-                  }}
-                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-full px-3 py-1.5 transition-all focus:outline-none"
-                >
-                  Clear
-                </button>
-              </div>
-
-              {/* Local */}
-              <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
-                <div>
-                  <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
-                    Local (Browser)
-                  </p>
-                  <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
-                    Stored in browser localStorage
-                  </p>
-                </div>
-                <button
-                  onClick={() => {
-                    if (confirm("Delete all local conversations? This cannot be undone.")) {
-                      onClearConversations("local");
-                    }
-                  }}
-                  className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-full px-3 py-1.5 transition-all focus:outline-none"
-                >
-                  Clear
-                </button>
-              </div>
-            </div>
-          </section>
-
-          {/* Data Management */}
-          <section>
-            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
-              Data Management
-            </h3>
-            <div className="space-y-3">
-              <div className="flex flex-col py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
-                      Export Workspace
-                    </p>
-                    <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
-                      Download all data as a ZIP file
-                    </p>
-                  </div>
-                  <button
-                    onClick={handleExportClick}
-                    disabled={isExporting || importProgress !== null}
-                    className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:text-gray-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/20 rounded-full px-3 py-1.5 transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {isExporting ? "Exporting..." : "Export"}
-                  </button>
-                </div>
-                {showExportSelector && (
-                  <div className="mt-4 pt-3 border-t-[0.5px] border-black/5 dark:border-white/10">
-                    <p className="text-xs text-gray-700 dark:text-white/80 font-medium mb-3">
-                      Select export scope:
-                    </p>
-                    <div className="flex flex-col gap-2">
-                      {(["local", "cloud", "both"] as const).map((scope) => (
-                        <label
-                          key={scope}
-                          className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
-                            exportScope === scope
-                              ? "bg-black/5 dark:bg-white/10"
-                              : "hover:bg-black/5 dark:hover:bg-white/5"
-                          }`}
-                        >
-                          <input
-                            type="radio"
-                            name="exportScope"
-                            value={scope}
-                            checked={exportScope === scope}
-                            onChange={() => setExportScope(scope)}
-                            className="w-3.5 h-3.5 accent-blue-500"
-                          />
-                          <span className="text-xs text-gray-900 dark:text-white/95">
-                            {scope === "local"
-                              ? "Local Only"
-                              : scope === "cloud"
-                                ? "Cloud Only"
-                                : "Both (Local & Cloud)"}
-                          </span>
-                        </label>
-                      ))}
-                      <div className="flex justify-end gap-2 mt-2">
-                        <button
-                          onClick={confirmExport}
-                          className="text-[11px] md:text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 rounded-full px-3 py-1 transition-colors"
-                        >
-                          Confirm Export
-                        </button>
-                        <button
-                          onClick={() => setShowExportSelector(false)}
-                          className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-3 py-1 transition-colors"
-                        >
-                          Cancel
-                        </button>
-                      </div>
+                <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
+                  Conversations
+                </h3>
+                <div className="space-y-3">
+                  {/* Cloud */}
+                  <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
+                    <div>
+                      <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+                        Cloud (D1)
+                      </p>
+                      <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
+                        Stored in Cloudflare D1
+                      </p>
                     </div>
-                  </div>
-                )}
-              </div>
-
-              <div className="flex flex-col py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
-                <div className="flex items-center justify-between">
-                  <div>
-                    <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
-                      Import Workspace
-                    </p>
-                    <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
-                      Restore from WaiChat or ChatGPT ZIP
-                    </p>
-                  </div>
-                  <div>
-                    <input
-                      type="file"
-                      accept=".zip"
-                      className="hidden"
-                      ref={fileInputRef}
-                      onChange={handleFileChange}
-                    />
                     <button
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={isExporting || importProgress !== null}
-                      className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:text-gray-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/20 rounded-full px-3 py-1.5 transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                      onClick={() => {
+                        if (confirm("Delete all cloud conversations? This cannot be undone.")) {
+                          onClearConversations("cloud");
+                        }
+                      }}
+                      className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-full px-3 py-1.5 transition-all focus:outline-none"
                     >
-                      Import
+                      Clear
+                    </button>
+                  </div>
+
+                  {/* Local */}
+                  <div className="flex items-center justify-between py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
+                    <div>
+                      <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+                        Local (Browser)
+                      </p>
+                      <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
+                        Stored in browser localStorage
+                      </p>
+                    </div>
+                    <button
+                      onClick={() => {
+                        if (confirm("Delete all local conversations? This cannot be undone.")) {
+                          onClearConversations("local");
+                        }
+                      }}
+                      className="text-[11px] md:text-xs font-medium text-red-500 dark:text-red-400 hover:text-red-600 dark:hover:text-red-300 border-[0.5px] border-red-500/30 hover:bg-red-50 dark:hover:bg-red-500/20 rounded-full px-3 py-1.5 transition-all focus:outline-none"
+                    >
+                      Clear
                     </button>
                   </div>
                 </div>
-                {importProgress && (
-                  <div className="mt-3">
-                    <p className="text-[11px] md:text-xs text-[#0A84FF] font-medium animate-pulse">
-                      {importProgress}
-                    </p>
-                  </div>
-                )}
-                {showImportConfirm && (
-                  <div className="mt-3 p-3 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-lg">
-                    <p className="text-xs text-red-600 dark:text-red-400 font-medium mb-2">
-                      This will overwrite any existing conversations with matching IDs. Continue?
-                    </p>
-                    <div className="flex justify-end gap-2">
+              </section>
+
+              {/* Data Management */}
+              <section>
+                <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
+                  Data Management
+                </h3>
+                <div className="space-y-3">
+                  <div className="flex flex-col py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+                          Export Workspace
+                        </p>
+                        <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
+                          Download all data as a ZIP file
+                        </p>
+                      </div>
                       <button
-                        onClick={confirmImport}
-                        className="text-[11px] md:text-xs font-medium text-white bg-red-500 hover:bg-red-600 rounded-full px-3 py-1 transition-colors"
+                        onClick={handleExportClick}
+                        disabled={isExporting || importProgress !== null}
+                        className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:text-gray-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/20 rounded-full px-3 py-1.5 transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
                       >
-                        Yes, Import
-                      </button>
-                      <button
-                        onClick={cancelImport}
-                        className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-3 py-1 transition-colors"
-                      >
-                        Cancel
+                        {isExporting ? "Exporting..." : "Export"}
                       </button>
                     </div>
+                    {showExportSelector && (
+                      <div className="mt-4 pt-3 border-t-[0.5px] border-black/5 dark:border-white/10">
+                        <p className="text-xs text-gray-700 dark:text-white/80 font-medium mb-3">
+                          Select export scope:
+                        </p>
+                        <div className="flex flex-col gap-2">
+                          {(["local", "cloud", "both"] as const).map((scope) => (
+                            <label
+                              key={scope}
+                              className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
+                                exportScope === scope
+                                  ? "bg-black/5 dark:bg-white/10"
+                                  : "hover:bg-black/5 dark:hover:bg-white/5"
+                              }`}
+                            >
+                              <input
+                                type="radio"
+                                name="exportScope"
+                                value={scope}
+                                checked={exportScope === scope}
+                                onChange={() => setExportScope(scope)}
+                                className="w-3.5 h-3.5 accent-blue-500"
+                              />
+                              <span className="text-xs text-gray-900 dark:text-white/95">
+                                {scope === "local"
+                                  ? "Local Only"
+                                  : scope === "cloud"
+                                    ? "Cloud Only"
+                                    : "Both (Local & Cloud)"}
+                              </span>
+                            </label>
+                          ))}
+                          <div className="flex justify-end gap-2 mt-2">
+                            <button
+                              onClick={confirmExport}
+                              className="text-[11px] md:text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 rounded-full px-3 py-1 transition-colors"
+                            >
+                              Confirm Export
+                            </button>
+                            <button
+                              onClick={() => setShowExportSelector(false)}
+                              className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-3 py-1 transition-colors"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    )}
                   </div>
-                )}
-              </div>
-            </div>
+
+                  <div className="flex flex-col py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+                          Import Workspace
+                        </p>
+                        <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
+                          Restore from WaiChat or ChatGPT ZIP
+                        </p>
+                      </div>
+                      <div>
+                        <input
+                          type="file"
+                          accept=".zip"
+                          className="hidden"
+                          ref={fileInputRef}
+                          onChange={handleFileChange}
+                        />
+                        <button
+                          onClick={() => fileInputRef.current?.click()}
+                          disabled={isExporting || importProgress !== null}
+                          className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:text-gray-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/20 rounded-full px-3 py-1.5 transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          Import
+                        </button>
+                      </div>
+                    </div>
+                    {importProgress && (
+                      <div className="mt-3">
+                        <p className="text-[11px] md:text-xs text-[#0A84FF] font-medium animate-pulse">
+                          {importProgress}
+                        </p>
+                      </div>
+                    )}
+                    {showImportConfirm && (
+                      <div className="mt-3 p-3 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-lg">
+                        <p className="text-xs text-red-600 dark:text-red-400 font-medium mb-2">
+                          This will overwrite any existing conversations with matching IDs.
+                          Continue?
+                        </p>
+                        <div className="flex justify-end gap-2">
+                          <button
+                            onClick={confirmImport}
+                            className="text-[11px] md:text-xs font-medium text-white bg-red-500 hover:bg-red-600 rounded-full px-3 py-1 transition-colors"
+                          >
+                            Yes, Import
+                          </button>
+                          <button
+                            onClick={cancelImport}
+                            className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-3 py-1 transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
               </section>
             </div>
           </div>

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -15,6 +15,8 @@ interface SettingsModalProps {
   onSystemPromptChange: (prompt: string, sync: boolean) => void;
   models: Model[];
   onClearConversations: (mode: StorageMode) => void;
+  onExportWorkspace: (scope: "local" | "cloud" | "both") => Promise<void>;
+  onImportWorkspace: (file: File, onProgress: (msg: string) => void) => Promise<void>;
   theme: "system" | "light" | "dark";
   onThemeChange: (theme: "system" | "light" | "dark") => void;
 }
@@ -31,16 +33,25 @@ export default function SettingsModal({
   onSystemPromptChange,
   models,
   onClearConversations,
+  onExportWorkspace,
+  onImportWorkspace,
   theme,
   onThemeChange,
 }: SettingsModalProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Local draft state — only committed on Save
   const [draftStorageMode, setDraftStorageMode] = useState<StorageMode>(storageMode);
   const [draftModel, setDraftModel] = useState(defaultModel);
   const [draftSystemPrompt, setDraftSystemPrompt] = useState(systemPrompt);
   const [draftSyncSettings, setDraftSyncSettings] = useState(syncSettings);
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportScope, setExportScope] = useState<"local" | "cloud" | "both">("both");
+  const [showExportSelector, setShowExportSelector] = useState(false);
+  const [importProgress, setImportProgress] = useState<string | null>(null);
+  const [showImportConfirm, setShowImportConfirm] = useState(false);
+  const [pendingImportFile, setPendingImportFile] = useState<File | null>(null);
 
   // Sync draft with props when modal opens
   useEffect(() => {
@@ -71,6 +82,52 @@ export default function SettingsModal({
 
   const handleCancel = () => {
     onClose();
+  };
+
+  const handleExportClick = () => {
+    setShowExportSelector(true);
+  };
+
+  const confirmExport = async () => {
+    setShowExportSelector(false);
+    setIsExporting(true);
+    try {
+      await onExportWorkspace(exportScope);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setPendingImportFile(file);
+      setShowImportConfirm(true);
+    }
+    // Reset input so the same file can be selected again
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const confirmImport = async () => {
+    if (!pendingImportFile) return;
+    setShowImportConfirm(false);
+    setImportProgress("Starting import...");
+    try {
+      await onImportWorkspace(pendingImportFile, setImportProgress);
+      setImportProgress(null);
+      setPendingImportFile(null);
+      alert("Workspace imported successfully!");
+    } catch (e: any) {
+      setImportProgress(null);
+      setPendingImportFile(null);
+    }
+  };
+
+  const cancelImport = () => {
+    setShowImportConfirm(false);
+    setPendingImportFile(null);
   };
 
   return (
@@ -258,6 +315,140 @@ export default function SettingsModal({
                 >
                   Clear
                 </button>
+              </div>
+            </div>
+          </section>
+
+          {/* Data Management */}
+          <section>
+            <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
+              Data Management
+            </h3>
+            <div className="space-y-3">
+              <div className="flex flex-col py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+                      Export Workspace
+                    </p>
+                    <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
+                      Download all data as a ZIP file
+                    </p>
+                  </div>
+                  <button
+                    onClick={handleExportClick}
+                    disabled={isExporting || importProgress !== null}
+                    className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:text-gray-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/20 rounded-full px-3 py-1.5 transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isExporting ? "Exporting..." : "Export"}
+                  </button>
+                </div>
+                {showExportSelector && (
+                  <div className="mt-4 pt-3 border-t-[0.5px] border-black/5 dark:border-white/10">
+                    <p className="text-xs text-gray-700 dark:text-white/80 font-medium mb-3">
+                      Select export scope:
+                    </p>
+                    <div className="flex flex-col gap-2">
+                      {(["local", "cloud", "both"] as const).map((scope) => (
+                        <label
+                          key={scope}
+                          className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer transition-colors ${
+                            exportScope === scope
+                              ? "bg-black/5 dark:bg-white/10"
+                              : "hover:bg-black/5 dark:hover:bg-white/5"
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name="exportScope"
+                            value={scope}
+                            checked={exportScope === scope}
+                            onChange={() => setExportScope(scope)}
+                            className="w-3.5 h-3.5 accent-blue-500"
+                          />
+                          <span className="text-xs text-gray-900 dark:text-white/95">
+                            {scope === "local"
+                              ? "Local Only"
+                              : scope === "cloud"
+                                ? "Cloud Only"
+                                : "Both (Local & Cloud)"}
+                          </span>
+                        </label>
+                      ))}
+                      <div className="flex gap-2 mt-2">
+                        <button
+                          onClick={confirmExport}
+                          className="text-[11px] md:text-xs font-medium text-white bg-blue-500 hover:bg-blue-600 rounded-full px-3 py-1 transition-colors"
+                        >
+                          Confirm Export
+                        </button>
+                        <button
+                          onClick={() => setShowExportSelector(false)}
+                          className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-3 py-1 transition-colors"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-col py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95">
+                      Import Workspace
+                    </p>
+                    <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5">
+                      Restore from WaiChat or ChatGPT ZIP
+                    </p>
+                  </div>
+                  <div>
+                    <input
+                      type="file"
+                      accept=".zip"
+                      className="hidden"
+                      ref={fileInputRef}
+                      onChange={handleFileChange}
+                    />
+                    <button
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={isExporting || importProgress !== null}
+                      className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:text-gray-900 dark:hover:text-white hover:bg-black/5 dark:hover:bg-white/10 border-[0.5px] border-black/10 dark:border-white/20 rounded-full px-3 py-1.5 transition-all focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      Import
+                    </button>
+                  </div>
+                </div>
+                {importProgress && (
+                  <div className="mt-3">
+                    <p className="text-[11px] md:text-xs text-[#0A84FF] font-medium animate-pulse">
+                      {importProgress}
+                    </p>
+                  </div>
+                )}
+                {showImportConfirm && (
+                  <div className="mt-3 p-3 bg-red-50 dark:bg-red-500/10 border border-red-200 dark:border-red-500/30 rounded-lg">
+                    <p className="text-xs text-red-600 dark:text-red-400 font-medium mb-2">
+                      This will overwrite any existing conversations with matching IDs. Continue?
+                    </p>
+                    <div className="flex gap-2">
+                      <button
+                        onClick={confirmImport}
+                        className="text-[11px] md:text-xs font-medium text-white bg-red-500 hover:bg-red-600 rounded-full px-3 py-1 transition-colors"
+                      >
+                        Yes, Import
+                      </button>
+                      <button
+                        onClick={cancelImport}
+                        className="text-[11px] md:text-xs font-medium text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-3 py-1 transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             </div>
           </section>

--- a/src/client/utils/exportUtils.ts
+++ b/src/client/utils/exportUtils.ts
@@ -124,7 +124,7 @@ export async function exportWorkspace(
 
   const zipped = zipSync(zipData);
 
-  const blob = new Blob([zipped as unknown as BlobPart], { type: "application/zip" });
+  const blob = new Blob([zipped as any], { type: "application/zip" });
   const url = URL.createObjectURL(blob);
 
   const a = document.createElement("a");

--- a/src/client/utils/exportUtils.ts
+++ b/src/client/utils/exportUtils.ts
@@ -1,0 +1,137 @@
+import { strToU8, zipSync } from "fflate";
+import type { Conversation, Message } from "../storage";
+
+export function convertToChatGPTFormat(conversations: Conversation[], messages: Message[]) {
+  const result = [];
+
+  // Group messages by conversation
+  const messagesByConv = new Map<string, Message[]>();
+  for (const m of messages) {
+    if (!messagesByConv.has(m.conversation_id)) {
+      messagesByConv.set(m.conversation_id, []);
+    }
+    messagesByConv.get(m.conversation_id)!.push(m);
+  }
+
+  for (const conv of conversations) {
+    const convMessages = messagesByConv.get(conv.id) || [];
+
+    // Build mapping
+    const mapping: Record<string, any> = {};
+    const childrenMap = new Map<string | null, string[]>();
+
+    // First pass to build children relationships
+    for (const msg of convMessages) {
+      const parentId = msg.parent_id || null;
+      if (!childrenMap.has(parentId)) {
+        childrenMap.set(parentId, []);
+      }
+      childrenMap.get(parentId)!.push(msg.id);
+    }
+
+    // Find leaves
+    let current_node = null;
+    let latestTime = 0;
+
+    for (const msg of convMessages) {
+      const children = childrenMap.get(msg.id) || [];
+      mapping[msg.id] = {
+        id: msg.id,
+        message: {
+          id: msg.id,
+          author: { role: msg.role },
+          create_time: msg.created_at / 1000,
+          content: {
+            content_type: "text",
+            parts: [msg.content],
+          },
+          metadata: {
+            model: msg.model || conv.model,
+          },
+        },
+        parent: msg.parent_id || null,
+        children,
+      };
+
+      if (children.length === 0) {
+        if (msg.created_at > latestTime) {
+          latestTime = msg.created_at;
+          current_node = msg.id;
+        }
+      }
+    }
+
+    // Add root nodes (messages without parent)
+    const rootNodes = convMessages.filter((m) => !m.parent_id).map((m) => m.id);
+
+    // ChatGPT uses a system root node that connects everything, we can synthesize one
+    // if there isn't a clear root. If we don't synthesize, we need to ensure root nodes
+    // have parent: null, which is already done above.
+
+    result.push({
+      title: conv.title,
+      create_time: conv.created_at / 1000,
+      update_time: conv.updated_at / 1000,
+      mapping,
+      current_node,
+    });
+  }
+
+  return result;
+}
+
+export async function exportWorkspace(
+  scope: "local" | "cloud" | "both",
+  data: {
+    local?: { conversations: Conversation[]; messages: Message[] };
+    cloud?: { conversations: Conversation[]; messages: Message[] };
+    settings: Record<string, string>;
+  },
+) {
+  const manifest = {
+    version: "1.0",
+    export_date: new Date().toISOString(),
+    app: "WaiChat",
+    schema_version: 1,
+    export_scope: scope,
+  };
+
+  const zipData: Record<string, Uint8Array> = {
+    "manifest.json": strToU8(JSON.stringify(manifest, null, 2)),
+    "settings.json": strToU8(JSON.stringify(data.settings, null, 2)),
+    "custom_prompts.json": strToU8(JSON.stringify([], null, 2)),
+    "model_configs.json": strToU8(JSON.stringify([], null, 2)),
+    "attachments/.placeholder": strToU8(""),
+  };
+
+  if (scope === "both") {
+    if (data.local) {
+      const localFormat = convertToChatGPTFormat(data.local.conversations, data.local.messages);
+      zipData["local/conversations.json"] = strToU8(JSON.stringify(localFormat, null, 2));
+    }
+    if (data.cloud) {
+      const cloudFormat = convertToChatGPTFormat(data.cloud.conversations, data.cloud.messages);
+      zipData["cloud/conversations.json"] = strToU8(JSON.stringify(cloudFormat, null, 2));
+    }
+  } else {
+    const targetData = scope === "local" ? data.local : data.cloud;
+    if (targetData) {
+      const flatFormat = convertToChatGPTFormat(targetData.conversations, targetData.messages);
+      zipData["conversations.json"] = strToU8(JSON.stringify(flatFormat, null, 2));
+    }
+  }
+
+  const zipped = zipSync(zipData);
+
+  const blob = new Blob([zipped as unknown as BlobPart], { type: "application/zip" });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement("a");
+  a.href = url;
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  a.download = `waichat_export_${timestamp}.zip`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/client/utils/exportUtils.ts
+++ b/src/client/utils/exportUtils.ts
@@ -69,6 +69,7 @@ export function convertToChatGPTFormat(conversations: Conversation[], messages: 
     // have parent: null, which is already done above.
 
     result.push({
+      id: conv.id,
       title: conv.title,
       create_time: conv.created_at / 1000,
       update_time: conv.updated_at / 1000,

--- a/src/client/utils/importUtils.ts
+++ b/src/client/utils/importUtils.ts
@@ -136,8 +136,7 @@ function parseChatGPTFormat(data: any[]): {
   const messages: Message[] = [];
 
   for (const conv of data) {
-    const id =
-      typeof conv.conversation_id === "string" ? conv.conversation_id : crypto.randomUUID();
+    const id = conv.id || conv.conversation_id || crypto.randomUUID();
 
     conversations.push({
       id,

--- a/src/client/utils/importUtils.ts
+++ b/src/client/utils/importUtils.ts
@@ -1,0 +1,220 @@
+import { strFromU8, unzipSync } from "fflate";
+import type { Conversation, Message } from "../storage";
+
+const MAX_COMPRESSED_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_UNCOMPRESSED_SIZE = 500 * 1024 * 1024; // 500MB
+
+export interface ImportResult {
+  scope: "local" | "cloud" | "both" | "external";
+  local?: { conversations: Conversation[]; messages: Message[] };
+  cloud?: { conversations: Conversation[]; messages: Message[] };
+  external?: { conversations: Conversation[]; messages: Message[] };
+  settings?: Record<string, string>;
+}
+
+export async function parseImportFile(file: File): Promise<ImportResult> {
+  // Check compressed file size
+  if (file.size > MAX_COMPRESSED_SIZE) {
+    throw new Error(`File is too large. Max size is ${MAX_COMPRESSED_SIZE / 1024 / 1024}MB.`);
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const uint8Array = new Uint8Array(arrayBuffer);
+
+  // Unzip and check uncompressed size
+  let unzipped;
+  try {
+    unzipped = unzipSync(uint8Array);
+  } catch (e) {
+    throw new Error("Failed to extract ZIP file. It may be corrupted.");
+  }
+
+  let totalSize = 0;
+  for (const key in unzipped) {
+    totalSize += unzipped[key].length;
+  }
+
+  if (totalSize > MAX_UNCOMPRESSED_SIZE) {
+    throw new Error(
+      `Uncompressed archive is too large. Max size is ${MAX_UNCOMPRESSED_SIZE / 1024 / 1024}MB.`,
+    );
+  }
+
+  // Parse manifest
+  let isWaiChat = false;
+  let exportScope: "local" | "cloud" | "both" | "external" = "external";
+  const keys = Object.keys(unzipped);
+  const manifestKey = keys.find((k) => k.endsWith("manifest.json"));
+
+  if (manifestKey) {
+    try {
+      const manifestStr = strFromU8(unzipped[manifestKey]);
+      const manifest = JSON.parse(manifestStr);
+      if (manifest.app === "WaiChat") {
+        isWaiChat = true;
+        if (["local", "cloud", "both"].includes(manifest.export_scope)) {
+          exportScope = manifest.export_scope as "local" | "cloud" | "both";
+        }
+      }
+    } catch (e) {
+      // Manifest parsing failed, treat as ChatGPT Compatibility Mode
+    }
+  }
+
+  const result: ImportResult = { scope: exportScope };
+
+  // Data validation
+  if (exportScope === "both") {
+    const localKey = keys.find((k) => k.endsWith("local/conversations.json"));
+    const cloudKey = keys.find((k) => k.endsWith("cloud/conversations.json"));
+
+    if (localKey) {
+      try {
+        result.local = parseChatGPTFormat(JSON.parse(strFromU8(unzipped[localKey])));
+      } catch (e) {
+        throw new Error("Invalid archive: Failed to parse local/conversations.json.");
+      }
+    }
+    if (cloudKey) {
+      try {
+        result.cloud = parseChatGPTFormat(JSON.parse(strFromU8(unzipped[cloudKey])));
+      } catch (e) {
+        throw new Error("Invalid archive: Failed to parse cloud/conversations.json.");
+      }
+    }
+
+    if (!localKey && !cloudKey) {
+      throw new Error(
+        "Invalid archive: missing both local and cloud conversations in 'both' scope.",
+      );
+    }
+  } else {
+    // Single scope or external
+    const convKey = keys.find(
+      (k) => k.endsWith("conversations.json") && !k.includes("local/") && !k.includes("cloud/"),
+    );
+    if (!convKey) {
+      throw new Error("Invalid archive: conversations.json not found.");
+    }
+
+    let chatGPTData;
+    try {
+      chatGPTData = JSON.parse(strFromU8(unzipped[convKey]));
+    } catch (e) {
+      throw new Error("Invalid archive: Failed to parse conversations.json.");
+    }
+
+    const parsed = parseChatGPTFormat(chatGPTData);
+    if (exportScope === "local") {
+      result.local = parsed;
+    } else if (exportScope === "cloud") {
+      result.cloud = parsed;
+    } else {
+      result.external = parsed;
+    }
+  }
+
+  let settings: Record<string, string> | undefined;
+  const settingsKey = keys.find((k) => k.endsWith("settings.json"));
+
+  if (isWaiChat && settingsKey) {
+    try {
+      result.settings = JSON.parse(strFromU8(unzipped[settingsKey]));
+    } catch (e) {
+      console.error("Failed to parse settings.json", e);
+    }
+  }
+
+  return result;
+}
+
+function parseChatGPTFormat(data: any[]): {
+  conversations: Conversation[];
+  messages: Message[];
+} {
+  const conversations: Conversation[] = [];
+  const messages: Message[] = [];
+
+  for (const conv of data) {
+    const id =
+      typeof conv.conversation_id === "string" ? conv.conversation_id : crypto.randomUUID();
+
+    conversations.push({
+      id,
+      title: typeof conv.title === "string" ? conv.title : "Imported Conversation",
+      model: "default",
+      created_at: (conv.create_time || Date.now() / 1000) * 1000,
+      updated_at: (conv.update_time || Date.now() / 1000) * 1000,
+    });
+
+    if (conv.mapping) {
+      let lastModel = null;
+
+      // We need to repair the parent_id chain for skipped nodes (e.g. system nodes or empty nodes)
+      const skippedNodes = new Map<string, string | null>();
+
+      // First pass: identify skipped nodes and their parents
+      for (const key in conv.mapping) {
+        const node = conv.mapping[key];
+        const msgData = node.message;
+
+        let skip = false;
+        if (!msgData) {
+          skip = true;
+        } else {
+          const role = msgData.author?.role;
+          // WaiChat only supports user and assistant roles
+          if (role !== "user" && role !== "assistant") {
+            skip = true;
+          }
+        }
+
+        if (skip) {
+          skippedNodes.set(key, node.parent || null);
+        }
+      }
+
+      // Helper to resolve the actual parent ID by bypassing skipped nodes
+      const resolveParent = (parentId: string | null): string | undefined => {
+        let current = parentId;
+        while (current && skippedNodes.has(current)) {
+          current = skippedNodes.get(current) || null;
+        }
+        return current || undefined;
+      };
+
+      for (const key in conv.mapping) {
+        if (skippedNodes.has(key)) continue;
+
+        const node = conv.mapping[key];
+        const msgData = node.message;
+
+        let content = "";
+        if (msgData.content?.parts) {
+          content = msgData.content.parts.filter((p: any) => typeof p === "string").join("\n");
+        } else if (typeof msgData.content === "string") {
+          content = msgData.content;
+        }
+
+        const model = msgData.metadata?.model || null;
+        if (model) lastModel = model;
+
+        messages.push({
+          id: String(msgData.id || key),
+          conversation_id: id,
+          role: msgData.author.role as "user" | "assistant",
+          content: content,
+          created_at: (msgData.create_time || Date.now() / 1000) * 1000,
+          model: model,
+          parent_id: resolveParent(node.parent || null),
+        });
+      }
+
+      if (lastModel) {
+        conversations[conversations.length - 1].model = lastModel;
+      }
+    }
+  }
+
+  return { conversations, messages };
+}

--- a/src/client/utils/importUtils.ts
+++ b/src/client/utils/importUtils.ts
@@ -2,7 +2,7 @@ import { strFromU8, unzipSync } from "fflate";
 import type { Conversation, Message } from "../storage";
 
 const MAX_COMPRESSED_SIZE = 50 * 1024 * 1024; // 50MB
-const MAX_UNCOMPRESSED_SIZE = 500 * 1024 * 1024; // 500MB
+const MAX_UNCOMPRESSED_SIZE = 100 * 1024 * 1024; // 100MB
 
 export interface ImportResult {
   scope: "local" | "cloud" | "both" | "external";

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -142,16 +142,8 @@ export async function importConversation(
   conversation: Conversation,
   messages: Message[],
 ): Promise<void> {
-  // Idempotency check
-  const existing = await getConversation(db, conversation.id);
-  if (existing) {
-    if (existing.import_complete === 1) {
-      // Previous import completed successfully - idempotent success
-      return;
-    }
-    // Partial leftover from a failed import - clean up
-    await deleteConversation(db, conversation.id);
-  }
+  // Removed idempotency check that prevented overwriting.
+  // Using INSERT OR REPLACE below handles upserts safely.
 
   const BATCH_SIZE = 99;
 
@@ -159,7 +151,7 @@ export async function importConversation(
   const msgStatements = messages.map((m) =>
     db
       .prepare(
-        "INSERT INTO messages (id, conversation_id, role, content, created_at, model, parent_id, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT OR REPLACE INTO messages (id, conversation_id, role, content, created_at, model, parent_id, deleted_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
       )
       .bind(
         m.id,
@@ -176,7 +168,7 @@ export async function importConversation(
   // First batch: conversation INSERT + first chunk of messages
   const convInsert = db
     .prepare(
-      "INSERT INTO conversations (id, title, model, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+      "INSERT OR REPLACE INTO conversations (id, title, model, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
     )
     .bind(
       conversation.id,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -151,9 +151,15 @@ app.get("/api/export", async (c) => {
   try {
     const db = c.env.DB;
     // Fetch all records from the database
-    const { results: conversations } = await db.prepare("SELECT * FROM conversations").all();
-    const { results: messages } = await db.prepare("SELECT * FROM messages").all();
-    const { results: settingsRaw } = await db.prepare("SELECT * FROM settings").all();
+    const { results: conversations } = await db
+      .prepare("SELECT id, title, model, created_at, updated_at FROM conversations")
+      .all();
+    const { results: messages } = await db
+      .prepare(
+        "SELECT id, conversation_id, role, content, created_at, model, parent_id FROM messages WHERE deleted_at IS NULL",
+      )
+      .all();
+    const { results: settingsRaw } = await db.prepare("SELECT key, value FROM settings").all();
 
     // Reformat settings into a simple key-value object
     const settings: Record<string, string> = {};

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -156,10 +156,10 @@ app.get("/api/export", async (c) => {
     const { results: settingsRaw } = await db.prepare("SELECT * FROM settings").all();
 
     // Reformat settings into a simple key-value object
-    const settings = (settingsRaw as { key: string; value: string }[]).reduce(
-      (acc, curr) => ({ ...acc, [curr.key]: curr.value }),
-      {} as Record<string, string>,
-    );
+    const settings: Record<string, string> = {};
+    for (const { key, value } of settingsRaw as { key: string; value: string }[]) {
+      settings[key] = value;
+    }
 
     return c.json({ conversations, messages, settings });
   } catch (e) {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -150,16 +150,29 @@ app.get("/api/conversations", async (c) => {
 app.get("/api/export", async (c) => {
   try {
     const db = c.env.DB;
-    // Fetch all records from the database
-    const { results: conversations } = await db
-      .prepare("SELECT id, title, model, created_at, updated_at FROM conversations")
-      .all();
-    const { results: messages } = await db
-      .prepare(
-        "SELECT id, conversation_id, role, content, created_at, model, parent_id FROM messages WHERE deleted_at IS NULL",
-      )
-      .all();
-    const { results: settingsRaw } = await db.prepare("SELECT key, value FROM settings").all();
+
+    // Helper to fetch all rows using pagination (bypass 10k limit)
+    const fetchAll = async (query: string) => {
+      const results: any[] = [];
+      const LIMIT = 10000;
+      let offset = 0;
+      while (true) {
+        const batch = await db.prepare(`${query} LIMIT ${LIMIT} OFFSET ${offset}`).all();
+        if (!batch.results || batch.results.length === 0) break;
+        results.push(...batch.results);
+        if (batch.results.length < LIMIT) break;
+        offset += LIMIT;
+      }
+      return results;
+    };
+
+    const conversations = await fetchAll(
+      "SELECT id, title, model, created_at, updated_at FROM conversations",
+    );
+    const messages = await fetchAll(
+      "SELECT id, conversation_id, role, content, created_at, model, parent_id FROM messages WHERE deleted_at IS NULL",
+    );
+    const settingsRaw = await fetchAll("SELECT key, value FROM settings");
 
     // Reformat settings into a simple key-value object
     const settings: Record<string, string> = {};

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -146,6 +146,28 @@ app.get("/api/conversations", async (c) => {
   return c.json(conversations);
 });
 
+// Export all workspace data (conversations, messages, settings)
+app.get("/api/export", async (c) => {
+  try {
+    const db = c.env.DB;
+    // Fetch all records from the database
+    const { results: conversations } = await db.prepare("SELECT * FROM conversations").all();
+    const { results: messages } = await db.prepare("SELECT * FROM messages").all();
+    const { results: settingsRaw } = await db.prepare("SELECT * FROM settings").all();
+
+    // Reformat settings into a simple key-value object
+    const settings = (settingsRaw as { key: string; value: string }[]).reduce(
+      (acc, curr) => ({ ...acc, [curr.key]: curr.value }),
+      {} as Record<string, string>,
+    );
+
+    return c.json({ conversations, messages, settings });
+  } catch (e) {
+    console.error("[GET /api/export] error:", e);
+    return c.json({ error: "Export failed" }, 500);
+  }
+});
+
 app.post("/api/conversations", async (c) => {
   const body = await c.req.json<{ model: string }>();
   const now = Date.now();


### PR DESCRIPTION
## Description

- Added `GET /api/export` backend endpoint for bulk cloud data retrieval.
- Implemented client-side ZIP assembly and extraction using `fflate`.
- Added Export Scope selector (Local, Cloud, Both) to Settings UI.
- Implemented nested ZIP structure and manifest support for multi-mode exports.
- Added intelligent import routing with ChatGPT compatibility mode fallback.
- Fixed TypeScript type mismatches for API responses and Blob construction.

**Closes #53**


## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `feat/53-export-import-workspace-data` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/53-export-import-workspace-data)
