### PR TITLE
feat: implement manual rename chat feature (#86)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -104,6 +104,7 @@ export default function App() {
     retryMessage,
     setActiveVersion,
     deleteMessage,
+    renameConversation,
   } = useChat(storageMode, pendingSelectionRef);
 
   const { transferState, initiateMove, executeMove, cancelMove, retryPendingCloudDeletes } =
@@ -569,6 +570,7 @@ export default function App() {
           onNew={handleNew}
           onDelete={deleteConversation}
           onMove={handleMoveConversation}
+          onRename={renameConversation}
           onSettingsOpen={() => setSettingsOpen(true)}
           currentMode={storageMode}
           savedMode={savedStorageMode}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -225,7 +225,11 @@ export default function Sidebar({
                       }}
                       onBlur={() => !isRenaming && setEditingId(null)}
                       disabled={isRenaming}
-                      className="w-full bg-white/50 dark:bg-black/20 border border-black/10 dark:border-white/20 rounded px-1.5 py-0.5 outline-none text-[13px] md:text-sm focus:ring-1 focus:ring-brand-cloud/50"
+                      className={`w-full bg-white/50 dark:bg-black/20 border border-black/10 dark:border-white/20 rounded px-1.5 py-0.5 outline-none text-[13px] md:text-sm focus:ring-1 ${
+                        currentMode === "cloud"
+                          ? "focus:ring-brand-cloud/50"
+                          : "focus:ring-brand-local/50"
+                      }`}
                     />
                   </div>
                 ) : (

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -224,7 +224,7 @@ export default function Sidebar({
               <div
                 key={c.id}
                 data-id={c.id}
-                className={`group flex items-center rounded-lg pl-3 pr-0 py-1.5 cursor-pointer text-[13px] md:text-sm transition-all duration-150 [--fade-size:1.1rem] hover:[--fade-size:2rem] ${
+                className={`group relative flex items-center rounded-lg pl-3 pr-0 py-1.5 cursor-pointer text-[13px] md:text-sm transition-all duration-150 [--fade-size:1.1rem] hover:[--fade-size:2rem] ${
                   openMenuId === c.id ? "[--fade-size:2rem]" : ""
                 } ${
                   activeId === c.id

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -41,19 +41,14 @@ export default function Sidebar({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
+  const [isMobileMenu, setIsMobileMenu] = useState(false);
+  const [menuPos, setMenuPos] = useState<{ top?: number; bottom?: number; left?: number }>({});
   const menuRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isLongPressRef = useRef(false);
+  const justOpenedRef = useRef(false);
   const targetMode: StorageMode = currentMode === "cloud" ? "local" : "cloud";
-
-  const handleTouchStart = (cId: string) => {
-    if (longPressTimer.current) clearTimeout(longPressTimer.current);
-    longPressTimer.current = setTimeout(() => {
-      setOpenMenuId(cId);
-      longPressTimer.current = null;
-    }, 500);
-  };
-
   const handleTouchEnd = () => {
     if (longPressTimer.current) {
       clearTimeout(longPressTimer.current);
@@ -70,6 +65,10 @@ export default function Sidebar({
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
+      if (justOpenedRef.current) {
+        justOpenedRef.current = false;
+        return;
+      }
       if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
         setOpenMenuId(null);
       }
@@ -194,18 +193,53 @@ export default function Sidebar({
             const isMoving = movingConversationId === c.id;
             const isMoveDisabled = isMoving || (activeId === c.id && isStreaming);
 
+            const onTouchStart = (e: React.TouchEvent) => {
+              isLongPressRef.current = false;
+              const rect = e.currentTarget.getBoundingClientRect();
+              if (longPressTimer.current) clearTimeout(longPressTimer.current);
+              longPressTimer.current = setTimeout(() => {
+                const menuHeight = 160;
+                const viewportHeight = window.innerHeight;
+                const hasSpaceBelow = rect.bottom + menuHeight < viewportHeight;
+
+                setIsMobileMenu(true);
+                if (hasSpaceBelow) {
+                  setMenuPos({ top: rect.bottom + 8, left: 16 });
+                } else {
+                  setMenuPos({ bottom: viewportHeight - rect.top + 8, left: 16 });
+                }
+
+                justOpenedRef.current = true;
+                setOpenMenuId(c.id);
+                isLongPressRef.current = true;
+                longPressTimer.current = null;
+              }, 500);
+            };
+
             return (
               <div
                 key={c.id}
-                className={`group flex items-center justify-between rounded-lg px-3 py-2 cursor-pointer text-[13px] md:text-sm transition-all duration-150 ${
+                className={`group flex items-center rounded-lg pl-3 pr-0 py-1.5 cursor-pointer text-[13px] md:text-sm transition-all duration-150 [--fade-size:1.1rem] hover:[--fade-size:2rem] ${
+                  openMenuId === c.id ? "[--fade-size:2rem]" : ""
+                } ${
                   activeId === c.id
                     ? currentMode === "cloud"
                       ? "bg-brand-cloud text-white font-medium"
                       : "bg-brand-local text-gray-900 font-medium"
-                    : "text-gray-600 hover:bg-black/5 hover:text-gray-900 dark:text-white/65 dark:hover:bg-white/5 dark:hover:text-white/95"
+                    : `${
+                        openMenuId === c.id
+                          ? "bg-black/8 dark:bg-white/10 text-gray-900 dark:text-white"
+                          : "text-gray-600 dark:text-white/65"
+                      } hover:bg-black/5 hover:text-gray-900 dark:hover:bg-white/5 dark:hover:text-white/95`
                 }`}
-                onClick={() => onSelect(c.id)}
-                onTouchStart={() => handleTouchStart(c.id)}
+                onClick={() => {
+                  if (isLongPressRef.current) {
+                    isLongPressRef.current = false;
+                    return;
+                  }
+                  onSelect(c.id);
+                }}
+                onTouchStart={onTouchStart}
                 onTouchEnd={handleTouchEnd}
                 onTouchMove={handleTouchMove}
                 onContextMenu={(e) => {
@@ -233,13 +267,30 @@ export default function Sidebar({
                     />
                   </div>
                 ) : (
-                  <span className="truncate">{c.title}</span>
+                  <div
+                    className="flex-1 relative overflow-hidden min-w-0 w-full transition-all duration-200"
+                    style={{
+                      maskImage:
+                        "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
+                      WebkitMaskImage:
+                        "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
+                    }}
+                  >
+                    <span className="whitespace-nowrap">{c.title}</span>
+                  </div>
                 )}
-                <div className="flex items-center shrink-0 ml-2">
-                  <div className="relative" ref={openMenuId === c.id ? menuRef : null}>
+                <div
+                  className={`hidden md:flex items-center shrink-0 transition-all duration-200 overflow-hidden ${
+                    openMenuId === c.id
+                      ? "w-8 ml-2 opacity-100"
+                      : "w-0 opacity-0 group-hover:w-8 group-hover:ml-2 group-hover:opacity-100"
+                  }`}
+                >
+                  <div className="relative">
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
+                        setIsMobileMenu(false);
                         setOpenMenuId(openMenuId === c.id ? null : c.id);
                       }}
                       className={`p-1.5 rounded-md focus:outline-none transition-all ${
@@ -268,113 +319,121 @@ export default function Sidebar({
                         <circle cx="12" cy="19" r="1" strokeWidth="2" />
                       </svg>
                     </button>
-
-                    {openMenuId === c.id && (
-                      <div
-                        role="menu"
-                        className="absolute right-0 mt-1 w-44 rounded-xl bg-white dark:bg-[#1c1c1e] shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-50 overflow-hidden backdrop-blur-xl"
-                      >
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleRenameClick(c);
-                          }}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-                          role="menuitem"
-                        >
-                          <svg
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            className="w-3.5 h-3.5"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth="2"
-                              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                            />
-                          </svg>
-                          Rename
-                        </button>
-                        <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setOpenMenuId(null);
-                            if (!isMoveDisabled) setPendingMove(c);
-                          }}
-                          disabled={isMoveDisabled}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                          role="menuitem"
-                        >
-                          {isMoving ? (
-                            <svg
-                              className="w-3.5 h-3.5 animate-spin"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                            >
-                              <circle
-                                cx="12"
-                                cy="12"
-                                r="10"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                opacity="0.25"
-                              />
-                              <path
-                                d="M4 12a8 8 0 018-8"
-                                stroke="currentColor"
-                                strokeWidth="2"
-                                strokeLinecap="round"
-                              />
-                            </svg>
-                          ) : (
-                            <svg
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              className="w-3.5 h-3.5"
-                            >
-                              <path
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                strokeWidth="2"
-                                d="M7 17L17 7M17 7H8M17 7v9"
-                              />
-                            </svg>
-                          )}
-                          Move Chat to {targetMode === "cloud" ? "Cloud" : "Local"}
-                        </button>
-                        <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setOpenMenuId(null);
-                            setPendingDelete(c);
-                          }}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
-                          role="menuitem"
-                        >
-                          <svg
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            className="w-3.5 h-3.5"
-                          >
-                            <path
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                              strokeWidth="2"
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                          </svg>
-                          Delete
-                        </button>
-                      </div>
-                    )}
                   </div>
                 </div>
+
+                {openMenuId === c.id && (
+                  <div
+                    ref={menuRef}
+                    role="menu"
+                    className={`${
+                      isMobileMenu ? "fixed" : "absolute right-2 mt-8"
+                    } w-44 rounded-xl bg-white dark:bg-[#1c1c1e] shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-[100] overflow-hidden backdrop-blur-xl`}
+                    style={
+                      isMobileMenu
+                        ? {
+                            top: menuPos.top,
+                            bottom: menuPos.bottom,
+                            left: menuPos.left,
+                          }
+                        : {}
+                    }
+                  >
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleRenameClick(c);
+                      }}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                      role="menuitem"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                        />
+                      </svg>
+                      Rename
+                    </button>
+                    <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setOpenMenuId(null);
+                        if (!isMoveDisabled) setPendingMove(c);
+                      }}
+                      disabled={isMoveDisabled}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                      role="menuitem"
+                    >
+                      {isMoving ? (
+                        <svg className="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none">
+                          <circle
+                            cx="12"
+                            cy="12"
+                            r="10"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            opacity="0.25"
+                          />
+                          <path
+                            d="M4 12a8 8 0 018-8"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                          />
+                        </svg>
+                      ) : (
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          className="w-3.5 h-3.5"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth="2"
+                            d="M7 17L17 7M17 7H8M17 7v9"
+                          />
+                        </svg>
+                      )}
+                      Move Chat to {targetMode === "cloud" ? "Cloud" : "Local"}
+                    </button>
+                    <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setOpenMenuId(null);
+                        setPendingDelete(c);
+                      }}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
+                      role="menuitem"
+                    >
+                      <svg
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        className="w-3.5 h-3.5"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="2"
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
+                      </svg>
+                      Delete
+                    </button>
+                  </div>
+                )}
               </div>
             );
           })}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Conversation, StorageMode } from "../storage";
 import ConfirmModal from "./ConfirmModal";
 
