### PR TITLE
feat: persist streaming messages in ref to maintain continuity during conversation switching

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -110,6 +110,8 @@ export default function App() {
     streamingConversationId,
   } = useChat(storageMode, pendingSelectionRef);
 
+  const isStreamingHere = isStreaming && activeConversation?.id === streamingConversationId;
+
   const { transferState, initiateMove, executeMove, cancelMove, retryPendingCloudDeletes } =
     useTransfer();
 
@@ -714,7 +716,7 @@ export default function App() {
             messages={messages}
             activeBranch={activeBranch}
             isStreaming={isStreaming}
-            isStreamingHere={isStreaming && activeConversation?.id === streamingConversationId}
+            isStreamingHere={isStreamingHere}
             onSelectPrompt={setPendingPrompt}
             onRetry={(messageId) =>
               retryMessage(
@@ -742,7 +744,7 @@ export default function App() {
           <ChatInput
             onSend={handleSend}
             isGenerating={isStreaming}
-            isStreamingHere={isStreaming && activeConversation?.id === streamingConversationId}
+            isStreamingHere={isStreamingHere}
             disabled={false}
             initialValue={pendingPrompt}
             onClearInitialValue={() => setPendingPrompt("")}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -107,6 +107,7 @@ export default function App() {
     setActiveVersion,
     deleteMessage,
     renameConversation,
+    streamingConversationId,
   } = useChat(storageMode, pendingSelectionRef);
 
   const { transferState, initiateMove, executeMove, cancelMove, retryPendingCloudDeletes } =
@@ -713,6 +714,7 @@ export default function App() {
             messages={messages}
             activeBranch={activeBranch}
             isStreaming={isStreaming}
+            isStreamingHere={isStreaming && activeConversation?.id === streamingConversationId}
             onSelectPrompt={setPendingPrompt}
             onRetry={(messageId) =>
               retryMessage(
@@ -740,6 +742,7 @@ export default function App() {
           <ChatInput
             onSend={handleSend}
             isGenerating={isStreaming}
+            isStreamingHere={isStreaming && activeConversation?.id === streamingConversationId}
             disabled={false}
             initialValue={pendingPrompt}
             onClearInitialValue={() => setPendingPrompt("")}

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -4,6 +4,7 @@ interface ChatInputProps {
   onSend: (content: string) => void;
   disabled: boolean;
   isGenerating?: boolean;
+  isStreamingHere?: boolean;
   initialValue?: string;
   onClearInitialValue?: () => void;
   onAbort?: () => void;
@@ -13,6 +14,7 @@ export default function ChatInput({
   onSend,
   disabled,
   isGenerating = false,
+  isStreamingHere = false,
   initialValue,
   onClearInitialValue,
   onAbort,
@@ -59,7 +61,7 @@ export default function ChatInput({
   return (
     <div className="w-full flex justify-center pb-6 pt-2 px-4 md:px-8 shrink-0">
       <div className="w-full max-w-[720px] relative">
-        {isGenerating && onAbort && (
+        {isStreamingHere && onAbort && (
           <div className="absolute -top-12 left-1/2 -translate-x-1/2 z-20">
             <button
               type="button"

--- a/src/client/components/MessageList.tsx
+++ b/src/client/components/MessageList.tsx
@@ -10,6 +10,7 @@ interface MessageListProps {
   messages: Message[];
   activeBranch: Message[];
   isStreaming: boolean;
+  isStreamingHere?: boolean;
   onSelectPrompt: (prompt: string) => void;
   onRetry?: (messageId: string) => void;
   onEdit?: (messageId: string, content: string) => void;
@@ -328,6 +329,7 @@ export default function MessageList({
   messages,
   activeBranch,
   isStreaming,
+  isStreamingHere = false,
   onSelectPrompt,
   onRetry,
   onEdit,
@@ -753,7 +755,7 @@ export default function MessageList({
 
           // Assistant group
           const isCurrentlyStreaming =
-            isStreaming && m.content === "" && idx === lastAssistantIndex;
+            isStreamingHere && m.content === "" && idx === lastAssistantIndex;
 
           return (
             <div key={m.id} className="group flex flex-col items-start w-full">

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -124,6 +124,7 @@ export function useChat(
           if (toAdd.length > 0) {
             currentMessages = [...currentMessages, ...toAdd];
           }
+          setIsStreaming(true);
         }
         setMessages(currentMessages);
 

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -41,6 +41,7 @@ interface UseChatReturn {
   setActiveVersion: (parentId: string, messageId: string) => void;
   deleteMessage: (messageId: string) => Promise<void>;
   renameConversation: (id: string, title: string) => Promise<void>;
+  streamingConversationId: string | null;
 }
 
 export function useChat(
@@ -55,6 +56,12 @@ export function useChat(
   const toast = useToast();
   const [activeVersions, setActiveVersions] = useState<Record<string, string>>({});
   const abortControllerRef = useRef<AbortController | null>(null);
+  const [streamingConversationId, setStreamingConversationId] = useState<string | null>(null);
+  const streamingDataRef = useRef<{
+    conversationId: string;
+    userMessage?: Message;
+    assistantMessage: Message;
+  } | null>(null);
 
   useEffect(() => {
     setActiveConversation(null);
@@ -100,6 +107,23 @@ export function useChat(
         if (!data) return;
         setActiveConversation(data.conversation);
         setMessages(data.messages);
+
+        // Merge in-progress streaming messages if this is the active stream
+        if (streamingDataRef.current?.conversationId === id) {
+          const streaming = streamingDataRef.current;
+          setMessages((prev) => {
+            const existingIds = new Set(prev.map((m) => m.id));
+            const toAdd: Message[] = [];
+            if (streaming.userMessage && !existingIds.has(streaming.userMessage.id)) {
+              toAdd.push(streaming.userMessage);
+            }
+            if (!existingIds.has(streaming.assistantMessage.id)) {
+              toAdd.push(streaming.assistantMessage);
+            }
+            return [...prev, ...toAdd];
+          });
+        }
+
         try {
           const stored = localStorage.getItem(`waichat:versions:${id}`);
           setActiveVersions(stored ? JSON.parse(stored) : {});
@@ -315,6 +339,17 @@ export function useChat(
               }
               if (token) {
                 fullContent += token;
+
+                // Update the persistent ref for re-hydration on re-focus.
+                // Note: JS is single-threaded, so this mutation is safe from interleaving
+                // with selectConversation's read of the same ref.
+                if (streamingDataRef.current?.conversationId === conversationId) {
+                  streamingDataRef.current.assistantMessage = {
+                    ...streamingDataRef.current.assistantMessage,
+                    content: fullContent,
+                  };
+                }
+
                 setMessages((prev) =>
                   prev.map((m) =>
                     m.id === assistantMessageId ? { ...m, content: fullContent } : m,
@@ -372,6 +407,14 @@ export function useChat(
       // Set it as active
       const rootKey = `${conversationId}_root`;
       setActiveVersionCb(userParentId || rootKey, userMessage.id);
+
+      // Track in ref for persistence during stream
+      streamingDataRef.current = {
+        conversationId,
+        userMessage: { ...userMessage }, // Owned copy
+        assistantMessage: { ...assistantMessage }, // Owned copy
+      };
+      setStreamingConversationId(conversationId);
 
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
       setIsStreaming(true);
@@ -439,6 +482,8 @@ export function useChat(
         setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
       } finally {
         setIsStreaming(false);
+        setStreamingConversationId(null);
+        streamingDataRef.current = null;
         abortControllerRef.current = null;
       }
     },
@@ -485,6 +530,14 @@ export function useChat(
       const versionKey = userParentId || rootKey;
       setActiveVersionCb(versionKey, userMessage.id);
 
+      // Track in ref for persistence during stream
+      streamingDataRef.current = {
+        conversationId,
+        userMessage: { ...userMessage }, // Owned copy
+        assistantMessage: { ...assistantMessage }, // Owned copy
+      };
+      setStreamingConversationId(conversationId);
+
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
       setIsStreaming(true);
 
@@ -522,6 +575,8 @@ export function useChat(
         setActiveVersionCb(userParentId || rootKey, targetMessageId);
       } finally {
         setIsStreaming(false);
+        setStreamingConversationId(null);
+        streamingDataRef.current = null;
         abortControllerRef.current = null;
       }
     },
@@ -556,6 +611,13 @@ export function useChat(
       const rootKey = `${conversationId}_root`;
       setActiveVersionCb(assistantParentId || rootKey, newAssistantMessage.id);
 
+      // Track in ref for persistence during stream
+      streamingDataRef.current = {
+        conversationId,
+        assistantMessage: { ...newAssistantMessage }, // Owned copy
+      };
+      setStreamingConversationId(conversationId);
+
       setMessages((prev) => [...prev, newAssistantMessage]);
       setIsStreaming(true);
 
@@ -589,6 +651,8 @@ export function useChat(
         setActiveVersionCb(assistantParentId || rootKey, messageId);
       } finally {
         setIsStreaming(false);
+        setStreamingConversationId(null);
+        streamingDataRef.current = null;
         abortControllerRef.current = null;
       }
     },
@@ -649,6 +713,7 @@ export function useChat(
     editMessage,
     stopGeneration,
     retryMessage,
+    streamingConversationId,
     setActiveVersion: setActiveVersionCb,
     deleteMessage: deleteMessageCb,
     renameConversation: async (id: string, title: string) => {

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -140,7 +140,7 @@ export function useChat(
         toast.error("Failed to load conversation");
       }
     },
-    [storage, storageMode],
+    [storage, storageMode, mergeStreamingData, toast],
   );
 
   const newConversation = useCallback(

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -59,6 +59,7 @@ export function useChat(
   const [streamingConversationId, setStreamingConversationId] = useState<string | null>(null);
   const streamingDataRef = useRef<{
     conversationId: string;
+    storageMode: StorageMode;
     userMessage?: Message;
     assistantMessage: Message;
   } | null>(null);
@@ -108,8 +109,11 @@ export function useChat(
         setActiveConversation(data.conversation);
         setMessages(data.messages);
 
-        // Merge in-progress streaming messages if this is the active stream
-        if (streamingDataRef.current?.conversationId === id) {
+        // Merge in-progress streaming messages if this is the active stream in the same storage mode
+        if (
+          streamingDataRef.current?.conversationId === id &&
+          streamingDataRef.current?.storageMode === storageMode
+        ) {
           const streaming = streamingDataRef.current;
           setMessages((prev) => {
             const existingIds = new Set(prev.map((m) => m.id));
@@ -120,6 +124,7 @@ export function useChat(
             if (!existingIds.has(streaming.assistantMessage.id)) {
               toAdd.push(streaming.assistantMessage);
             }
+            if (toAdd.length === 0) return prev;
             return [...prev, ...toAdd];
           });
         }
@@ -134,7 +139,7 @@ export function useChat(
         toast.error("Failed to load conversation");
       }
     },
-    [storage],
+    [storage, storageMode],
   );
 
   const newConversation = useCallback(
@@ -411,6 +416,7 @@ export function useChat(
       // Track in ref for persistence during stream
       streamingDataRef.current = {
         conversationId,
+        storageMode,
         userMessage: { ...userMessage }, // Owned copy
         assistantMessage: { ...assistantMessage }, // Owned copy
       };
@@ -533,6 +539,7 @@ export function useChat(
       // Track in ref for persistence during stream
       streamingDataRef.current = {
         conversationId,
+        storageMode,
         userMessage: { ...userMessage }, // Owned copy
         assistantMessage: { ...assistantMessage }, // Owned copy
       };
@@ -614,6 +621,7 @@ export function useChat(
       // Track in ref for persistence during stream
       streamingDataRef.current = {
         conversationId,
+        storageMode,
         assistantMessage: { ...newAssistantMessage }, // Owned copy
       };
       setStreamingConversationId(conversationId);

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -67,9 +67,29 @@ export function useChat(
   useEffect(() => {
     setActiveConversation(null);
     setMessages([]);
-    setIsStreaming(false);
     setActiveVersions({});
   }, [storageMode]);
+
+  const mergeStreamingData = useCallback(
+    (id: string, currentMessages: Message[]) => {
+      const streaming = streamingDataRef.current;
+      if (streaming?.conversationId === id && streaming?.storageMode === storageMode) {
+        const existingIds = new Set(currentMessages.map((m) => m.id));
+        const toAdd: Message[] = [];
+        if (streaming.userMessage && !existingIds.has(streaming.userMessage.id)) {
+          toAdd.push(streaming.userMessage);
+        }
+        if (!existingIds.has(streaming.assistantMessage.id)) {
+          toAdd.push(streaming.assistantMessage);
+        }
+        if (toAdd.length > 0) {
+          return [...currentMessages, ...toAdd];
+        }
+      }
+      return currentMessages;
+    },
+    [storageMode],
+  );
 
   // After mode change: auto-select a conversation if pendingSelectionRef is set
   const selectAfterModeChangeRef = useRef(false);
@@ -86,7 +106,8 @@ export function useChat(
       storage.getConversation(id).then((result) => {
         if (result) {
           setActiveConversation(result.conversation);
-          setMessages(result.messages);
+          const finalMessages = mergeStreamingData(id, result.messages);
+          setMessages(finalMessages);
         }
       });
     }
@@ -107,26 +128,7 @@ export function useChat(
         const data = await storage.getConversation(id);
         if (!data) return;
         setActiveConversation(data.conversation);
-
-        let currentMessages = data.messages;
-        const streaming = streamingDataRef.current;
-
-        // Merge in-progress streaming messages if this is the active stream in the same storage mode
-        if (streaming?.conversationId === id && streaming?.storageMode === storageMode) {
-          const existingIds = new Set(currentMessages.map((m) => m.id));
-          const toAdd: Message[] = [];
-          if (streaming.userMessage && !existingIds.has(streaming.userMessage.id)) {
-            toAdd.push(streaming.userMessage);
-          }
-          if (!existingIds.has(streaming.assistantMessage.id)) {
-            toAdd.push(streaming.assistantMessage);
-          }
-          if (toAdd.length > 0) {
-            currentMessages = [...currentMessages, ...toAdd];
-          }
-          setIsStreaming(true);
-        }
-        setMessages(currentMessages);
+        setMessages(mergeStreamingData(id, data.messages));
 
         try {
           const stored = localStorage.getItem(`waichat:versions:${id}`);

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -107,27 +107,25 @@ export function useChat(
         const data = await storage.getConversation(id);
         if (!data) return;
         setActiveConversation(data.conversation);
-        setMessages(data.messages);
+
+        let currentMessages = data.messages;
+        const streaming = streamingDataRef.current;
 
         // Merge in-progress streaming messages if this is the active stream in the same storage mode
-        if (
-          streamingDataRef.current?.conversationId === id &&
-          streamingDataRef.current?.storageMode === storageMode
-        ) {
-          const streaming = streamingDataRef.current;
-          setMessages((prev) => {
-            const existingIds = new Set(prev.map((m) => m.id));
-            const toAdd: Message[] = [];
-            if (streaming.userMessage && !existingIds.has(streaming.userMessage.id)) {
-              toAdd.push(streaming.userMessage);
-            }
-            if (!existingIds.has(streaming.assistantMessage.id)) {
-              toAdd.push(streaming.assistantMessage);
-            }
-            if (toAdd.length === 0) return prev;
-            return [...prev, ...toAdd];
-          });
+        if (streaming?.conversationId === id && streaming?.storageMode === storageMode) {
+          const existingIds = new Set(currentMessages.map((m) => m.id));
+          const toAdd: Message[] = [];
+          if (streaming.userMessage && !existingIds.has(streaming.userMessage.id)) {
+            toAdd.push(streaming.userMessage);
+          }
+          if (!existingIds.has(streaming.assistantMessage.id)) {
+            toAdd.push(streaming.assistantMessage);
+          }
+          if (toAdd.length > 0) {
+            currentMessages = [...currentMessages, ...toAdd];
+          }
         }
+        setMessages(currentMessages);
 
         try {
           const stored = localStorage.getItem(`waichat:versions:${id}`);


### PR DESCRIPTION
## Description

Persist streaming messages in ref to maintain continuity during conversation switching

**Fixes #91**

## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `fix/91-stream-not-rendered-when-returning-to-streaming-chat` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/fix/91-stream-not-rendered-when-returning-to-streaming-chat)
