### PR TITLE
feat: allow drafting next prompt while the response is streaming

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -539,8 +539,6 @@ export default function App() {
     }
   };
 
-  const isInputLocked = false; // Placeholder for future locking logic
-
   return (
     <div className="relative flex h-screen w-full overflow-hidden font-sans text-gray-900 dark:text-white/95">
       {/* Full-screen base layers */}
@@ -742,7 +740,7 @@ export default function App() {
           <ChatInput
             onSend={handleSend}
             isGenerating={isStreaming}
-            disabled={isInputLocked}
+            disabled={false}
             initialValue={pendingPrompt}
             onClearInitialValue={() => setPendingPrompt("")}
             onAbort={stopGeneration}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -539,6 +539,8 @@ export default function App() {
     }
   };
 
+  const isInputLocked = false; // Placeholder for future locking logic
+
   return (
     <div className="relative flex h-screen w-full overflow-hidden font-sans text-gray-900 dark:text-white/95">
       {/* Full-screen base layers */}
@@ -739,7 +741,8 @@ export default function App() {
           />
           <ChatInput
             onSend={handleSend}
-            disabled={isStreaming}
+            isGenerating={isStreaming}
+            disabled={isInputLocked}
             initialValue={pendingPrompt}
             onClearInitialValue={() => setPendingPrompt("")}
             onAbort={stopGeneration}

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -12,7 +12,7 @@ interface ChatInputProps {
 export default function ChatInput({
   onSend,
   disabled,
-  isGenerating,
+  isGenerating = false,
   initialValue,
   onClearInitialValue,
   onAbort,
@@ -52,7 +52,6 @@ export default function ChatInput({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      if (disabled || isGenerating) return;
       handleSend();
     }
   };

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 interface ChatInputProps {
   onSend: (content: string) => void;
   disabled: boolean;
+  isGenerating?: boolean;
   initialValue?: string;
   onClearInitialValue?: () => void;
   onAbort?: () => void;
@@ -11,6 +12,7 @@ interface ChatInputProps {
 export default function ChatInput({
   onSend,
   disabled,
+  isGenerating,
   initialValue,
   onClearInitialValue,
   onAbort,
@@ -19,10 +21,14 @@ export default function ChatInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    if (initialValue) {
+    // Only apply initialValue if current input is empty to avoid overwriting drafts
+    if (initialValue && !value.trim()) {
       setValue(initialValue);
       onClearInitialValue?.();
       textareaRef.current?.focus();
+    } else if (initialValue) {
+      // Clear the trigger even if we didn't use it to prevent stale state
+      onClearInitialValue?.();
     }
   }, [initialValue, onClearInitialValue]);
 
@@ -37,7 +43,7 @@ export default function ChatInput({
   const handleSend = (e?: React.FormEvent) => {
     e?.preventDefault(); // Prevent page reload if triggered via form submission
     const trimmed = value.trim();
-    if (!trimmed || disabled) return;
+    if (!trimmed || disabled || isGenerating) return;
     onSend(trimmed);
     setValue("");
 
@@ -50,6 +56,7 @@ export default function ChatInput({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
+      if (disabled || isGenerating) return;
       handleSend();
     }
   };
@@ -57,7 +64,7 @@ export default function ChatInput({
   return (
     <div className="w-full flex justify-center pb-6 pt-2 px-4 md:px-8 shrink-0">
       <div className="w-full max-w-[720px] relative">
-        {disabled && onAbort && (
+        {isGenerating && onAbort && (
           <div className="absolute -top-12 left-1/2 -translate-x-1/2 z-20">
             <button
               type="button"
@@ -87,7 +94,7 @@ export default function ChatInput({
 
           <button
             type="submit"
-            disabled={disabled || !value.trim()}
+            disabled={disabled || isGenerating || !value.trim()}
             className="absolute right-3 top-2.5 w-8 h-8 bg-black/5 dark:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 rounded-full flex items-center justify-center text-gray-500 dark:text-white/80 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black hover:scale-105 disabled:opacity-40 disabled:hover:bg-black/5 disabled:hover:text-gray-500 dark:disabled:hover:bg-white/10 dark:disabled:hover:text-white/80 disabled:hover:scale-100 transition-all duration-200 cursor-pointer"
             aria-label="Send message"
           >

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -21,13 +21,12 @@ export default function ChatInput({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    // Only apply initialValue if current input is empty to avoid overwriting drafts
-    if (initialValue && !value.trim()) {
+    if (initialValue) {
       setValue(initialValue);
       onClearInitialValue?.();
       textareaRef.current?.focus();
     }
-  }, [initialValue, onClearInitialValue, value]);
+  }, [initialValue, onClearInitialValue]);
 
   // Auto-resize the textarea
   useEffect(() => {

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -26,11 +26,8 @@ export default function ChatInput({
       setValue(initialValue);
       onClearInitialValue?.();
       textareaRef.current?.focus();
-    } else if (initialValue) {
-      // Clear the trigger even if we didn't use it to prevent stale state
-      onClearInitialValue?.();
     }
-  }, [initialValue, onClearInitialValue]);
+  }, [initialValue, onClearInitialValue, value]);
 
   // Auto-resize the textarea
   useEffect(() => {


### PR DESCRIPTION
## Description

Allow drafting next prompt while the response is streaming

**Fixes #89**

## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `fix/89-input-field-disabled-during-response-generation` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/fix/89-input-field-disabled-during-response-generation)
