### PR TITLE
feat: add visual indicator for active streaming conversations in sidebar and update move restrictions

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -586,6 +586,8 @@ export default function App() {
           currentMode={storageMode}
           savedMode={savedStorageMode}
           isStreaming={isStreaming}
+          streamingConversationId={streamingConversationId}
+          streamingStorageMode={streamingStorageMode}
           movingConversationId={transferState.conversationId}
         />
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -585,7 +585,6 @@ export default function App() {
           onSettingsOpen={() => setSettingsOpen(true)}
           currentMode={storageMode}
           savedMode={savedStorageMode}
-          isStreaming={isStreaming}
           streamingConversationId={streamingConversationId}
           streamingStorageMode={streamingStorageMode}
           movingConversationId={transferState.conversationId}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -15,7 +15,6 @@ interface SidebarProps {
   onSettingsOpen: () => void;
   currentMode: StorageMode;
   savedMode: StorageMode;
-  isStreaming: boolean;
   streamingConversationId: string | null;
   streamingStorageMode: StorageMode | null;
   movingConversationId: string | null;
@@ -34,7 +33,6 @@ export default function Sidebar({
   onSettingsOpen,
   currentMode,
   savedMode, // Kept in props to satisfy the interface and App.tsx
-  isStreaming,
   streamingConversationId,
   streamingStorageMode,
   movingConversationId,
@@ -369,7 +367,7 @@ export default function Sidebar({
                         e.stopPropagation();
                         handleRenameClick(c);
                       }}
-                      disabled={isThisStreaming}
+                      disabled={isMoveDisabled}
                       className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                       role="menuitem"
                     >
@@ -440,7 +438,7 @@ export default function Sidebar({
                         setOpenMenuId(null);
                         setPendingDelete(c);
                       }}
-                      disabled={isThisStreaming}
+                      disabled={isMoveDisabled}
                       className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                       role="menuitem"
                     >

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -369,7 +369,8 @@ export default function Sidebar({
                         e.stopPropagation();
                         handleRenameClick(c);
                       }}
-                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                      disabled={isThisStreaming}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                       role="menuitem"
                     >
                       <svg
@@ -439,7 +440,8 @@ export default function Sidebar({
                         setOpenMenuId(null);
                         setPendingDelete(c);
                       }}
-                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 transition-colors"
+                      disabled={isThisStreaming}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                       role="menuitem"
                     >
                       <svg

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -16,6 +16,8 @@ interface SidebarProps {
   currentMode: StorageMode;
   savedMode: StorageMode;
   isStreaming: boolean;
+  streamingConversationId: string | null;
+  streamingStorageMode: StorageMode | null;
   movingConversationId: string | null;
 }
 
@@ -33,6 +35,8 @@ export default function Sidebar({
   currentMode,
   savedMode, // Kept in props to satisfy the interface and App.tsx
   isStreaming,
+  streamingConversationId,
+  streamingStorageMode,
   movingConversationId,
 }: SidebarProps) {
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
@@ -218,7 +222,9 @@ export default function Sidebar({
           )}
           {conversations.map((c) => {
             const isMoving = movingConversationId === c.id;
-            const isMoveDisabled = isMoving || (activeId === c.id && isStreaming);
+            const isThisStreaming =
+              c.id === streamingConversationId && currentMode === streamingStorageMode;
+            const isMoveDisabled = isMoving || isThisStreaming;
 
             return (
               <div
@@ -273,7 +279,7 @@ export default function Sidebar({
                   </div>
                 ) : (
                   <div
-                    className="flex-1 relative overflow-hidden min-w-0 w-full transition-all duration-200"
+                    className="flex-1 relative flex items-center gap-2 overflow-hidden min-w-0 w-full transition-all duration-200"
                     style={{
                       maskImage:
                         "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
@@ -281,6 +287,20 @@ export default function Sidebar({
                         "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
                     }}
                   >
+                    {isThisStreaming && (
+                      <div
+                        className={`shrink-0 w-1.5 h-1.5 rounded-full animate-pulse ${
+                          activeId === c.id
+                            ? currentMode === "cloud"
+                              ? "bg-white"
+                              : "bg-gray-900"
+                            : currentMode === "cloud"
+                              ? "bg-brand-cloud"
+                              : "bg-brand-local"
+                        }`}
+                        title="Generation in progress..."
+                      />
+                    )}
                     <span className="whitespace-nowrap">{c.title}</span>
                   </div>
                 )}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -278,6 +278,7 @@ export default function Sidebar({
                 ) : (
                   <div
                     className="flex-1 relative flex items-center gap-2 overflow-hidden min-w-0 w-full transition-all duration-200"
+                    title={isThisStreaming ? "Generation in progress..." : undefined}
                     style={{
                       maskImage:
                         "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
@@ -296,7 +297,6 @@ export default function Sidebar({
                               ? "bg-brand-cloud"
                               : "bg-brand-local"
                         }`}
-                        title="Generation in progress..."
                       />
                     )}
                     <span className="whitespace-nowrap">{c.title}</span>


### PR DESCRIPTION
## Description

Add visual indicator for active streaming conversations in sidebar and update move restrictions

**Fixes #97**


## Checklist

- [x] CI Build & Type-check Tests Pass
- [x] CodeQL All Tests Pass
- [x] README/Docs updated if needed
- [x] No breaking changes (or described below)

---

## How to Test This PR

You have two options to test these changes live:

### Option A: Test on your existing self-hosted instance (Recommended)

If you already have a WaiChat instance running on Cloudflare, you can test this PR without losing your database history:

1. Go to the **Actions** tab of your own WaiChat repository.
2. Select the **Dev: Test Upstream Branch** workflow.
3. Click **Run workflow** and enter `feat/97-show-in-progress-stream-indicator-on-sidebar-chat-item` (the author's branch) into the input field.

### Option B: 1-Click Fresh Deployment

Want to test these changes on a brand new, isolated Cloudflare instance? Use the button below.

[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/ranajahanzaib/WaiChat/tree/feat/97-show-in-progress-stream-indicator-on-sidebar-chat-item)
