### PR TITLE
feat: exclude deprecated Workers AI models (#32)

### DIFF
--- a/src/worker/config/model-exclusions.ts
+++ b/src/worker/config/model-exclusions.ts
@@ -26,7 +26,18 @@ const DEPRECATED: string[] = [
 ];
 
 /** Models present in the catalog but consistently unavailable (non-deprecated reasons) */
-const UNAVAILABLE: string[] = [];
+const UNAVAILABLE: string[] = [
+  /** Error 5016: Requires license agreement 'agree' prompt (@todo: Needs to be addressed in a separate issue) */
+  "@cf/meta/llama-3.2-11b-vision-instruct",
+  /** Error 5006: Incorrect role handling */
+  "@cf/meta/llama-guard-3-8b",
+  /** No output response */
+  "@hf/nousresearch/hermes-2-pro-mistral-7b",
+  /** Error 5021: Context window limit exceeded */
+  "@cf/microsoft/phi-2",
+  /** Error 5021/1031: Context window limit exceeded or upstream error */
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora",
+];
 
 /** Other exclusions */
 const OTHER: string[] = [];

--- a/src/worker/config/model-exclusions.ts
+++ b/src/worker/config/model-exclusions.ts
@@ -29,14 +29,17 @@ const DEPRECATED: string[] = [
 const UNAVAILABLE: string[] = [
   /** Error 5016: Requires license agreement 'agree' prompt (@todo: Needs to be addressed in a separate issue) */
   "@cf/meta/llama-3.2-11b-vision-instruct",
+
   /** Error 5006: Incorrect role handling */
   "@cf/meta/llama-guard-3-8b",
+
   /** No output response */
   "@hf/nousresearch/hermes-2-pro-mistral-7b",
-  /** Error 5021: Context window limit exceeded */
+
+  /** Error 5021/1031: Unlike standard 5021 context limit errors that resolve in a new chat,
+   * these models fail even in new sessions, suggesting a different root cause. */
   "@cf/microsoft/phi-2",
-  /** Error 5021/1031: Context window limit exceeded or upstream error */
-  "@cf/meta-llama/llama-2-7b-chat-hf-lora",
+  "@cf/meta-llama/llama-2-7b-chat-hf-lora", // 1031
 ];
 
 /** Other exclusions */

--- a/src/worker/config/model-exclusions.ts
+++ b/src/worker/config/model-exclusions.ts
@@ -1,0 +1,39 @@
+/**
+ * System-level model exclusions.
+ * These models are never shown to users regardless of user preferences.
+ */
+
+/** Error 5028: Deprecated on 2025-10-01 */
+const DEPRECATED: string[] = [
+  "@hf/thebloke/deepseek-coder-6.7b-base-awq",
+  "@hf/thebloke/deepseek-coder-6.7b-instruct-awq",
+  "@cf/qwen/qwen1.5-14b-chat-awq",
+  "@hf/thebloke/openhermes-2.5-mistral-7b-awq",
+  "@cf/qwen/qwen1.5-1.8b-chat",
+  "@cf/qwen/qwen1.5-7b-chat-awq",
+  "@hf/nexusflow/starling-lm-7b-beta",
+  "@hf/thebloke/neural-chat-7b-v3-1-awq",
+  "@cf/fblgit/una-cybertron-7b-v2-bf16",
+  "@cf/thebloke/discolm-german-7b-v1-awq",
+  "@cf/deepseek-ai/deepseek-math-7b-instruct",
+  "@cf/tiiuae/falcon-7b-instruct",
+  "@hf/thebloke/zephyr-7b-beta-awq",
+  "@cf/openchat/openchat-3.5-0106",
+  "@cf/qwen/qwen1.5-0.5b-chat",
+  "@cf/tinyllama/tinyllama-1.1b-chat-v1.0",
+  "@hf/thebloke/mistral-7b-instruct-v0.1-awq",
+  "@hf/thebloke/llama-2-13b-chat-awq",
+];
+
+/** Models present in the catalog but consistently unavailable (non-deprecated reasons) */
+const UNAVAILABLE: string[] = [];
+
+/** Other exclusions */
+const OTHER: string[] = [];
+
+export const EXCLUDED_MODELS = new Set([...DEPRECATED, ...UNAVAILABLE, ...OTHER]);
+
+/** Maps error codes to their excluded model IDs - useful for logging and future admin tooling */
+export const EXCLUDED_BY_ERROR: Record<string, string[]> = {
+  "5028": DEPRECATED,
+};

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { AVAILABLE_MODELS, generateTitle, streamAiResponse } from "./ai";
+import { EXCLUDED_MODELS } from "./config/model-exclusions";
 import {
   createConversation,
   deleteConversation,
@@ -136,6 +137,7 @@ async function fetchDynamicModels(accountId: string, apiToken: string): Promise<
 
   return data.result
     .map((m) => ({ id: m.name, name: formatModelName(m.name) }))
+    .filter((m) => !EXCLUDED_MODELS.has(m.id))
     .sort((a, b) => scoreModel(b.id) - scoreModel(a.id));
 }
 
@@ -170,7 +172,7 @@ app.get("/api/models", async (c) => {
   }
 
   if (!accountId || !apiToken) {
-    return c.json(AVAILABLE_MODELS);
+    return c.json(AVAILABLE_MODELS.filter((m) => !EXCLUDED_MODELS.has(m.id)));
   }
 
   // Fetch & Cache
@@ -181,7 +183,7 @@ app.get("/api/models", async (c) => {
   } catch (e) {
     console.error("[/api/models] error:", e);
     // Fallback to hardcoded list if API call fails
-    return c.json(AVAILABLE_MODELS);
+    return c.json(AVAILABLE_MODELS.filter((m) => !EXCLUDED_MODELS.has(m.id)));
   }
 });
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -20,6 +20,8 @@ import {
 } from "./db";
 import type { ChatRequest, Env, Model } from "./types";
 
+const FILTERED_AVAILABLE_MODELS = AVAILABLE_MODELS.filter((m) => !EXCLUDED_MODELS.has(m.id));
+
 // Isolate-specific in-memory cache for models
 let modelCache: { data: Model[]; timestamp: number } | null = null;
 const CACHE_TTL = 60 * 60 * 1000; // 1 hour
@@ -136,8 +138,8 @@ async function fetchDynamicModels(accountId: string, apiToken: string): Promise<
   }
 
   return data.result
+    .filter((m) => !EXCLUDED_MODELS.has(m.name))
     .map((m) => ({ id: m.name, name: formatModelName(m.name) }))
-    .filter((m) => !EXCLUDED_MODELS.has(m.id))
     .sort((a, b) => scoreModel(b.id) - scoreModel(a.id));
 }
 
@@ -172,7 +174,7 @@ app.get("/api/models", async (c) => {
   }
 
   if (!accountId || !apiToken) {
-    return c.json(AVAILABLE_MODELS.filter((m) => !EXCLUDED_MODELS.has(m.id)));
+    return c.json(FILTERED_AVAILABLE_MODELS);
   }
 
   // Fetch & Cache
@@ -183,7 +185,7 @@ app.get("/api/models", async (c) => {
   } catch (e) {
     console.error("[/api/models] error:", e);
     // Fallback to hardcoded list if API call fails
-    return c.json(AVAILABLE_MODELS.filter((m) => !EXCLUDED_MODELS.has(m.id)));
+    return c.json(FILTERED_AVAILABLE_MODELS);
   }
 });
 


### PR DESCRIPTION
## Description

- Introduce system-level model exclusion list in `src/worker/config/model-exclusions.ts`
- Filter 18 deprecated models that return 5028 error from the dynamic catalog API
- Apply filtering to the hardcoded fallback model list for consistency

**Fixes #32**



## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `feat/32-exclude-deprecated-models` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/32-exclude-deprecated-models)
