### PR TITLE
feat: replace alert-based notifications with a custom toast system via ToastProvider

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -4,8 +4,10 @@ import MessageList from "./components/MessageList";
 import ModelPicker from "./components/ModelPicker";
 import SettingsModal from "./components/SettingsModal";
 import Sidebar from "./components/Sidebar";
+import { ToastContainer } from "./components/Toast";
 import { useChat } from "./hooks/useChat";
 import { DEFAULT_MODEL_ID, useModels } from "./hooks/useModels";
+import { useToast } from "./hooks/useToast";
 import { useTransfer } from "./hooks/useTransfer";
 import type { Conversation, Message, StorageMode } from "./storage";
 import { createStorage } from "./storage";
@@ -22,6 +24,7 @@ const MOBILE_BREAKPOINT = 768;
 export type ThemeMode = "system" | "light" | "dark";
 
 export default function App() {
+  const toast = useToast();
   const [theme, setTheme] = useState<ThemeMode>(() => {
     if (typeof window !== "undefined") {
       const stored = localStorage.getItem(THEME_KEY);
@@ -89,7 +92,6 @@ export default function App() {
     activeConversation,
     messages,
     isStreaming,
-    error,
     activeBranch,
     activeVersions,
     loadConversations,
@@ -377,6 +379,8 @@ export default function App() {
       // Execute the move
       const movedId = await executeMove(storageMode, targetMode);
 
+      toast.success(`Chat moved to ${targetMode === "cloud" ? "Cloud" : "Local"} successfully!`);
+
       // If the moved conversation was the active one, clear it
       if (activeConversation?.id === conversationId) {
         clearConversation();
@@ -440,7 +444,7 @@ export default function App() {
       await exportWorkspace(scope, exportData);
     } catch (e) {
       console.error(e);
-      alert("Failed to export workspace");
+      toast.error("Failed to export workspace");
     }
   };
 
@@ -705,12 +709,6 @@ export default function App() {
             </div>
           </header>
 
-          {error && (
-            <div className="mx-6 mt-4 px-4 py-3 bg-red-100/50 dark:bg-red-900/30 border border-red-200 dark:border-red-500/30 rounded-lg text-sm text-red-600 dark:text-red-400">
-              {error}
-            </div>
-          )}
-
           <MessageList
             messages={messages}
             activeBranch={activeBranch}
@@ -767,6 +765,7 @@ export default function App() {
           refreshModels={refreshModels}
         />
       </div>
+      <ToastContainer />
     </div>
   );
 }

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { Model } from "../hooks/useModels";
+import { useToast } from "../hooks/useToast";
 import type { StorageMode } from "../storage";
 import CloudflareHelpModal from "./CloudflareHelpModal";
 import ModelPicker from "./ModelPicker";
@@ -48,6 +49,7 @@ export default function SettingsModal({
   onThemeChange,
   refreshModels,
 }: SettingsModalProps) {
+  const toast = useToast();
   const overlayRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -91,7 +93,7 @@ export default function SettingsModal({
 
   const handleConnect = async () => {
     if (!cfAccountId || !cfApiToken) {
-      alert("Account ID and API Token are required");
+      toast.warning("Account ID and API Token are required");
       return;
     }
     setIsConnecting(true);
@@ -104,7 +106,7 @@ export default function SettingsModal({
       const data = (await res.json()) as { error?: string; models?: Model[] };
       if (!res.ok) throw new Error(data.error || "Failed to connect");
 
-      alert("Connected successfully! Models updated.");
+      toast.success("Connected successfully! Models updated.");
       setCfAccountId("");
       setCfApiToken("");
       await fetchSecretsStatus();
@@ -112,7 +114,7 @@ export default function SettingsModal({
         refreshModels(data.models);
       }
     } catch (e: any) {
-      alert(e.message);
+      toast.error(e.message);
     } finally {
       setIsConnecting(false);
     }
@@ -131,11 +133,11 @@ export default function SettingsModal({
       const res = await fetch("/api/secrets", { method: "DELETE" });
       if (!res.ok) throw new Error("Failed to reset");
 
-      alert("Credentials reset successfully.");
+      toast.success("Credentials reset successfully.");
       await fetchSecretsStatus();
       refreshModels(); // Force-fetch static list
     } catch (e: any) {
-      alert(e.message);
+      toast.error(e.message);
     } finally {
       setIsResetting(false);
     }
@@ -216,11 +218,11 @@ export default function SettingsModal({
       await onImportWorkspace(pendingImportFile, setImportProgress);
       setImportProgress(null);
       setPendingImportFile(null);
-      alert("Workspace imported successfully!");
+      toast.success("Workspace imported successfully!");
     } catch (e: any) {
       setImportProgress(null);
       setPendingImportFile(null);
-      alert(e.message || "Failed to import workspace");
+      toast.error(e.message || "Failed to import workspace");
     }
   };
 

--- a/src/client/components/Toast.tsx
+++ b/src/client/components/Toast.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Toast, ToastType, useToast } from "../hooks/useToast";
+import { Toast, ToastType, useToast, useToasts } from "../hooks/useToast";
 
 export function ToastContainer() {
-  const { toasts } = useToast();
+  const toasts = useToasts();
 
   return (
     <div

--- a/src/client/components/Toast.tsx
+++ b/src/client/components/Toast.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Toast, ToastType, useToast } from "../hooks/useToast";
 
 export function ToastContainer() {
@@ -18,22 +18,63 @@ export function ToastContainer() {
   );
 }
 
+const ICONS: Record<ToastType, React.ReactNode> = {
+  success: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-green-500">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+    </svg>
+  ),
+  error: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-red-500">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2.5"
+        d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+      />
+    </svg>
+  ),
+  warning: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-amber-500">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2.5"
+        d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 12.376zM12 15.75h.007v.008H12v-.008z"
+      />
+    </svg>
+  ),
+  info: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-blue-500">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="2.5"
+        d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12v-.008z"
+      />
+    </svg>
+  ),
+};
+
+const VARIANT_STYLES: Record<ToastType, string> = {
+  success:
+    "bg-green-50/90 dark:bg-green-500/10 border-green-200 dark:border-green-500/20 text-green-900 dark:text-green-100",
+  error:
+    "bg-red-50/90 dark:bg-red-500/10 border-red-200 dark:border-red-500/20 text-red-900 dark:text-red-100",
+  warning:
+    "bg-amber-50/90 dark:bg-amber-500/10 border-amber-200 dark:border-amber-500/20 text-amber-900 dark:text-amber-100",
+  info: "bg-blue-50/90 dark:bg-blue-500/10 border-blue-200 dark:border-blue-500/20 text-blue-900 dark:text-blue-100",
+};
+
 function ToastItem({ toast }: { toast: Toast }) {
   const { removeToast } = useToast();
   const [isVisible, setIsVisible] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
+  const isRemovingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const remainingRef = useRef<number>(toast.duration || 4000);
   const startTimeRef = useRef<number>(Date.now());
-  const isPausedRef = useRef(false);
-
-  const startTimer = (duration: number) => {
-    startTimeRef.current = Date.now();
-    timerRef.current = setTimeout(() => {
-      handleDismiss();
-    }, duration);
-  };
 
   const clearTimer = () => {
     if (timerRef.current) {
@@ -42,14 +83,22 @@ function ToastItem({ toast }: { toast: Toast }) {
     }
   };
 
-  const handleDismiss = () => {
-    if (isRemoving) return;
+  const handleDismiss = useCallback(() => {
+    if (isRemovingRef.current) return;
+    isRemovingRef.current = true;
     setIsVisible(false);
     setIsRemoving(true);
     clearTimer();
     dismissTimerRef.current = setTimeout(() => {
       removeToast(toast.id);
     }, 400); // Wait for transition
+  }, [toast.id, removeToast]);
+
+  const startTimer = (duration: number) => {
+    startTimeRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      handleDismiss();
+    }, duration);
   };
 
   useEffect(() => {
@@ -66,70 +115,22 @@ function ToastItem({ toast }: { toast: Toast }) {
         dismissTimerRef.current = null;
       }
     };
-  }, []);
+  }, [handleDismiss]);
 
   const handleMouseEnter = () => {
-    isPausedRef.current = true;
+    if (isRemovingRef.current) return;
     clearTimer();
     const elapsed = Date.now() - startTimeRef.current;
     remainingRef.current = Math.max(0, remainingRef.current - elapsed);
   };
 
   const handleMouseLeave = () => {
-    isPausedRef.current = false;
+    if (isRemovingRef.current) return;
     if (remainingRef.current > 0) {
       startTimer(remainingRef.current);
     } else {
       handleDismiss();
     }
-  };
-
-  const icons: Record<ToastType, React.ReactNode> = {
-    success: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-green-500">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
-      </svg>
-    ),
-    error: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-red-500">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2.5"
-          d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
-        />
-      </svg>
-    ),
-    warning: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-amber-500">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2.5"
-          d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 12.376zM12 15.75h.007v.008H12v-.008z"
-        />
-      </svg>
-    ),
-    info: (
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-blue-500">
-        <path
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2.5"
-          d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12v-.008z"
-        />
-      </svg>
-    ),
-  };
-
-  const variantStyles: Record<ToastType, string> = {
-    success:
-      "bg-green-50/90 dark:bg-green-500/10 border-green-200 dark:border-green-500/20 text-green-900 dark:text-green-100",
-    error:
-      "bg-red-50/90 dark:bg-red-500/10 border-red-200 dark:border-red-500/20 text-red-900 dark:text-red-100",
-    warning:
-      "bg-amber-50/90 dark:bg-amber-500/10 border-amber-200 dark:border-amber-500/20 text-amber-900 dark:text-amber-100",
-    info: "bg-blue-50/90 dark:bg-blue-500/10 border-blue-200 dark:border-blue-500/20 text-blue-900 dark:text-blue-100",
   };
 
   return (
@@ -147,10 +148,10 @@ function ToastItem({ toast }: { toast: Toast }) {
         transition-all duration-400 ease-[cubic-bezier(0.4,0,0.2,1)]
         ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 -translate-y-4 scale-95"}
         ${isRemoving ? "opacity-0 scale-90" : ""}
-        ${variantStyles[toast.type]}
+        ${VARIANT_STYLES[toast.type]}
       `}
     >
-      <div className="shrink-0 mt-0.5">{icons[toast.type]}</div>
+      <div className="shrink-0 mt-0.5">{ICONS[toast.type]}</div>
       <div className="flex-1 min-w-0">
         <p className="text-[13px] md:text-sm font-medium leading-relaxed break-words">
           {toast.message}

--- a/src/client/components/Toast.tsx
+++ b/src/client/components/Toast.tsx
@@ -23,6 +23,7 @@ function ToastItem({ toast }: { toast: Toast }) {
   const [isVisible, setIsVisible] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const remainingRef = useRef<number>(toast.duration || 4000);
   const startTimeRef = useRef<number>(Date.now());
   const isPausedRef = useRef(false);
@@ -42,9 +43,11 @@ function ToastItem({ toast }: { toast: Toast }) {
   };
 
   const handleDismiss = () => {
+    if (isRemoving) return;
     setIsVisible(false);
     setIsRemoving(true);
-    setTimeout(() => {
+    clearTimer();
+    dismissTimerRef.current = setTimeout(() => {
       removeToast(toast.id);
     }, 400); // Wait for transition
   };
@@ -58,6 +61,10 @@ function ToastItem({ toast }: { toast: Toast }) {
     return () => {
       cancelAnimationFrame(raf);
       clearTimer();
+      if (dismissTimerRef.current) {
+        clearTimeout(dismissTimerRef.current);
+        dismissTimerRef.current = null;
+      }
     };
   }, []);
 
@@ -137,7 +144,7 @@ function ToastItem({ toast }: { toast: Toast }) {
         flex items-start gap-3 p-4
         backdrop-blur-xl
         border-[0.5px] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.4)]
-        transition-all duration-400 cubic-bezier(0.4, 0, 0.2, 1)
+        transition-all duration-400 ease-[cubic-bezier(0.4,0,0.2,1)]
         ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 -translate-y-4 scale-95"}
         ${isRemoving ? "opacity-0 scale-90" : ""}
         ${variantStyles[toast.type]}

--- a/src/client/components/Toast.tsx
+++ b/src/client/components/Toast.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Toast, ToastType, useToast } from "../hooks/useToast";
+
+export function ToastContainer() {
+  const { toasts } = useToast();
+
+  return (
+    <div
+      className="fixed top-0 right-0 left-0 md:left-auto md:w-[400px] z-[9999] pointer-events-none flex flex-col items-center md:items-end p-4 gap-3"
+      style={{
+        paddingTop: "calc(max(1rem, env(safe-area-inset-top)))",
+      }}
+    >
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const { removeToast } = useToast();
+  const [isVisible, setIsVisible] = useState(false);
+  const [isRemoving, setIsRemoving] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const remainingRef = useRef<number>(toast.duration || 4000);
+  const startTimeRef = useRef<number>(Date.now());
+  const isPausedRef = useRef(false);
+
+  const startTimer = (duration: number) => {
+    startTimeRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      handleDismiss();
+    }, duration);
+  };
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const handleDismiss = () => {
+    setIsVisible(false);
+    setIsRemoving(true);
+    setTimeout(() => {
+      removeToast(toast.id);
+    }, 400); // Wait for transition
+  };
+
+  useEffect(() => {
+    // Small delay to trigger entry animation
+    const raf = requestAnimationFrame(() => setIsVisible(true));
+
+    startTimer(remainingRef.current);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimer();
+    };
+  }, []);
+
+  const handleMouseEnter = () => {
+    isPausedRef.current = true;
+    clearTimer();
+    const elapsed = Date.now() - startTimeRef.current;
+    remainingRef.current = Math.max(0, remainingRef.current - elapsed);
+  };
+
+  const handleMouseLeave = () => {
+    isPausedRef.current = false;
+    if (remainingRef.current > 0) {
+      startTimer(remainingRef.current);
+    } else {
+      handleDismiss();
+    }
+  };
+
+  const icons: Record<ToastType, React.ReactNode> = {
+    success: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-green-500">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M5 13l4 4L19 7" />
+      </svg>
+    ),
+    error: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-red-500">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2.5"
+          d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+        />
+      </svg>
+    ),
+    warning: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-amber-500">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2.5"
+          d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 12.376zM12 15.75h.007v.008H12v-.008z"
+        />
+      </svg>
+    ),
+    info: (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-5 h-5 text-blue-500">
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2.5"
+          d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12v-.008z"
+        />
+      </svg>
+    ),
+  };
+
+  const variantStyles: Record<ToastType, string> = {
+    success:
+      "bg-green-50/90 dark:bg-green-500/10 border-green-200 dark:border-green-500/20 text-green-900 dark:text-green-100",
+    error:
+      "bg-red-50/90 dark:bg-red-500/10 border-red-200 dark:border-red-500/20 text-red-900 dark:text-red-100",
+    warning:
+      "bg-amber-50/90 dark:bg-amber-500/10 border-amber-200 dark:border-amber-500/20 text-amber-900 dark:text-amber-100",
+    info: "bg-blue-50/90 dark:bg-blue-500/10 border-blue-200 dark:border-blue-500/20 text-blue-900 dark:text-blue-100",
+  };
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      className={`
+        pointer-events-auto
+        w-full max-w-[calc(100vw-2rem)] md:w-full
+        flex items-start gap-3 p-4
+        backdrop-blur-xl
+        border-[0.5px] rounded-2xl shadow-[0_8px_32px_rgba(0,0,0,0.08)] dark:shadow-[0_8px_32px_rgba(0,0,0,0.4)]
+        transition-all duration-400 cubic-bezier(0.4, 0, 0.2, 1)
+        ${isVisible ? "opacity-100 translate-y-0 scale-100" : "opacity-0 -translate-y-4 scale-95"}
+        ${isRemoving ? "opacity-0 scale-90" : ""}
+        ${variantStyles[toast.type]}
+      `}
+    >
+      <div className="shrink-0 mt-0.5">{icons[toast.type]}</div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] md:text-sm font-medium leading-relaxed break-words">
+          {toast.message}
+        </p>
+      </div>
+      <button
+        onClick={handleDismiss}
+        className="shrink-0 ml-2 p-1 rounded-lg text-gray-400 hover:text-gray-900 dark:hover:text-white/90 hover:bg-black/5 dark:hover:bg-white/5 transition-all focus:outline-none"
+        aria-label="Close"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="w-4 h-4 stroke-2">
+          <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Conversation, Message, StorageMode } from "../storage";
 import { createStorage } from "../storage";
+import { useToast } from "./useToast";
 
 interface UseChatReturn {
   conversations: Conversation[];
@@ -8,7 +9,6 @@ interface UseChatReturn {
   messages: Message[];
   activeBranch: Message[];
   isStreaming: boolean;
-  error: string | null;
   activeVersions: Record<string, string>;
   loadConversations: () => Promise<void>;
   selectConversation: (id: string) => Promise<void>;
@@ -52,14 +52,13 @@ export function useChat(
   const [activeConversation, setActiveConversation] = useState<Conversation | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const toast = useToast();
   const [activeVersions, setActiveVersions] = useState<Record<string, string>>({});
   const abortControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     setActiveConversation(null);
     setMessages([]);
-    setError(null);
     setIsStreaming(false);
     setActiveVersions({});
   }, [storageMode]);
@@ -90,7 +89,7 @@ export function useChat(
       const data = await storage.getConversations();
       setConversations(data);
     } catch {
-      setError("Failed to load conversations");
+      toast.error("Failed to load conversations");
     }
   }, [storage]);
 
@@ -108,7 +107,7 @@ export function useChat(
           setActiveVersions({});
         }
       } catch {
-        setError("Failed to load conversation");
+        toast.error("Failed to load conversation");
       }
     },
     [storage],
@@ -154,7 +153,7 @@ export function useChat(
         );
       } catch (err) {
         console.error("Failed to update active model:", err);
-        setError("Failed to update conversation model");
+        toast.error("Failed to update conversation model");
       }
     },
     [storage, activeConversation],
@@ -163,7 +162,6 @@ export function useChat(
   const clearConversation = useCallback(() => {
     setActiveConversation(null);
     setMessages([]);
-    setError(null);
     setActiveVersions({});
   }, []);
 
@@ -348,7 +346,6 @@ export function useChat(
       systemPrompt?: string,
     ) => {
       if (isStreaming) return;
-      setError(null);
 
       const userParentId =
         activeBranch.length > 0 ? activeBranch[activeBranch.length - 1].id : undefined;
@@ -438,7 +435,7 @@ export function useChat(
         }
       } catch (e) {
         console.error("[sendMessage] error:", e);
-        setError("Failed to send message");
+        toast.error("Failed to send message");
         setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
       } finally {
         setIsStreaming(false);
@@ -458,7 +455,6 @@ export function useChat(
       systemPrompt?: string,
     ) => {
       if (isStreaming) return;
-      setError(null);
 
       const targetMsg = messages.find((m) => m.id === targetMessageId);
       if (!targetMsg) return;
@@ -518,7 +514,7 @@ export function useChat(
         await storage.saveMessage({ ...assistantMessage, content: fullContent });
       } catch (e) {
         console.error("[editMessage] error:", e);
-        setError("Failed to edit message");
+        toast.error("Failed to edit message");
         setMessages((prev) =>
           prev.filter((m) => m.id !== assistantMessage.id && m.id !== userMessage.id),
         );
@@ -535,7 +531,6 @@ export function useChat(
   const retryMessage = useCallback(
     async (messageId: string, model: string, storageMode: StorageMode, systemPrompt?: string) => {
       if (isStreaming) return;
-      setError(null);
 
       // Find the target assistant message
       const targetMsg = messages.find((m) => m.id === messageId);
@@ -586,7 +581,7 @@ export function useChat(
         await storage.saveMessage({ ...newAssistantMessage, content: fullContent });
       } catch (e) {
         console.error("[retryMessage] error:", e);
-        setError("Failed to retry message");
+        toast.error("Failed to retry message");
         // Remove the failed placeholder
         setMessages((prev) => prev.filter((m) => m.id !== newAssistantMessage.id));
         // Revert active version to the one the user was viewing
@@ -631,7 +626,7 @@ export function useChat(
         });
       } catch (e) {
         console.error("[deleteMessage] error:", e);
-        setError("Failed to delete message");
+        toast.error("Failed to delete message");
       }
     },
     [activeConversation, storage],
@@ -643,7 +638,6 @@ export function useChat(
     messages,
     activeBranch,
     isStreaming,
-    error,
     activeVersions,
     loadConversations,
     selectConversation,
@@ -676,7 +670,7 @@ export function useChat(
         }
       } catch (err) {
         console.error("Failed to rename conversation:", err);
-        setError("Failed to rename conversation");
+        toast.error("Failed to rename conversation");
         throw err; // Re-throw so the UI can handle UI-specific logic (like closing the input)
       }
     },

--- a/src/client/hooks/useToast.tsx
+++ b/src/client/hooks/useToast.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useState } from "react";
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
 
 export type ToastType = "success" | "error" | "warning" | "info";
 
@@ -32,23 +32,24 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const addToast = useCallback((message: string, type: ToastType, duration?: number) => {
+    const generateId = () =>
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : Math.random().toString(36).substring(2, 11);
+
     setToasts((prev) => {
       // Deduplication: Check if same message already exists
       const existingIndex = prev.findIndex((t) => t.message === message && t.type === type);
 
       if (existingIndex !== -1) {
-        // If message exists, we just want to trigger a "reset" signal
-        // The easiest way is to remove it and re-add it, or just return prev
-        // and let the component handle timer reset via key change.
-        // However, for pure CSS and React state, let's replace it to ensure re-render.
         const updated = [...prev];
         const existing = updated[existingIndex];
         updated.splice(existingIndex, 1);
-        return [{ ...existing, id: crypto.randomUUID() }, ...updated];
+        return [{ ...existing, id: generateId() }, ...updated];
       }
 
       const newToast: Toast = {
-        id: crypto.randomUUID(),
+        id: generateId(),
         message,
         type,
         duration:
@@ -68,11 +69,12 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const warning = useCallback((msg: string, d?: number) => addToast(msg, "warning", d), [addToast]);
   const info = useCallback((msg: string, d?: number) => addToast(msg, "info", d), [addToast]);
 
-  return (
-    <ToastContext.Provider value={{ toasts, addToast, removeToast, success, error, warning, info }}>
-      {children}
-    </ToastContext.Provider>
+  const value = useMemo(
+    () => ({ toasts, addToast, removeToast, success, error, warning, info }),
+    [toasts, addToast, removeToast, success, error, warning, info],
   );
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
 }
 
 export function useToast() {

--- a/src/client/hooks/useToast.tsx
+++ b/src/client/hooks/useToast.tsx
@@ -9,8 +9,7 @@ export interface Toast {
   duration?: number;
 }
 
-interface ToastContextType {
-  toasts: Toast[];
+interface ToastActionsContextType {
   addToast: (message: string, type: ToastType, duration?: number) => void;
   removeToast: (id: string) => void;
   success: (message: string, duration?: number) => void;
@@ -19,7 +18,8 @@ interface ToastContextType {
   info: (message: string, duration?: number) => void;
 }
 
-const ToastContext = createContext<ToastContextType | undefined>(undefined);
+const ToastStateContext = createContext<Toast[] | undefined>(undefined);
+const ToastActionsContext = createContext<ToastActionsContextType | undefined>(undefined);
 
 const MAX_TOASTS = 3;
 const DEFAULT_DURATION = 4000;
@@ -69,17 +69,31 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const warning = useCallback((msg: string, d?: number) => addToast(msg, "warning", d), [addToast]);
   const info = useCallback((msg: string, d?: number) => addToast(msg, "info", d), [addToast]);
 
-  const value = useMemo(
-    () => ({ toasts, addToast, removeToast, success, error, warning, info }),
-    [toasts, addToast, removeToast, success, error, warning, info],
+  const actions = useMemo(
+    () => ({ addToast, removeToast, success, error, warning, info }),
+    [addToast, removeToast, success, error, warning, info],
   );
 
-  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+  return (
+    <ToastStateContext.Provider value={toasts}>
+      <ToastActionsContext.Provider value={actions}>{children}</ToastActionsContext.Provider>
+    </ToastStateContext.Provider>
+  );
 }
 
+/** Returns the current list of toasts (state) */
+export function useToasts() {
+  const context = useContext(ToastStateContext);
+  if (context === undefined) {
+    throw new Error("useToasts must be used within a ToastProvider");
+  }
+  return context;
+}
+
+/** Returns the stable action functions for triggering toasts */
 export function useToast() {
-  const context = useContext(ToastContext);
-  if (!context) {
+  const context = useContext(ToastActionsContext);
+  if (context === undefined) {
     throw new Error("useToast must be used within a ToastProvider");
   }
   return context;

--- a/src/client/hooks/useToast.tsx
+++ b/src/client/hooks/useToast.tsx
@@ -1,0 +1,84 @@
+import React, { createContext, useCallback, useContext, useState } from "react";
+
+export type ToastType = "success" | "error" | "warning" | "info";
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+  duration?: number;
+}
+
+interface ToastContextType {
+  toasts: Toast[];
+  addToast: (message: string, type: ToastType, duration?: number) => void;
+  removeToast: (id: string) => void;
+  success: (message: string, duration?: number) => void;
+  error: (message: string, duration?: number) => void;
+  warning: (message: string, duration?: number) => void;
+  info: (message: string, duration?: number) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+const MAX_TOASTS = 3;
+const DEFAULT_DURATION = 4000;
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const addToast = useCallback((message: string, type: ToastType, duration?: number) => {
+    setToasts((prev) => {
+      // Deduplication: Check if same message already exists
+      const existingIndex = prev.findIndex((t) => t.message === message && t.type === type);
+
+      if (existingIndex !== -1) {
+        // If message exists, we just want to trigger a "reset" signal
+        // The easiest way is to remove it and re-add it, or just return prev
+        // and let the component handle timer reset via key change.
+        // However, for pure CSS and React state, let's replace it to ensure re-render.
+        const updated = [...prev];
+        const existing = updated[existingIndex];
+        updated.splice(existingIndex, 1);
+        return [{ ...existing, id: crypto.randomUUID() }, ...updated];
+      }
+
+      const newToast: Toast = {
+        id: crypto.randomUUID(),
+        message,
+        type,
+        duration:
+          duration ?? (type === "error" ? 8000 : type === "warning" ? 6000 : DEFAULT_DURATION),
+      };
+
+      const next = [newToast, ...prev];
+      if (next.length > MAX_TOASTS) {
+        return next.slice(0, MAX_TOASTS);
+      }
+      return next;
+    });
+  }, []);
+
+  const success = useCallback((msg: string, d?: number) => addToast(msg, "success", d), [addToast]);
+  const error = useCallback((msg: string, d?: number) => addToast(msg, "error", d), [addToast]);
+  const warning = useCallback((msg: string, d?: number) => addToast(msg, "warning", d), [addToast]);
+  const info = useCallback((msg: string, d?: number) => addToast(msg, "info", d), [addToast]);
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast, success, error, warning, info }}>
+      {children}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}

--- a/src/client/hooks/useTransfer.ts
+++ b/src/client/hooks/useTransfer.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import type { Conversation, Message, StorageMode } from "../storage";
 import { createStorage } from "../storage";
+import { useToast } from "./useToast";
 
 const PENDING_CLOUD_DELETE_KEY = "waichat:pending-cloud-delete";
 
@@ -13,8 +14,6 @@ interface TransferState {
   prefetchedData: { conversation: Conversation; messages: Message[] } | null;
   /** Estimated bytes for cloud→local size warning */
   estimatedBytes: number;
-  /** Error message if transfer failed */
-  error: string | null;
 }
 
 interface UseTransferReturn {
@@ -36,8 +35,8 @@ export function useTransfer(): UseTransferReturn {
     phase: "idle",
     prefetchedData: null,
     estimatedBytes: 0,
-    error: null,
   });
+  const toast = useToast();
 
   // Keep prefetched data in a ref so async executeMove can access it
   // without depending on stale state
@@ -49,7 +48,6 @@ export function useTransfer(): UseTransferReturn {
       phase: "prefetch",
       prefetchedData: null,
       estimatedBytes: 0,
-      error: null,
     });
 
     try {
@@ -60,8 +58,8 @@ export function useTransfer(): UseTransferReturn {
         setTransferState((prev) => ({
           ...prev,
           phase: "idle",
-          error: "Conversation not found",
         }));
+        toast.error("Conversation not found");
         return;
       }
 
@@ -73,7 +71,6 @@ export function useTransfer(): UseTransferReturn {
         phase: "idle", // Prefetch done, waiting for confirm
         prefetchedData: data,
         estimatedBytes,
-        error: null,
       });
     } catch (e) {
       console.error("[useTransfer] prefetch error:", e);
@@ -82,8 +79,8 @@ export function useTransfer(): UseTransferReturn {
         phase: "idle",
         prefetchedData: null,
         estimatedBytes: 0,
-        error: "Failed to read conversation",
       });
+      toast.error("Failed to read conversation");
     }
   }, []);
 
@@ -97,7 +94,6 @@ export function useTransfer(): UseTransferReturn {
       setTransferState((prev) => ({
         ...prev,
         phase: "transfer",
-        error: null,
       }));
 
       try {
@@ -136,7 +132,6 @@ export function useTransfer(): UseTransferReturn {
           phase: "idle",
           prefetchedData: null,
           estimatedBytes: 0,
-          error: null,
         });
 
         return conversation.id;
@@ -146,8 +141,8 @@ export function useTransfer(): UseTransferReturn {
         setTransferState((prev) => ({
           ...prev,
           phase: "idle",
-          error: errorMessage,
         }));
+        toast.error(errorMessage);
         throw e;
       }
     },
@@ -161,7 +156,6 @@ export function useTransfer(): UseTransferReturn {
       phase: "idle",
       prefetchedData: null,
       estimatedBytes: 0,
-      error: null,
     });
   }, []);
 

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import "./index.css";
 import App from "./App";
+import { ToastProvider } from "./hooks/useToast";
+import "./index.css";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+    </ToastProvider>
   </StrictMode>,
 );


### PR DESCRIPTION
## Description

Replaces inline error messages with toasts.

**Fixes #88**

## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `feat/88-add-toasts` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/88-add-toasts)
