### PR TITLE
feat: add cross-mode streaming support with background completion toasts and actionable notifications

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -86,6 +86,14 @@ export default function App() {
   });
 
   const pendingSelectionRef = useRef<string | null>(null);
+  const [storageDropdownOpen, setStorageDropdownOpen] = useState(false);
+
+  const handleStorageToggle = (next: StorageMode) => {
+    setStorageMode(next);
+    setSavedStorageMode(next); // Sync saved mode when manually toggled
+    localStorage.setItem(STORAGE_MODE_KEY, next);
+    setStorageDropdownOpen(false);
+  };
 
   const {
     conversations,
@@ -108,9 +116,13 @@ export default function App() {
     deleteMessage,
     renameConversation,
     streamingConversationId,
-  } = useChat(storageMode, pendingSelectionRef);
+    streamingStorageMode,
+  } = useChat(storageMode, pendingSelectionRef, handleStorageToggle);
 
-  const isStreamingHere = isStreaming && activeConversation?.id === streamingConversationId;
+  const isStreamingHere =
+    isStreaming &&
+    activeConversation?.id === streamingConversationId &&
+    storageMode === streamingStorageMode;
 
   const { transferState, initiateMove, executeMove, cancelMove, retryPendingCloudDeletes } =
     useTransfer();