@@ -43,12 +43,40 @@ export default function Sidebar({
   const [isRenaming, setIsRenaming] = useState(false);
   const [isMobileMenu, setIsMobileMenu] = useState(false);
   const [menuPos, setMenuPos] = useState<{ top?: number; bottom?: number; left?: number }>({});
+  const MENU_HEIGHT_ESTIMATE = 160;
   const menuRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isLongPressRef = useRef(false);
   const justOpenedRef = useRef(false);
   const targetMode: StorageMode = currentMode === "cloud" ? "local" : "cloud";
+
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const id = e.currentTarget.getAttribute("data-id");
+    if (!id) return;
+
+    isLongPressRef.current = false;
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (longPressTimer.current) clearTimeout(longPressTimer.current);
+
+    longPressTimer.current = setTimeout(() => {
+      const viewportHeight = window.innerHeight;
+      const hasSpaceBelow = rect.bottom + MENU_HEIGHT_ESTIMATE < viewportHeight;
+
+      setIsMobileMenu(true);
+      if (hasSpaceBelow) {
+        setMenuPos({ top: rect.bottom + 8, left: 16 });
+      } else {
+        setMenuPos({ bottom: viewportHeight - rect.top + 8, left: 16 });
+      }
+
+      justOpenedRef.current = true;
+      setOpenMenuId(id);
+      isLongPressRef.current = true;
+      longPressTimer.current = null;
+    }, 500);
+  }, []);
+
   const handleTouchEnd = () => {
     if (longPressTimer.current) {
       clearTimeout(longPressTimer.current);
@@ -114,9 +142,8 @@ export default function Sidebar({
       await onRename(id, trimmed);
       setEditingId(null);
     } catch (err) {
-      // Error is handled in useChat (setError), but we might want to keep the input open?
-      // Actually, UX-wise, if it fails, closing it is fine since the error is visible.
-      setEditingId(null);
+      // Keep the input open on error so the user doesn't lose their changes.
+      // The error message is handled by useChat's error state.
     } finally {
       setIsRenaming(false);
     }
@@ -193,32 +220,10 @@ export default function Sidebar({
             const isMoving = movingConversationId === c.id;
             const isMoveDisabled = isMoving || (activeId === c.id && isStreaming);
 
-            const onTouchStart = (e: React.TouchEvent) => {
-              isLongPressRef.current = false;
-              const rect = e.currentTarget.getBoundingClientRect();
-              if (longPressTimer.current) clearTimeout(longPressTimer.current);
-              longPressTimer.current = setTimeout(() => {
-                const menuHeight = 160;
-                const viewportHeight = window.innerHeight;
-                const hasSpaceBelow = rect.bottom + menuHeight < viewportHeight;
-
-                setIsMobileMenu(true);
-                if (hasSpaceBelow) {
-                  setMenuPos({ top: rect.bottom + 8, left: 16 });
-                } else {
-                  setMenuPos({ bottom: viewportHeight - rect.top + 8, left: 16 });
-                }
-
-                justOpenedRef.current = true;
-                setOpenMenuId(c.id);
-                isLongPressRef.current = true;
-                longPressTimer.current = null;
-              }, 500);
-            };
-
             return (
               <div
                 key={c.id}
+                data-id={c.id}
                 className={`group flex items-center rounded-lg pl-3 pr-0 py-1.5 cursor-pointer text-[13px] md:text-sm transition-all duration-150 [--fade-size:1.1rem] hover:[--fade-size:2rem] ${
                   openMenuId === c.id ? "[--fade-size:2rem]" : ""
                 } ${
@@ -239,7 +244,7 @@ export default function Sidebar({
                   }
                   onSelect(c.id);
                 }}
-                onTouchStart={onTouchStart}
+                onTouchStart={handleTouchStart}
                 onTouchEnd={handleTouchEnd}
                 onTouchMove={handleTouchMove}
                 onContextMenu={(e) => {

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -11,6 +11,7 @@ interface SidebarProps {
   onNew: (mode?: StorageMode) => void;
   onDelete: (id: string) => void;
   onMove: (id: string) => void;
+  onRename: (id: string, title: string) => Promise<void>;
   onSettingsOpen: () => void;
   currentMode: StorageMode;
   savedMode: StorageMode;
@@ -27,6 +28,7 @@ export default function Sidebar({
   onNew,
   onDelete,
   onMove,
+  onRename,
   onSettingsOpen,
   currentMode,
   savedMode, // Kept in props to satisfy the interface and App.tsx
@@ -36,7 +38,11 @@ export default function Sidebar({
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
   const [pendingMove, setPendingMove] = useState<Conversation | null>(null);
   const [openMenuId, setOpenMenuId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [isRenaming, setIsRenaming] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const editInputRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const targetMode: StorageMode = currentMode === "cloud" ? "local" : "cloud";
 
@@ -82,6 +88,40 @@ export default function Sidebar({
       if (longPressTimer.current) clearTimeout(longPressTimer.current);
     };
   }, [openMenuId]);
+
+  useEffect(() => {
+    if (editingId && editInputRef.current) {
+      editInputRef.current.focus();
+      editInputRef.current.select();
+    }
+  }, [editingId]);
+
+  const handleRenameClick = (c: Conversation) => {
+    setEditTitle(c.title);
+    setEditingId(c.id);
+    setOpenMenuId(null);
+  };
+
+  const handleSaveRename = async (id: string) => {
+    if (isRenaming) return;
+    const trimmed = editTitle.trim();
+    if (!trimmed) {
+      setEditingId(null);
+      return;
+    }
+
+    setIsRenaming(true);
+    try {
+      await onRename(id, trimmed);
+      setEditingId(null);
+    } catch (err) {
+      // Error is handled in useChat (setError), but we might want to keep the input open?
+      // Actually, UX-wise, if it fails, closing it is fine since the error is visible.
+      setEditingId(null);
+    } finally {
+      setIsRenaming(false);
+    }
+  };
 
   return (
     <>
@@ -172,7 +212,25 @@ export default function Sidebar({
                   if (window.innerWidth < 768) e.preventDefault();
                 }}
               >
-                <span className="truncate">{c.title}</span>
+                {editingId === c.id ? (
+                  <div className="flex-1 min-w-0" onClick={(e) => e.stopPropagation()}>
+                    <input
+                      ref={editInputRef}
+                      type="text"
+                      value={editTitle}
+                      onChange={(e) => setEditTitle(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") handleSaveRename(c.id);
+                        if (e.key === "Escape") setEditingId(null);
+                      }}
+                      onBlur={() => !isRenaming && setEditingId(null)}
+                      disabled={isRenaming}
+                      className="w-full bg-white/50 dark:bg-black/20 border border-black/10 dark:border-white/20 rounded px-1.5 py-0.5 outline-none text-[13px] md:text-sm focus:ring-1 focus:ring-brand-cloud/50"
+                    />
+                  </div>
+                ) : (
+                  <span className="truncate">{c.title}</span>
+                )}
                 <div className="flex items-center shrink-0 ml-2">
                   <div className="relative" ref={openMenuId === c.id ? menuRef : null}>
                     <button
@@ -212,6 +270,30 @@ export default function Sidebar({
                         role="menu"
                         className="absolute right-0 mt-1 w-44 rounded-xl bg-white dark:bg-[#1c1c1e] shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-50 overflow-hidden backdrop-blur-xl"
                       >
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleRenameClick(c);
+                          }}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                          role="menuitem"
+                        >
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            className="w-3.5 h-3.5"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth="2"
+                              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                            />
+                          </svg>
+                          Rename
+                        </button>
+                        <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
                         <button
                           onClick={(e) => {
                             e.stopPropagation();

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -40,6 +40,7 @@ interface UseChatReturn {
   ) => Promise<void>;
   setActiveVersion: (parentId: string, messageId: string) => void;
   deleteMessage: (messageId: string) => Promise<void>;
+  renameConversation: (id: string, title: string) => Promise<void>;
 }
 
 export function useChat(
@@ -656,5 +657,28 @@ export function useChat(
     retryMessage,
     setActiveVersion: setActiveVersionCb,
     deleteMessage: deleteMessageCb,
+    renameConversation: async (id: string, title: string) => {
+      const trimmed = title.trim();
+      if (!trimmed) return;
+
+      const current = conversations.find((c) => c.id === id);
+      if (!current || current.title === trimmed) return;
+
+      try {
+        await storage.updateConversationTitle(id, trimmed);
+
+        // Update local list
+        setConversations((prev) => prev.map((c) => (c.id === id ? { ...c, title: trimmed } : c)));
+
+        // Update active conversation if it's the one being renamed
+        if (activeConversation?.id === id) {
+          setActiveConversation((prev) => (prev ? { ...prev, title: trimmed } : null));
+        }
+      } catch (err) {
+        console.error("Failed to rename conversation:", err);
+        setError("Failed to rename conversation");
+        throw err; // Re-throw so the UI can handle UI-specific logic (like closing the input)
+      }
+    },
   };
 }

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -1,4 +1,4 @@
-import type { StorageAdapter, Conversation, Message, DeleteMessageResult } from "./index";
+import type { Conversation, DeleteMessageResult, Message, StorageAdapter } from "./index";
 
 export class CloudStorage implements StorageAdapter {
   async getConversations(): Promise<Conversation[]> {
@@ -30,7 +30,7 @@ export class CloudStorage implements StorageAdapter {
     const res = await fetch(`/api/conversations/${id}`, { method: "DELETE" });
     if (!res.ok) throw new Error("Failed to delete conversation");
   }
-  
+
   async updateConversationModel(id: string, model: string): Promise<void> {
     const res = await fetch(`/api/conversations/${id}`, {
       method: "PATCH",
@@ -50,7 +50,12 @@ export class CloudStorage implements StorageAdapter {
   }
 
   async updateConversationTitle(id: string, title: string): Promise<void> {
-    // Title is updated server-side after first message — nothing to do here
+    const res = await fetch(`/api/conversations/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title }),
+    });
+    if (!res.ok) throw new Error("Failed to update conversation title");
   }
 
   async deleteMessage(conversationId: string, messageId: string): Promise<DeleteMessageResult> {

--- a/src/worker/db.ts
+++ b/src/worker/db.ts
@@ -34,10 +34,7 @@ export async function updateConversationTitle(
   id: string,
   title: string,
 ): Promise<void> {
-  await db
-    .prepare("UPDATE conversations SET title = ?, updated_at = ? WHERE id = ?")
-    .bind(title, Date.now(), id)
-    .run();
+  await db.prepare("UPDATE conversations SET title = ? WHERE id = ?").bind(title, id).run();
 }
 
 export async function updateConversationModel(

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -389,6 +389,8 @@ app.patch("/api/conversations/:id", async (c) => {
   if (body.model) {
     updates.push("model = ?");
     params.push(body.model);
+    updates.push("updated_at = ?");
+    params.push(Date.now());
   }
   if (body.title) {
     updates.push("title = ?");
@@ -396,8 +398,6 @@ app.patch("/api/conversations/:id", async (c) => {
   }
 
   if (updates.length > 0) {
-    updates.push("updated_at = ?");
-    params.push(Date.now());
     params.push(id);
     await db
       .prepare(`UPDATE conversations SET ${updates.join(", ")} WHERE id = ?`)


### PR DESCRIPTION
## Description

- Added inline editing interaction in the Sidebar for renaming conversations.
- Decoupled title updates from the `updated_at` timestamp to ensure renames remain cosmetic and preserve sidebar sort order.
- Implemented `renameConversation` in the `useChat` hook with robust error handling and D1/LocalStorage persistence.
- Updated the `CloudStorage` adapter and Hono backend routes to support title-only PATCH updates.
- Added UX improvements: auto-focus on edit, text selection, and "Save on Enter / Cancel on Escape" logic.


**Fixes #86**


## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `feat/86-rename-chat` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/86-rename-chat)