@@ -130,7 +142,6 @@ export default function App() {
   const [settingsOpen, setSettingsOpen] = useState(false);
 
   // Storage dropdown state for mobile-friendly click toggling
-  const [storageDropdownOpen, setStorageDropdownOpen] = useState(false);
 
   // Sidebar state: Open by default on desktop, closed on mobile
   const [sidebarOpen, setSidebarOpen] = useState(() => {
@@ -276,13 +287,6 @@ export default function App() {
   const handleSelectConversation = (id: string) => {
     selectConversation(id);
     closeSidebarOnMobile();
-  };
-
-  const handleStorageToggle = (next: StorageMode) => {
-    setStorageMode(next);
-    setSavedStorageMode(next); // Sync saved mode when manually toggled
-    localStorage.setItem(STORAGE_MODE_KEY, next);
-    setStorageDropdownOpen(false);
   };
 
   // Wrapper for new chat with mode support
@@ -745,6 +749,7 @@ export default function App() {
             onSend={handleSend}
             isGenerating={isStreaming}
             isStreamingHere={isStreamingHere}
+            streamingStorageMode={streamingStorageMode}
             disabled={false}
             initialValue={pendingPrompt}
             onClearInitialValue={() => setPendingPrompt("")}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import ChatInput from "./components/ChatInput";
 import MessageList from "./components/MessageList";
 import ModelPicker from "./components/ModelPicker";
@@ -88,12 +88,12 @@ export default function App() {
   const pendingSelectionRef = useRef<string | null>(null);
   const [storageDropdownOpen, setStorageDropdownOpen] = useState(false);
 
-  const handleStorageToggle = (next: StorageMode) => {
+  const handleStorageToggle = useCallback((next: StorageMode) => {
     setStorageMode(next);
     setSavedStorageMode(next); // Sync saved mode when manually toggled
     localStorage.setItem(STORAGE_MODE_KEY, next);
     setStorageDropdownOpen(false);
-  };
+  }, []);
 
   const {
     conversations,

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -87,7 +87,7 @@ export default function ChatInput({
             onKeyDown={handleKeyDown}
             placeholder={
               isGenerating && !isStreamingHere
-                ? `Another generation is in progress in ${streamingStorageMode} mode...`
+                ? `Another generation is in progress in ${streamingStorageMode === "cloud" ? "Cloud" : "Local"} mode...`
                 : "Message WaiChat..."
             }
             disabled={disabled || (isGenerating && !isStreamingHere)}

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -5,6 +5,7 @@ interface ChatInputProps {
   disabled: boolean;
   isGenerating?: boolean;
   isStreamingHere?: boolean;
+  streamingStorageMode?: string | null;
   initialValue?: string;
   onClearInitialValue?: () => void;
   onAbort?: () => void;
@@ -15,6 +16,7 @@ export default function ChatInput({
   disabled,
   isGenerating = false,
   isStreamingHere = false,
+  streamingStorageMode,
   initialValue,
   onClearInitialValue,
   onAbort,
@@ -83,8 +85,12 @@ export default function ChatInput({
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Message WaiChat..."
-            disabled={disabled}
+            placeholder={
+              isGenerating && !isStreamingHere
+                ? `Another generation is in progress in ${streamingStorageMode} mode...`
+                : "Message WaiChat..."
+            }
+            disabled={disabled || (isGenerating && !isStreamingHere)}
             rows={1}
             className="w-full bg-transparent border-none text-gray-900 dark:text-white/95 text-base outline-none resize-none leading-relaxed min-h-[24px] max-h-[200px] pr-12 placeholder:text-gray-400 dark:placeholder:text-white/40 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
           />

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useRef, useState } from "react";
+import type { StorageMode } from "../storage";
 
 interface ChatInputProps {
   onSend: (content: string) => void;
   disabled: boolean;
   isGenerating?: boolean;
   isStreamingHere?: boolean;
-  streamingStorageMode?: string | null;
+  streamingStorageMode?: StorageMode | null;
   initialValue?: string;
   onClearInitialValue?: () => void;
   onAbort?: () => void;

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -88,7 +88,11 @@ export default function ChatInput({
             onKeyDown={handleKeyDown}
             placeholder={
               isGenerating && !isStreamingHere
-                ? `Another generation is in progress in ${streamingStorageMode === "cloud" ? "Cloud" : "Local"} mode...`
+                ? "Another generation is in progress" +
+                  (streamingStorageMode
+                    ? " in " + (streamingStorageMode === "cloud" ? "Cloud" : "Local") + " mode"
+                    : "") +
+                  "..."
                 : "Message WaiChat..."
             }
             disabled={disabled || (isGenerating && !isStreamingHere)}

--- a/src/client/components/Toast.tsx
+++ b/src/client/components/Toast.tsx
@@ -156,6 +156,18 @@ function ToastItem({ toast }: { toast: Toast }) {
         <p className="text-[13px] md:text-sm font-medium leading-relaxed break-words">
           {toast.message}
         </p>
+        {toast.action && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              toast.action?.onClick();
+              handleDismiss();
+            }}
+            className="mt-2 px-3 py-1 bg-white dark:bg-white/10 border-[0.5px] border-black/10 dark:border-white/20 rounded-lg text-xs font-semibold hover:bg-black/5 dark:hover:bg-white/20 transition-all focus:outline-none"
+          >
+            {toast.action.label}
+          </button>
+        )}
       </div>
       <button
         onClick={handleDismiss}

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -296,18 +296,16 @@ export function useChat(
       conversationId: string,
       model: string,
       currentStorageMode: StorageMode,
+      signal: AbortSignal,
       systemPrompt?: string,
       parentId?: string,
       userMessageId?: string,
       userParentId?: string,
     ) => {
-      const abortController = new AbortController();
-      abortControllerRef.current = abortController;
-
       const res = await fetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        signal: abortController.signal,
+        signal: signal,
         body: JSON.stringify({
           conversation_id: conversationId,
           model,
@@ -451,6 +449,7 @@ export function useChat(
           conversationId,
           model,
           storageMode,
+          abortController.signal,
           systemPrompt,
           assistantMessage.parent_id,
           userMessage.id,
@@ -620,6 +619,7 @@ export function useChat(
           conversationId,
           model,
           storageMode,
+          abortController.signal,
           systemPrompt,
           assistantMessage.parent_id,
           userMessage.id,
@@ -740,6 +740,7 @@ export function useChat(
           conversationId,
           model,
           storageMode,
+          abortController.signal,
           systemPrompt,
           newAssistantMessage.parent_id,
           undefined,

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -9,6 +9,7 @@ interface UseChatReturn {
   messages: Message[];
   activeBranch: Message[];
   isStreaming: boolean;
+  streamingStorageMode: StorageMode | null;
   activeVersions: Record<string, string>;
   loadConversations: () => Promise<void>;
   selectConversation: (id: string) => Promise<void>;
@@ -47,12 +48,19 @@ interface UseChatReturn {
 export function useChat(
   storageMode: StorageMode,
   pendingSelectionRef?: React.RefObject<string | null>,
+  onStorageModeChange?: (mode: StorageMode) => void,
 ): UseChatReturn {
+  const storageModeRef = useRef(storageMode);
+  useEffect(() => {
+    storageModeRef.current = storageMode;
+  }, [storageMode]);
+
   const storage = useMemo(() => createStorage(storageMode), [storageMode]);
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [activeConversation, setActiveConversation] = useState<Conversation | null>(null);
   const [messages, setMessages] = useState<Message[]>([]);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [streamingStorageMode, setStreamingStorageMode] = useState<StorageMode | null>(null);
   const toast = useToast();
   const [activeVersions, setActiveVersions] = useState<Record<string, string>>({});
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -108,6 +116,7 @@ export function useChat(
           setActiveConversation(result.conversation);
           const finalMessages = mergeStreamingData(id, result.messages);
           setMessages(finalMessages);
+          if (pendingSelectionRef) pendingSelectionRef.current = null;
         }
       });
     }
@@ -425,6 +434,10 @@ export function useChat(
 
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
       setIsStreaming(true);
+      setStreamingStorageMode(storageMode);
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
 
       try {
         const contextMessages = [...activeBranch, userMessage].map((m) => ({
@@ -448,6 +461,8 @@ export function useChat(
         await storage.saveMessage(userMessage);
         await storage.saveMessage({ ...assistantMessage, content: fullContent });
 
+        // Handle auto-titling if needed
+        let finalTitle = activeConversation?.title;
         if (messages.length === 0 && storageMode === "local" && fullContent) {
           try {
             const res = await fetch("/api/title", {
@@ -461,12 +476,14 @@ export function useChat(
             setConversations((prev) =>
               prev.map((c) => (c.id === conversationId ? { ...c, title } : c)),
             );
+            finalTitle = title;
           } catch {
             const title = content.split(" ").slice(0, 5).join(" ");
             await storage.updateConversationTitle(conversationId, title);
             setConversations((prev) =>
               prev.map((c) => (c.id === conversationId ? { ...c, title } : c)),
             );
+            finalTitle = title;
           }
         }
 
@@ -483,18 +500,52 @@ export function useChat(
             } catch {}
           }, 3000);
         }
+
+        // --- BACKGROUND COMPLETION TOAST ---
+        if (storageModeRef.current !== storageMode) {
+          toast.success(`Response ready in "${finalTitle || "New Conversation"}"`, 6000, {
+            label: "View",
+            onClick: () => {
+              if (onStorageModeChange) {
+                onStorageModeChange(storageMode);
+                if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
+              } else {
+                selectConversation(conversationId);
+              }
+            },
+          });
+        }
       } catch (e) {
-        console.error("[sendMessage] error:", e);
-        toast.error("Failed to send message");
-        setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
+        if (e instanceof Error && e.name === "AbortError") {
+          console.log("[sendMessage] Aborted background stream");
+        } else {
+          console.error("[sendMessage] error:", e);
+          toast.error("Failed to send message");
+          setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
+        }
       } finally {
-        setIsStreaming(false);
-        setStreamingConversationId(null);
-        streamingDataRef.current = null;
-        abortControllerRef.current = null;
+        if (abortControllerRef.current === abortController) {
+          setIsStreaming(false);
+          setStreamingStorageMode(null);
+          setStreamingConversationId(null);
+          streamingDataRef.current = null;
+          abortControllerRef.current = null;
+        }
       }
     },
-    [isStreaming, messages, storage, activeBranch, setActiveVersionCb, streamResponse],
+    [
+      isStreaming,
+      messages,
+      storage,
+      activeBranch,
+      setActiveVersionCb,
+      streamResponse,
+      activeConversation,
+      toast,
+      onStorageModeChange,
+      selectConversation,
+      pendingSelectionRef,
+    ],
   );
 
   const editMessage = useCallback(
@@ -548,6 +599,10 @@ export function useChat(
 
       setMessages((prev) => [...prev, userMessage, assistantMessage]);
       setIsStreaming(true);
+      setStreamingStorageMode(storageMode);
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
 
       try {
         // Calculate the branch up to this new message
@@ -573,22 +628,60 @@ export function useChat(
 
         await storage.saveMessage(userMessage);
         await storage.saveMessage({ ...assistantMessage, content: fullContent });
+
+        // --- BACKGROUND COMPLETION TOAST ---
+        if (storageModeRef.current !== storageMode) {
+          toast.success(
+            `Response ready in "${activeConversation?.title || "New Conversation"}"`,
+            6000,
+            {
+              label: "View",
+              onClick: () => {
+                if (onStorageModeChange) {
+                  onStorageModeChange(storageMode);
+                  if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
+                } else {
+                  selectConversation(conversationId);
+                }
+              },
+            },
+          );
+        }
       } catch (e) {
-        console.error("[editMessage] error:", e);
-        toast.error("Failed to edit message");
-        setMessages((prev) =>
-          prev.filter((m) => m.id !== assistantMessage.id && m.id !== userMessage.id),
-        );
-        const rootKey = `${conversationId}_root`;
-        setActiveVersionCb(userParentId || rootKey, targetMessageId);
+        if (e instanceof Error && e.name === "AbortError") {
+          console.log("[editMessage] Aborted background stream");
+        } else {
+          console.error("[editMessage] error:", e);
+          toast.error("Failed to edit message");
+          setMessages((prev) =>
+            prev.filter((m) => m.id !== assistantMessage.id && m.id !== userMessage.id),
+          );
+          const rootKey = `${conversationId}_root`;
+          setActiveVersionCb(userParentId || rootKey, targetMessageId);
+        }
       } finally {
-        setIsStreaming(false);
-        setStreamingConversationId(null);
-        streamingDataRef.current = null;
-        abortControllerRef.current = null;
+        if (abortControllerRef.current === abortController) {
+          setIsStreaming(false);
+          setStreamingStorageMode(null);
+          setStreamingConversationId(null);
+          streamingDataRef.current = null;
+          abortControllerRef.current = null;
+        }
       }
     },
-    [isStreaming, messages, storage, activeBranch, setActiveVersionCb, streamResponse],
+    [
+      isStreaming,
+      messages,
+      storage,
+      activeBranch,
+      setActiveVersionCb,
+      streamResponse,
+      activeConversation,
+      toast,
+      onStorageModeChange,
+      selectConversation,
+      pendingSelectionRef,
+    ],
   );
 
   const retryMessage = useCallback(
@@ -629,6 +722,10 @@ export function useChat(
 
       setMessages((prev) => [...prev, newAssistantMessage]);
       setIsStreaming(true);
+      setStreamingStorageMode(storageMode);
+
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
 
       try {
         // Calculate the active branch up to the parent user message
@@ -650,22 +747,60 @@ export function useChat(
         );
 
         await storage.saveMessage({ ...newAssistantMessage, content: fullContent });
+
+        // --- BACKGROUND COMPLETION TOAST ---
+        if (storageModeRef.current !== storageMode) {
+          toast.success(
+            `Response ready in "${activeConversation?.title || "New Conversation"}"`,
+            6000,
+            {
+              label: "View",
+              onClick: () => {
+                if (onStorageModeChange) {
+                  onStorageModeChange(storageMode);
+                  if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
+                } else {
+                  selectConversation(conversationId);
+                }
+              },
+            },
+          );
+        }
       } catch (e) {
-        console.error("[retryMessage] error:", e);
-        toast.error("Failed to retry message");
-        // Remove the failed placeholder
-        setMessages((prev) => prev.filter((m) => m.id !== newAssistantMessage.id));
-        // Revert active version to the one the user was viewing
-        const rootKey = `${conversationId}_root`;
-        setActiveVersionCb(assistantParentId || rootKey, messageId);
+        if (e instanceof Error && e.name === "AbortError") {
+          console.log("[retryMessage] Aborted background stream");
+        } else {
+          console.error("[retryMessage] error:", e);
+          toast.error("Failed to retry message");
+          // Remove the failed placeholder
+          setMessages((prev) => prev.filter((m) => m.id !== newAssistantMessage.id));
+          // Revert active version to the one the user was viewing
+          const rootKey = `${conversationId}_root`;
+          setActiveVersionCb(assistantParentId || rootKey, messageId);
+        }
       } finally {
-        setIsStreaming(false);
-        setStreamingConversationId(null);
-        streamingDataRef.current = null;
-        abortControllerRef.current = null;
+        if (abortControllerRef.current === abortController) {
+          setIsStreaming(false);
+          setStreamingStorageMode(null);
+          setStreamingConversationId(null);
+          streamingDataRef.current = null;
+          abortControllerRef.current = null;
+        }
       }
     },
-    [isStreaming, messages, storage, activeBranch, setActiveVersionCb, streamResponse],
+    [
+      isStreaming,
+      messages,
+      storage,
+      activeBranch,
+      setActiveVersionCb,
+      streamResponse,
+      activeConversation,
+      toast,
+      onStorageModeChange,
+      selectConversation,
+      pendingSelectionRef,
+    ],
   );
 
   const deleteMessageCb = useCallback(
@@ -711,6 +846,7 @@ export function useChat(
     messages,
     activeBranch,
     isStreaming,
+    streamingStorageMode,
     activeVersions,
     loadConversations,
     selectConversation,

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -140,6 +140,29 @@ export function useChat(
     [onStorageModeChange, toast, pendingSelectionRef],
   );
 
+  const showBackgroundErrorToast = useCallback(
+    (actionName: string, targetMode: StorageMode, conversationId: string) => {
+      const isBackground = storageModeRef.current !== targetMode;
+      const modeLabel = targetMode === "cloud" ? "Cloud" : "Local";
+
+      const message = `Failed to ${actionName}${isBackground ? ` in ${modeLabel} mode` : ""}`;
+
+      const action =
+        isBackground && onStorageModeChange
+          ? {
+              label: "Switch",
+              onClick: () => {
+                onStorageModeChange(targetMode);
+                if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
+              },
+            }
+          : undefined;
+
+      toast.error(message, 6000, action);
+    },
+    [onStorageModeChange, toast, pendingSelectionRef],
+  );
+
   const loadConversations = useCallback(async () => {
     try {
       const data = await storage.getConversations();
@@ -525,7 +548,7 @@ export function useChat(
           console.log("[sendMessage] Aborted background stream");
         } else {
           console.error("[sendMessage] error:", e);
-          toast.error("Failed to send message");
+          showBackgroundErrorToast("send message", storageMode, conversationId);
           setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
         }
       } finally {
@@ -548,6 +571,7 @@ export function useChat(
       activeConversation,
       toast,
       showBackgroundCompletionToast,
+      showBackgroundErrorToast,
     ],
   );
 
@@ -640,7 +664,7 @@ export function useChat(
           console.log("[editMessage] Aborted background stream");
         } else {
           console.error("[editMessage] error:", e);
-          toast.error("Failed to edit message");
+          showBackgroundErrorToast("edit message", storageMode, conversationId);
           setMessages((prev) =>
             prev.filter((m) => m.id !== assistantMessage.id && m.id !== userMessage.id),
           );
@@ -667,6 +691,7 @@ export function useChat(
       activeConversation,
       toast,
       showBackgroundCompletionToast,
+      showBackgroundErrorToast,
     ],
   );
 
@@ -742,7 +767,7 @@ export function useChat(
           console.log("[retryMessage] Aborted background stream");
         } else {
           console.error("[retryMessage] error:", e);
-          toast.error("Failed to retry message");
+          showBackgroundErrorToast("retry message", storageMode, conversationId);
           // Remove the failed placeholder
           setMessages((prev) => prev.filter((m) => m.id !== newAssistantMessage.id));
           // Revert active version to the one the user was viewing
@@ -769,6 +794,7 @@ export function useChat(
       activeConversation,
       toast,
       showBackgroundCompletionToast,
+      showBackgroundErrorToast,
     ],
   );
 

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -99,70 +99,6 @@ export function useChat(
     [storageMode],
   );
 
-  // After mode change: auto-select a conversation if pendingSelectionRef is set
-  const selectAfterModeChangeRef = useRef(false);
-  useEffect(() => {
-    selectAfterModeChangeRef.current = true;
-  }, [storageMode]);
-
-  useEffect(() => {
-    if (selectAfterModeChangeRef.current && pendingSelectionRef?.current) {
-      const id = pendingSelectionRef.current;
-      pendingSelectionRef.current = null;
-      selectAfterModeChangeRef.current = false;
-      // Select the specific conversation (conversation list is loaded by App.tsx)
-      storage.getConversation(id).then((result) => {
-        if (result) {
-          setActiveConversation(result.conversation);
-          const finalMessages = mergeStreamingData(id, result.messages);
-          setMessages(finalMessages);
-        }
-      });
-    }
-  }, [storage, storageMode, pendingSelectionRef]);
-
-  const showBackgroundCompletionToast = useCallback(
-    (targetMode: StorageMode, conversationId: string, title?: string) => {
-      if (storageModeRef.current === targetMode) return;
-
-      const action = onStorageModeChange
-        ? {
-            label: "View",
-            onClick: () => {
-              onStorageModeChange(targetMode);
-              if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
-            },
-          }
-        : undefined;
-
-      toast.success(`Response ready in "${title || "New Conversation"}"`, 6000, action);
-    },
-    [onStorageModeChange, toast, pendingSelectionRef],
-  );
-
-  const showBackgroundErrorToast = useCallback(
-    (actionName: string, targetMode: StorageMode, conversationId: string) => {
-      const isBackground = storageModeRef.current !== targetMode;
-      const modeLabel = targetMode === "cloud" ? "Cloud" : "Local";
-
-      const message = `Failed to ${actionName}${isBackground ? ` in ${modeLabel} mode` : ""}`;
-
-      const action =
-        isBackground && onStorageModeChange
-          ? {
-              label: "Switch",
-              onClick: () => {
-                onStorageModeChange(targetMode);
-                if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
-              },
-            }
-          : undefined;
-
-      toast.error(message, 6000, action);
-    },
-    [onStorageModeChange, toast, pendingSelectionRef],
-  );
-
   const loadConversations = useCallback(async () => {
     try {
       const data = await storage.getConversations();
@@ -191,6 +127,79 @@ export function useChat(
       }
     },
     [storage, storageMode, mergeStreamingData, toast],
+  );
+
+  // After mode change: auto-select a conversation if pendingSelectionRef is set
+  const selectAfterModeChangeRef = useRef(false);
+  useEffect(() => {
+    selectAfterModeChangeRef.current = true;
+  }, [storageMode]);
+
+  useEffect(() => {
+    if (selectAfterModeChangeRef.current && pendingSelectionRef?.current) {
+      const id = pendingSelectionRef.current;
+      pendingSelectionRef.current = null;
+      selectAfterModeChangeRef.current = false;
+      // Select the specific conversation (conversation list is loaded by App.tsx)
+      storage.getConversation(id).then((result) => {
+        if (result) {
+          setActiveConversation(result.conversation);
+          const finalMessages = mergeStreamingData(id, result.messages);
+          setMessages(finalMessages);
+        }
+      });
+    }
+  }, [storage, storageMode, pendingSelectionRef]);
+
+  const showBackgroundCompletionToast = useCallback(
+    (targetMode: StorageMode, conversationId: string, title?: string) => {
+      const isWrongMode = storageModeRef.current !== targetMode;
+      const isWrongChat = activeConversation?.id !== conversationId;
+
+      if (!isWrongMode && !isWrongChat) return;
+
+      const action = {
+        label: "View",
+        onClick: () => {
+          if (isWrongMode && onStorageModeChange) {
+            onStorageModeChange(targetMode);
+            if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
+          } else {
+            selectConversation(conversationId);
+          }
+        },
+      };
+
+      toast.success(`Response ready in "${title || "New Conversation"}"`, 6000, action);
+    },
+    [onStorageModeChange, toast, pendingSelectionRef, activeConversation?.id, selectConversation],
+  );
+
+  const showBackgroundErrorToast = useCallback(
+    (actionName: string, targetMode: StorageMode, conversationId: string) => {
+      const isWrongMode = storageModeRef.current !== targetMode;
+      const isWrongChat = activeConversation?.id !== conversationId;
+
+      if (!isWrongMode && !isWrongChat) return;
+
+      const modeLabel = targetMode === "cloud" ? "Cloud" : "Local";
+      const message = `Failed to ${actionName}${isWrongMode ? ` in ${modeLabel} mode` : ""}`;
+
+      const action = {
+        label: "Switch",
+        onClick: () => {
+          if (isWrongMode && onStorageModeChange) {
+            onStorageModeChange(targetMode);
+            if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
+          } else {
+            selectConversation(conversationId);
+          }
+        },
+      };
+
+      toast.error(message, 6000, action);
+    },
+    [onStorageModeChange, toast, pendingSelectionRef, activeConversation?.id, selectConversation],
   );
 
   const newConversation = useCallback(

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -121,6 +121,25 @@ export function useChat(
     }
   }, [storage, storageMode, pendingSelectionRef]);
 
+  const showBackgroundCompletionToast = useCallback(
+    (targetMode: StorageMode, conversationId: string, title?: string) => {
+      if (storageModeRef.current === targetMode) return;
+
+      const action = onStorageModeChange
+        ? {
+            label: "View",
+            onClick: () => {
+              onStorageModeChange(targetMode);
+              if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
+            },
+          }
+        : undefined;
+
+      toast.success(`Response ready in "${title || "New Conversation"}"`, 6000, action);
+    },
+    [onStorageModeChange, toast, pendingSelectionRef],
+  );
+
   const loadConversations = useCallback(async () => {
     try {
       const data = await storage.getConversations();
@@ -500,19 +519,7 @@ export function useChat(
         }
 
         // --- BACKGROUND COMPLETION TOAST ---
-        if (storageModeRef.current !== storageMode) {
-          toast.success(`Response ready in "${finalTitle || "New Conversation"}"`, 6000, {
-            label: "View",
-            onClick: () => {
-              if (onStorageModeChange) {
-                onStorageModeChange(storageMode);
-                if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
-              } else {
-                selectConversation(conversationId);
-              }
-            },
-          });
-        }
+        showBackgroundCompletionToast(storageMode, conversationId, finalTitle);
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") {
           console.log("[sendMessage] Aborted background stream");
@@ -629,23 +636,7 @@ export function useChat(
         await storage.saveMessage({ ...assistantMessage, content: fullContent });
 
         // --- BACKGROUND COMPLETION TOAST ---
-        if (storageModeRef.current !== storageMode) {
-          toast.success(
-            `Response ready in "${activeConversation?.title || "New Conversation"}"`,
-            6000,
-            {
-              label: "View",
-              onClick: () => {
-                if (onStorageModeChange) {
-                  onStorageModeChange(storageMode);
-                  if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
-                } else {
-                  selectConversation(conversationId);
-                }
-              },
-            },
-          );
-        }
+        showBackgroundCompletionToast(storageMode, conversationId, activeConversation?.title);
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") {
           console.log("[editMessage] Aborted background stream");
@@ -749,23 +740,7 @@ export function useChat(
         await storage.saveMessage({ ...newAssistantMessage, content: fullContent });
 
         // --- BACKGROUND COMPLETION TOAST ---
-        if (storageModeRef.current !== storageMode) {
-          toast.success(
-            `Response ready in "${activeConversation?.title || "New Conversation"}"`,
-            6000,
-            {
-              label: "View",
-              onClick: () => {
-                if (onStorageModeChange) {
-                  onStorageModeChange(storageMode);
-                  if (pendingSelectionRef) pendingSelectionRef.current = conversationId;
-                } else {
-                  selectConversation(conversationId);
-                }
-              },
-            },
-          );
-        }
+        showBackgroundCompletionToast(storageMode, conversationId, activeConversation?.title);
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") {
           console.log("[retryMessage] Aborted background stream");

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -116,7 +116,6 @@ export function useChat(
           setActiveConversation(result.conversation);
           const finalMessages = mergeStreamingData(id, result.messages);
           setMessages(finalMessages);
-          if (pendingSelectionRef) pendingSelectionRef.current = null;
         }
       });
     }

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -529,7 +529,7 @@ export function useChat(
           setMessages((prev) => prev.filter((m) => m.id !== assistantMessage.id));
         }
       } finally {
-        if (abortControllerRef.current === abortController) {
+        if (abortControllerRef.current === abortController || abortControllerRef.current === null) {
           setIsStreaming(false);
           setStreamingStorageMode(null);
           setStreamingConversationId(null);
@@ -547,9 +547,7 @@ export function useChat(
       streamResponse,
       activeConversation,
       toast,
-      onStorageModeChange,
-      selectConversation,
-      pendingSelectionRef,
+      showBackgroundCompletionToast,
     ],
   );
 
@@ -650,7 +648,7 @@ export function useChat(
           setActiveVersionCb(userParentId || rootKey, targetMessageId);
         }
       } finally {
-        if (abortControllerRef.current === abortController) {
+        if (abortControllerRef.current === abortController || abortControllerRef.current === null) {
           setIsStreaming(false);
           setStreamingStorageMode(null);
           setStreamingConversationId(null);
@@ -668,9 +666,7 @@ export function useChat(
       streamResponse,
       activeConversation,
       toast,
-      onStorageModeChange,
-      selectConversation,
-      pendingSelectionRef,
+      showBackgroundCompletionToast,
     ],
   );
 
@@ -754,7 +750,7 @@ export function useChat(
           setActiveVersionCb(assistantParentId || rootKey, messageId);
         }
       } finally {
-        if (abortControllerRef.current === abortController) {
+        if (abortControllerRef.current === abortController || abortControllerRef.current === null) {
           setIsStreaming(false);
           setStreamingStorageMode(null);
           setStreamingConversationId(null);
@@ -772,9 +768,7 @@ export function useChat(
       streamResponse,
       activeConversation,
       toast,
-      onStorageModeChange,
-      selectConversation,
-      pendingSelectionRef,
+      showBackgroundCompletionToast,
     ],
   );
 

--- a/src/client/hooks/useToast.tsx
+++ b/src/client/hooks/useToast.tsx
@@ -7,15 +7,19 @@ export interface Toast {
   message: string;
   type: ToastType;
   duration?: number;
+  action?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 
 interface ToastActionsContextType {
-  addToast: (message: string, type: ToastType, duration?: number) => void;
+  addToast: (message: string, type: ToastType, duration?: number, action?: Toast["action"]) => void;
   removeToast: (id: string) => void;
-  success: (message: string, duration?: number) => void;
-  error: (message: string, duration?: number) => void;
-  warning: (message: string, duration?: number) => void;
-  info: (message: string, duration?: number) => void;
+  success: (message: string, duration?: number, action?: Toast["action"]) => void;
+  error: (message: string, duration?: number, action?: Toast["action"]) => void;
+  warning: (message: string, duration?: number, action?: Toast["action"]) => void;
+  info: (message: string, duration?: number, action?: Toast["action"]) => void;
 }
 
 const ToastStateContext = createContext<Toast[] | undefined>(undefined);
@@ -31,43 +35,59 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
-  const addToast = useCallback((message: string, type: ToastType, duration?: number) => {
-    const generateId = () =>
-      typeof crypto !== "undefined" && crypto.randomUUID
-        ? crypto.randomUUID()
-        : Math.random().toString(36).substring(2, 11);
+  const addToast = useCallback(
+    (message: string, type: ToastType, duration?: number, action?: Toast["action"]) => {
+      const generateId = () =>
+        typeof crypto !== "undefined" && crypto.randomUUID
+          ? crypto.randomUUID()
+          : Math.random().toString(36).substring(2, 11);
 
-    setToasts((prev) => {
-      // Deduplication: Check if same message already exists
-      const existingIndex = prev.findIndex((t) => t.message === message && t.type === type);
+      setToasts((prev) => {
+        // Deduplication: Check if same message already exists
+        const existingIndex = prev.findIndex((t) => t.message === message && t.type === type);
 
-      if (existingIndex !== -1) {
-        const updated = [...prev];
-        const existing = updated[existingIndex];
-        updated.splice(existingIndex, 1);
-        return [{ ...existing, id: generateId() }, ...updated];
-      }
+        if (existingIndex !== -1) {
+          const updated = [...prev];
+          const existing = updated[existingIndex];
+          updated.splice(existingIndex, 1);
+          return [{ ...existing, id: generateId(), action }, ...updated];
+        }
 
-      const newToast: Toast = {
-        id: generateId(),
-        message,
-        type,
-        duration:
-          duration ?? (type === "error" ? 8000 : type === "warning" ? 6000 : DEFAULT_DURATION),
-      };
+        const newToast: Toast = {
+          id: generateId(),
+          message,
+          type,
+          action,
+          duration:
+            duration ?? (type === "error" ? 8000 : type === "warning" ? 6000 : DEFAULT_DURATION),
+        };
 
-      const next = [newToast, ...prev];
-      if (next.length > MAX_TOASTS) {
-        return next.slice(0, MAX_TOASTS);
-      }
-      return next;
-    });
-  }, []);
+        const next = [newToast, ...prev];
+        if (next.length > MAX_TOASTS) {
+          return next.slice(0, MAX_TOASTS);
+        }
+        return next;
+      });
+    },
+    [],
+  );
 
-  const success = useCallback((msg: string, d?: number) => addToast(msg, "success", d), [addToast]);
-  const error = useCallback((msg: string, d?: number) => addToast(msg, "error", d), [addToast]);
-  const warning = useCallback((msg: string, d?: number) => addToast(msg, "warning", d), [addToast]);
-  const info = useCallback((msg: string, d?: number) => addToast(msg, "info", d), [addToast]);
+  const success = useCallback(
+    (msg: string, d?: number, a?: Toast["action"]) => addToast(msg, "success", d, a),
+    [addToast],
+  );
+  const error = useCallback(
+    (msg: string, d?: number, a?: Toast["action"]) => addToast(msg, "error", d, a),
+    [addToast],
+  );
+  const warning = useCallback(
+    (msg: string, d?: number, a?: Toast["action"]) => addToast(msg, "warning", d, a),
+    [addToast],
+  );
+  const info = useCallback(
+    (msg: string, d?: number, a?: Toast["action"]) => addToast(msg, "info", d, a),
+    [addToast],
+  );
 
   const actions = useMemo(
     () => ({ addToast, removeToast, success, error, warning, info }),


### PR DESCRIPTION
## Description

Add cross-mode streaming support with background completion toasts and actionable notifications

**Fixes #96**

## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `fix/96-stream-orphaned-when-switching-storage-modes-during-active-generation` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/fix/96-stream-orphaned-when-switching-storage-modes-during-active-generation)
