### PR TITLE
feat: system prompt library with per-session selection

### DIFF
--- a/migrations/0008_add_system_prompts.sql
+++ b/migrations/0008_add_system_prompts.sql
@@ -3,7 +3,8 @@ CREATE TABLE IF NOT EXISTS system_prompts (
   user_id TEXT NOT NULL DEFAULT 'default',
   name TEXT NOT NULL,
   content TEXT NOT NULL,
-  created_at INTEGER NOT NULL
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER
 );
 
 CREATE INDEX IF NOT EXISTS idx_system_prompts_user_id ON system_prompts (user_id);

--- a/migrations/0008_add_system_prompts.sql
+++ b/migrations/0008_add_system_prompts.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS system_prompts (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL DEFAULT 'default',
+  name TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_system_prompts_user_id ON system_prompts (user_id);

--- a/migrations/0009_add_system_prompt_to_conversations.sql
+++ b/migrations/0009_add_system_prompt_to_conversations.sql
@@ -1,0 +1,1 @@
+ALTER TABLE conversations ADD COLUMN system_prompt_id TEXT;

--- a/migrations/0010_add_system_prompt_content_to_conversations.sql
+++ b/migrations/0010_add_system_prompt_content_to_conversations.sql
@@ -1,0 +1,1 @@
+ALTER TABLE conversations ADD COLUMN system_prompt TEXT;

--- a/migrations/0011_add_updated_at_to_system_prompts.sql
+++ b/migrations/0011_add_updated_at_to_system_prompts.sql
@@ -1,0 +1,3 @@
+ALTER TABLE system_prompts ADD COLUMN updated_at INTEGER;
+
+UPDATE system_prompts SET updated_at = created_at WHERE updated_at IS NULL;

--- a/migrations/0011_add_updated_at_to_system_prompts.sql
+++ b/migrations/0011_add_updated_at_to_system_prompts.sql
@@ -1,3 +1,2 @@
-ALTER TABLE system_prompts ADD COLUMN updated_at INTEGER;
-
-UPDATE system_prompts SET updated_at = created_at WHERE updated_at IS NULL;
+-- updated_at is now included in 0008_add_system_prompts.sql.
+-- This migration is a no-op kept for environments that applied 0008 before it was consolidated.

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -33,6 +33,17 @@ export interface SystemPrompt {
 
 export type ThemeMode = "system" | "light" | "dark";
 
+function generateUUID(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
 /**
  * Read system prompts from localStorage, running a one-time migration of the
  * legacy waichat:system-prompt key if present. Defined outside the component
@@ -48,7 +59,7 @@ function readSystemPromptsFromStorage(): SystemPrompt[] {
     if (legacyPrompt?.trim()) {
       const now = Date.now();
       const migrated: SystemPrompt = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         user_id: "default",
         name: "Default Prompt",
         content: legacyPrompt.trim(),
@@ -299,7 +310,7 @@ export default function App() {
             const postRes = await fetch("/api/system-prompts", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ id: p.id, name: p.name, content: p.content, created_at: p.created_at }),
+              body: JSON.stringify({ id: p.id, name: p.name, content: p.content, created_at: p.created_at, updated_at: p.updated_at }),
             });
             if (!postRes.ok) throw new Error(`Failed to sync prompt: ${p.name}`);
           }),
@@ -491,10 +502,9 @@ export default function App() {
   // For an active conversation use its stored snapshot so library edits/deletes
   // don't silently change the AI's behaviour mid-conversation.
   // For a new chat (no active conversation) use the currently selected prompt.
-  const effectiveSystemPrompt =
-    activeConversation?.system_prompt ??
-    systemPrompts.find((p) => p.id === selectedPromptId)?.content ??
-    "";
+  const effectiveSystemPrompt = activeConversation
+    ? (activeConversation.system_prompt ?? "")
+    : (systemPrompts.find((p) => p.id === selectedPromptId)?.content ?? "");
 
   const handleSend = async (content: string) => {
     if (isStreaming) return;
@@ -571,7 +581,7 @@ export default function App() {
     } else {
       const now = Date.now();
       const prompt: SystemPrompt = {
-        id: crypto.randomUUID(),
+        id: generateUUID(),
         user_id: "default",
         name,
         content,

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -248,7 +248,7 @@ export default function App() {
         const cloudPrompts = (await res.json()) as SystemPrompt[];
         if (!active) return;
 
-        const cloudIds = new Set(cloudPrompts.map((p) => p.id));
+        const cloudPromptsMap = new Map(cloudPrompts.map((p) => [p.id, p]));
 
         // Read local prompts directly from storage to avoid stale closure
         let localPrompts: SystemPrompt[] = [];
@@ -259,9 +259,15 @@ export default function App() {
         } catch {
           localPrompts = [];
         }
-        const localOnly = localPrompts.filter((p) => !cloudIds.has(p.id));
+
+        // Upload prompts that are missing from cloud OR have been edited locally
+        const localOnlyOrModified = localPrompts.filter((p) => {
+          const cloud = cloudPromptsMap.get(p.id);
+          if (!cloud) return true;
+          return cloud.name !== p.name || cloud.content !== p.content;
+        });
         await Promise.all(
-          localOnly.map(async (p) => {
+          localOnlyOrModified.map(async (p) => {
             const postRes = await fetch("/api/system-prompts", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
@@ -274,7 +280,7 @@ export default function App() {
 
         // Re-fetch the merged list from cloud
         const merged =
-          localOnly.length > 0
+          localOnlyOrModified.length > 0
             ? await fetch("/api/system-prompts").then((r) => {
                 if (!r.ok) throw new Error("Failed to fetch merged prompts");
                 return r.json() as Promise<SystemPrompt[]>;
@@ -454,14 +460,19 @@ export default function App() {
     closeSidebarOnMobile();
   };
 
+  // For an active conversation use its stored snapshot so library edits/deletes
+  // don't silently change the AI's behaviour mid-conversation.
+  // For a new chat (no active conversation) use the currently selected prompt.
   const effectiveSystemPrompt =
-    systemPrompts.find((p) => p.id === selectedPromptId)?.content ?? "";
+    activeConversation?.system_prompt ??
+    systemPrompts.find((p) => p.id === selectedPromptId)?.content ??
+    "";
 
   const handleSend = async (content: string) => {
     if (isStreaming) return;
     const currentModel = activeConversation?.model ?? defaultModel;
     if (!activeConversation) {
-      const convo = await newConversation(defaultModel, storageMode, selectedPromptId);
+      const convo = await newConversation(defaultModel, storageMode, selectedPromptId, effectiveSystemPrompt || null);
       await sendMessage(content, defaultModel, convo.id, storageMode, effectiveSystemPrompt);
     } else {
       await sendMessage(
@@ -583,6 +594,17 @@ export default function App() {
     });
     if (selectedPromptId === id) setSelectedPromptId(null);
   };
+
+  // One-time migration: import legacy global system prompt into the library
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    const legacyPrompt = localStorage.getItem("waichat:system-prompt");
+    if (legacyPrompt?.trim()) {
+      handleAddSystemPrompt("Default Prompt", legacyPrompt.trim())
+        .then(() => localStorage.removeItem("waichat:system-prompt"))
+        .catch((err) => console.error("Failed to migrate legacy system prompt:", err));
+    }
+  }, []);
 
   const handleClearConversations = async (mode: StorageMode) => {
     const storage = createStorage(mode);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -160,15 +160,34 @@ export default function App() {
   }, [activeConversation?.id]);
 
   const isCreatingConversationRef = useRef(false);
+  const prevActiveIdRef = useRef<string | null | undefined>(undefined);
 
-  // Reset selected prompt when switching conversations, but preserve it for
-  // the null → new-id transition that happens when sending the first message.
+  // When switching to a different existing conversation, restore its system prompt.
+  // When creating a new conversation (null → id), preserve the chosen prompt.
+  // When clearing to a new-chat screen (id → null), reset the prompt.
   useEffect(() => {
-    if (isCreatingConversationRef.current) {
-      isCreatingConversationRef.current = false;
+    const prevId = prevActiveIdRef.current;
+    const nextId = activeConversation?.id ?? null;
+    prevActiveIdRef.current = nextId;
+
+    if (prevId === undefined) {
+      // Initial mount: if we loaded straight into a conversation, restore its prompt
+      if (nextId !== null) {
+        const convo = conversations.find((c) => c.id === nextId);
+        if (convo?.system_prompt_id) setSelectedPromptId(convo.system_prompt_id);
+      }
       return;
     }
-    setSelectedPromptId(null);
+
+    if (isCreatingConversationRef.current) {
+      isCreatingConversationRef.current = false;
+      return; // null → new id: keep the chosen prompt for this session
+    }
+
+    if (nextId === null) {
+      setSelectedPromptId(null); // cleared to new-chat screen
+    }
+    // switching to an existing convo: handleSelectConversation already sets the prompt
   }, [activeConversation?.id]);
 
   const handleTempExpiryChange = useCallback((val: string) => {
@@ -240,12 +259,15 @@ export default function App() {
   // Load system prompts from cloud if sync enabled, merging local-only prompts up first
   useEffect(() => {
     if (!syncSettings) return;
+    let active = true;
 
     const syncPrompts = async () => {
       try {
         const res = await fetch("/api/system-prompts");
         if (!res.ok) throw new Error("Failed to fetch system prompts");
         const cloudPrompts = (await res.json()) as SystemPrompt[];
+        if (!active) return;
+
         const cloudIds = new Set(cloudPrompts.map((p) => p.id));
 
         // Read local prompts directly from storage to avoid stale closure
@@ -261,20 +283,26 @@ export default function App() {
             }),
           ),
         );
+        if (!active) return;
 
         // Re-fetch the merged list from cloud
-        const merged = localOnly.length > 0
-          ? await fetch("/api/system-prompts").then((r) => r.json() as Promise<SystemPrompt[]>)
-          : cloudPrompts;
+        const merged =
+          localOnly.length > 0
+            ? await fetch("/api/system-prompts").then((r) => r.json() as Promise<SystemPrompt[]>)
+            : cloudPrompts;
+        if (!active) return;
 
         setSystemPrompts(merged);
         localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(merged));
       } catch (err) {
-        console.error("Cloud sync error (system_prompts):", err);
+        if (active) console.error("Cloud sync error (system_prompts):", err);
       }
     };
 
     syncPrompts();
+    return () => {
+      active = false;
+    };
   }, [syncSettings]);
 
   // Sync Default Model from Cloud if enabled
@@ -408,6 +436,11 @@ export default function App() {
     setDrafts((prev) => ({ ...prev, [currentKey]: inputValue }));
     selectConversation(id);
     setInputValue(nextDraft);
+
+    // Restore the system prompt that was selected when this conversation was created
+    const convo = conversations.find((c) => c.id === id);
+    setSelectedPromptId(convo?.system_prompt_id ?? null);
+
     closeSidebarOnMobile();
   };
 
@@ -444,7 +477,7 @@ export default function App() {
     const currentModel = activeConversation?.model ?? defaultModel;
     if (!activeConversation) {
       isCreatingConversationRef.current = true;
-      const convo = await newConversation(defaultModel, storageMode);
+      const convo = await newConversation(defaultModel, storageMode, selectedPromptId);
       await sendMessage(content, defaultModel, convo.id, storageMode, effectiveSystemPrompt);
     } else {
       await sendMessage(

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -971,6 +971,10 @@ export default function App() {
           onDefaultModelChange={handleDefaultModelChange}
           systemPrompts={systemPrompts}
           syncSettings={syncSettings}
+          onSyncSettingsChange={(sync) => {
+            setSyncSettings(sync);
+            localStorage.setItem(SYNC_SETTINGS_KEY, String(sync));
+          }}
           onAddSystemPrompt={handleAddSystemPrompt}
           onUpdateSystemPrompt={handleUpdateSystemPrompt}
           onDeleteSystemPrompt={handleDeleteSystemPrompt}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -159,8 +159,15 @@ export default function App() {
     activeConversationIdRef.current = activeConversation?.id || null;
   }, [activeConversation?.id]);
 
-  // Reset selected prompt when switching or creating conversations to prevent leakage
+  const isCreatingConversationRef = useRef(false);
+
+  // Reset selected prompt when switching conversations, but preserve it for
+  // the null → new-id transition that happens when sending the first message.
   useEffect(() => {
+    if (isCreatingConversationRef.current) {
+      isCreatingConversationRef.current = false;
+      return;
+    }
     setSelectedPromptId(null);
   }, [activeConversation?.id]);
 
@@ -241,14 +248,16 @@ export default function App() {
         const cloudPrompts = (await res.json()) as SystemPrompt[];
         const cloudIds = new Set(cloudPrompts.map((p) => p.id));
 
-        // Upload any local prompts that don't exist in the cloud yet
-        const localOnly = systemPrompts.filter((p) => !cloudIds.has(p.id));
+        // Read local prompts directly from storage to avoid stale closure
+        const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
+        const localPrompts: SystemPrompt[] = stored ? JSON.parse(stored) : [];
+        const localOnly = localPrompts.filter((p) => !cloudIds.has(p.id));
         await Promise.all(
           localOnly.map((p) =>
             fetch("/api/system-prompts", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ name: p.name, content: p.content }),
+              body: JSON.stringify({ id: p.id, name: p.name, content: p.content, created_at: p.created_at }),
             }),
           ),
         );
@@ -434,6 +443,7 @@ export default function App() {
     if (isStreaming) return;
     const currentModel = activeConversation?.model ?? defaultModel;
     if (!activeConversation) {
+      isCreatingConversationRef.current = true;
       const convo = await newConversation(defaultModel, storageMode);
       await sendMessage(content, defaultModel, convo.id, storageMode, effectiveSystemPrompt);
     } else {
@@ -493,9 +503,11 @@ export default function App() {
         });
         if (!res.ok) throw new Error("Failed to save prompt");
         const prompt = (await res.json()) as SystemPrompt;
-        const updated = [...systemPrompts, prompt];
-        setSystemPrompts(updated);
-        savePromptsLocally(updated);
+        setSystemPrompts((prev) => {
+          const updated = [...prev, prompt];
+          savePromptsLocally(updated);
+          return updated;
+        });
       } catch (err) {
         console.error("Failed to add system prompt:", err);
         throw err;
@@ -508,9 +520,11 @@ export default function App() {
         content,
         created_at: Date.now(),
       };
-      const updated = [...systemPrompts, prompt];
-      setSystemPrompts(updated);
-      savePromptsLocally(updated);
+      setSystemPrompts((prev) => {
+        const updated = [...prev, prompt];
+        savePromptsLocally(updated);
+        return updated;
+      });
     }
   };
 
@@ -528,9 +542,11 @@ export default function App() {
         throw err;
       }
     }
-    const updated = systemPrompts.map((p) => (p.id === id ? { ...p, name, content } : p));
-    setSystemPrompts(updated);
-    savePromptsLocally(updated);
+    setSystemPrompts((prev) => {
+      const updated = prev.map((p) => (p.id === id ? { ...p, name, content } : p));
+      savePromptsLocally(updated);
+      return updated;
+    });
   };
 
   const handleDeleteSystemPrompt = async (id: string) => {
@@ -543,9 +559,11 @@ export default function App() {
         throw err;
       }
     }
-    const updated = systemPrompts.filter((p) => p.id !== id);
-    setSystemPrompts(updated);
-    savePromptsLocally(updated);
+    setSystemPrompts((prev) => {
+      const updated = prev.filter((p) => p.id !== id);
+      savePromptsLocally(updated);
+      return updated;
+    });
     if (selectedPromptId === id) setSelectedPromptId(null);
   };
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -110,7 +110,9 @@ export default function App() {
   );
   const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>(() => {
     try {
-      return JSON.parse(localStorage.getItem(SYSTEM_PROMPTS_KEY) ?? "[]");
+      const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
+      const parsed = stored ? JSON.parse(stored) : [];
+      return Array.isArray(parsed) ? parsed : [];
     } catch {
       return [];
     }
@@ -507,9 +509,11 @@ export default function App() {
   const handleDeleteSystemPrompt = async (id: string) => {
     if (syncSettings) {
       try {
-        await fetch(`/api/system-prompts/${id}`, { method: "DELETE" });
+        const res = await fetch(`/api/system-prompts/${id}`, { method: "DELETE" });
+        if (!res.ok) throw new Error("Failed to delete prompt");
       } catch (err) {
         console.error("Failed to delete system prompt:", err);
+        throw err;
       }
     }
     const updated = systemPrompts.filter((p) => p.id !== id);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -252,11 +252,10 @@ export default function App() {
           created_at: now,
           updated_at: now,
         };
-        setSystemPrompts((prev) => {
-          const updated = [...prev, migrated];
-          localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(updated));
-          return updated;
-        });
+        const current = readSystemPromptsFromStorage();
+        const updated = [...current, migrated];
+        localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(updated));
+        setSystemPrompts(updated);
         localStorage.removeItem("waichat:system-prompt");
       }
     } catch (err) {
@@ -580,11 +579,9 @@ export default function App() {
     };
 
     // Update local state immediately so the UI is always responsive
-    setSystemPrompts((prev) => {
-      const updated = [...prev, prompt];
-      savePromptsLocally(updated);
-      return updated;
-    });
+    const newList = [...systemPrompts, prompt];
+    savePromptsLocally(newList);
+    setSystemPrompts(newList);
 
     if (syncSettings) {
       try {
@@ -610,13 +607,11 @@ export default function App() {
     const now = Date.now();
 
     // Update local state immediately
-    setSystemPrompts((prev) => {
-      const updated = prev.map((p) =>
-        p.id === id ? { ...p, name, content, updated_at: now } : p,
-      );
-      savePromptsLocally(updated);
-      return updated;
-    });
+    const updatedList = systemPrompts.map((p) =>
+      p.id === id ? { ...p, name, content, updated_at: now } : p,
+    );
+    savePromptsLocally(updatedList);
+    setSystemPrompts(updatedList);
 
     if (syncSettings) {
       try {
@@ -634,11 +629,9 @@ export default function App() {
 
   const handleDeleteSystemPrompt = async (id: string) => {
     // Update local state immediately so the UI is responsive and works offline
-    setSystemPrompts((prev) => {
-      const updated = prev.filter((p) => p.id !== id);
-      savePromptsLocally(updated);
-      return updated;
-    });
+    const filteredList = systemPrompts.filter((p) => p.id !== id);
+    savePromptsLocally(filteredList);
+    setSystemPrompts(filteredList);
     if (selectedPromptId === id) setSelectedPromptId(null);
 
     if (syncSettings) {
@@ -824,12 +817,27 @@ export default function App() {
         }
       }
 
-      // Restore system prompt library if present
+      // Restore system prompt library — bulk update preserving original IDs and timestamps
       if (data.systemPrompts && Array.isArray(data.systemPrompts) && data.systemPrompts.length > 0) {
         const existingIds = new Set(systemPrompts.map((p) => p.id));
         const toImport = (data.systemPrompts as SystemPrompt[]).filter((p) => !existingIds.has(p.id));
-        for (const p of toImport) {
-          await handleAddSystemPrompt(p.name, p.content);
+        if (toImport.length > 0) {
+          const merged = [...systemPrompts, ...toImport];
+          savePromptsLocally(merged);
+          setSystemPrompts(merged);
+          if (syncSettings) {
+            for (const p of toImport) {
+              try {
+                await fetch("/api/system-prompts", {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify(p),
+                });
+              } catch (err) {
+                console.error("Failed to sync imported prompt:", err);
+              }
+            }
+          }
         }
       }
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -597,12 +597,13 @@ export default function App() {
   };
 
   const handleUpdateSystemPrompt = async (id: string, name: string, content: string) => {
+    const now = Date.now();
     if (syncSettings) {
       try {
         const res = await fetch(`/api/system-prompts/${id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name, content }),
+          body: JSON.stringify({ name, content, updated_at: now }),
         });
         if (!res.ok) throw new Error("Failed to update prompt");
       } catch (err) {
@@ -612,7 +613,7 @@ export default function App() {
     }
     setSystemPrompts((prev) => {
       const updated = prev.map((p) =>
-        p.id === id ? { ...p, name, content, updated_at: Date.now() } : p,
+        p.id === id ? { ...p, name, content, updated_at: now } : p,
       );
       savePromptsLocally(updated);
       return updated;

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -28,7 +28,7 @@ export interface SystemPrompt {
   name: string;
   content: string;
   created_at: number;
-  updated_at: number;
+  updated_at?: number | null;
 }
 
 export type ThemeMode = "system" | "light" | "dark";
@@ -826,17 +826,20 @@ export default function App() {
           savePromptsLocally(merged);
           setSystemPrompts(merged);
           if (syncSettings) {
-            for (const p of toImport) {
-              try {
-                await fetch("/api/system-prompts", {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify(p),
-                });
-              } catch (err) {
-                console.error("Failed to sync imported prompt:", err);
-              }
-            }
+            await Promise.all(
+              toImport.map(async (p) => {
+                try {
+                  const res = await fetch("/api/system-prompts", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify(p),
+                  });
+                  if (!res.ok) throw new Error(`Failed to sync imported prompt: ${p.name}`);
+                } catch (err) {
+                  console.error("Failed to sync imported prompt:", err);
+                }
+              }),
+            );
           }
         }
       }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -159,36 +159,16 @@ export default function App() {
     activeConversationIdRef.current = activeConversation?.id || null;
   }, [activeConversation?.id]);
 
-  const isCreatingConversationRef = useRef(false);
-  const prevActiveIdRef = useRef<string | null | undefined>(undefined);
-
-  // When switching to a different existing conversation, restore its system prompt.
-  // When creating a new conversation (null → id), preserve the chosen prompt.
-  // When clearing to a new-chat screen (id → null), reset the prompt.
+  // Sync selected prompt with the active conversation's stored system_prompt_id.
+  // Covers all cases: initial URL load, conversation switch, new-chat clear, and
+  // new conversation creation (which comes back from storage with system_prompt_id set).
   useEffect(() => {
-    const prevId = prevActiveIdRef.current;
-    const nextId = activeConversation?.id ?? null;
-    prevActiveIdRef.current = nextId;
-
-    if (prevId === undefined) {
-      // Initial mount: if we loaded straight into a conversation, restore its prompt
-      if (nextId !== null) {
-        const convo = conversations.find((c) => c.id === nextId);
-        if (convo?.system_prompt_id) setSelectedPromptId(convo.system_prompt_id);
-      }
-      return;
+    if (activeConversation) {
+      setSelectedPromptId(activeConversation.system_prompt_id ?? null);
+    } else {
+      setSelectedPromptId(null);
     }
-
-    if (isCreatingConversationRef.current) {
-      isCreatingConversationRef.current = false;
-      return; // null → new id: keep the chosen prompt for this session
-    }
-
-    if (nextId === null) {
-      setSelectedPromptId(null); // cleared to new-chat screen
-    }
-    // switching to an existing convo: handleSelectConversation already sets the prompt
-  }, [activeConversation?.id]);
+  }, [activeConversation?.id, activeConversation?.system_prompt_id]);
 
   const handleTempExpiryChange = useCallback((val: string) => {
     setTempExpiry(val);
@@ -436,11 +416,6 @@ export default function App() {
     setDrafts((prev) => ({ ...prev, [currentKey]: inputValue }));
     selectConversation(id);
     setInputValue(nextDraft);
-
-    // Restore the system prompt that was selected when this conversation was created
-    const convo = conversations.find((c) => c.id === id);
-    setSelectedPromptId(convo?.system_prompt_id ?? null);
-
     closeSidebarOnMobile();
   };
 
@@ -476,7 +451,6 @@ export default function App() {
     if (isStreaming) return;
     const currentModel = activeConversation?.model ?? defaultModel;
     if (!activeConversation) {
-      isCreatingConversationRef.current = true;
       const convo = await newConversation(defaultModel, storageMode, selectedPromptId);
       await sendMessage(content, defaultModel, convo.id, storageMode, effectiveSystemPrompt);
     } else {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -255,20 +255,24 @@ export default function App() {
         const localPrompts: SystemPrompt[] = stored ? JSON.parse(stored) : [];
         const localOnly = localPrompts.filter((p) => !cloudIds.has(p.id));
         await Promise.all(
-          localOnly.map((p) =>
-            fetch("/api/system-prompts", {
+          localOnly.map(async (p) => {
+            const postRes = await fetch("/api/system-prompts", {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ id: p.id, name: p.name, content: p.content, created_at: p.created_at }),
-            }),
-          ),
+            });
+            if (!postRes.ok) throw new Error(`Failed to sync prompt: ${p.name}`);
+          }),
         );
         if (!active) return;
 
         // Re-fetch the merged list from cloud
         const merged =
           localOnly.length > 0
-            ? await fetch("/api/system-prompts").then((r) => r.json() as Promise<SystemPrompt[]>)
+            ? await fetch("/api/system-prompts").then((r) => {
+                if (!r.ok) throw new Error("Failed to fetch merged prompts");
+                return r.json() as Promise<SystemPrompt[]>;
+              })
             : cloudPrompts;
         if (!active) return;
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -251,8 +251,14 @@ export default function App() {
         const cloudIds = new Set(cloudPrompts.map((p) => p.id));
 
         // Read local prompts directly from storage to avoid stale closure
-        const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
-        const localPrompts: SystemPrompt[] = stored ? JSON.parse(stored) : [];
+        let localPrompts: SystemPrompt[] = [];
+        try {
+          const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
+          const parsed = stored ? JSON.parse(stored) : [];
+          localPrompts = Array.isArray(parsed) ? parsed : [];
+        } catch {
+          localPrompts = [];
+        }
         const localOnly = localPrompts.filter((p) => !cloudIds.has(p.id));
         await Promise.all(
           localOnly.map(async (p) => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -28,9 +28,42 @@ export interface SystemPrompt {
   name: string;
   content: string;
   created_at: number;
+  updated_at: number;
 }
 
 export type ThemeMode = "system" | "light" | "dark";
+
+/**
+ * Read system prompts from localStorage, running a one-time migration of the
+ * legacy waichat:system-prompt key if present. Defined outside the component
+ * so it runs once at module load time without any React lifecycle involvement.
+ */
+function readSystemPromptsFromStorage(): SystemPrompt[] {
+  try {
+    const legacyPrompt = localStorage.getItem("waichat:system-prompt");
+    const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
+    const parsed = stored ? JSON.parse(stored) : [];
+    let prompts: SystemPrompt[] = Array.isArray(parsed) ? parsed : [];
+
+    if (legacyPrompt?.trim()) {
+      const now = Date.now();
+      const migrated: SystemPrompt = {
+        id: crypto.randomUUID(),
+        user_id: "default",
+        name: "Default Prompt",
+        content: legacyPrompt.trim(),
+        created_at: now,
+        updated_at: now,
+      };
+      prompts = [...prompts, migrated];
+      localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(prompts));
+      localStorage.removeItem("waichat:system-prompt");
+    }
+    return prompts;
+  } catch {
+    return [];
+  }
+}
 
 export default function App() {
   const toast = useToast();
@@ -108,30 +141,9 @@ export default function App() {
   const [defaultModel, setDefaultModel] = useState(
     () => localStorage.getItem(DEFAULT_MODEL_KEY) ?? DEFAULT_MODEL_ID,
   );
-  const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>(() => {
-    try {
-      const legacyPrompt = localStorage.getItem("waichat:system-prompt");
-      const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
-      const parsed = stored ? JSON.parse(stored) : [];
-      let localPrompts: SystemPrompt[] = Array.isArray(parsed) ? parsed : [];
-
-      if (legacyPrompt?.trim()) {
-        const migrated: SystemPrompt = {
-          id: crypto.randomUUID(),
-          user_id: "default",
-          name: "Default Prompt",
-          content: legacyPrompt.trim(),
-          created_at: Date.now(),
-        };
-        localPrompts = [...localPrompts, migrated];
-        localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(localPrompts));
-        localStorage.removeItem("waichat:system-prompt");
-      }
-      return localPrompts;
-    } catch {
-      return [];
-    }
-  });
+  const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>(
+    () => readSystemPromptsFromStorage(),
+  );
   const [selectedPromptId, setSelectedPromptId] = useState<string | null>(null);
   const [syncSettings, setSyncSettings] = useState(
     () =>
@@ -275,11 +287,12 @@ export default function App() {
           localPrompts = [];
         }
 
-        // Upload prompts that are missing from cloud OR have been edited locally
+        // Upload prompts that are missing from cloud OR are strictly newer locally
+        // (using updated_at to avoid overwriting changes made on other devices)
         const localOnlyOrModified = localPrompts.filter((p) => {
           const cloud = cloudPromptsMap.get(p.id);
           if (!cloud) return true;
-          return cloud.name !== p.name || cloud.content !== p.content;
+          return (p.updated_at ?? p.created_at) > (cloud.updated_at ?? cloud.created_at);
         });
         await Promise.all(
           localOnlyOrModified.map(async (p) => {
@@ -556,12 +569,14 @@ export default function App() {
         throw err;
       }
     } else {
+      const now = Date.now();
       const prompt: SystemPrompt = {
         id: crypto.randomUUID(),
         user_id: "default",
         name,
         content,
-        created_at: Date.now(),
+        created_at: now,
+        updated_at: now,
       };
       setSystemPrompts((prev) => {
         const updated = [...prev, prompt];
@@ -586,7 +601,9 @@ export default function App() {
       }
     }
     setSystemPrompts((prev) => {
-      const updated = prev.map((p) => (p.id === id ? { ...p, name, content } : p));
+      const updated = prev.map((p) =>
+        p.id === id ? { ...p, name, content, updated_at: Date.now() } : p,
+      );
       savePromptsLocally(updated);
       return updated;
     });

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -16,11 +16,19 @@ import { exportWorkspace } from "./utils/exportUtils";
 import { parseImportFile } from "./utils/importUtils";
 
 const STORAGE_MODE_KEY = "waichat:storage-mode";
-const SYSTEM_PROMPT_KEY = "waichat:system-prompt";
 const SYNC_SETTINGS_KEY = "waichat:sync-settings";
 const DEFAULT_MODEL_KEY = "waichat:default-model";
+const SYSTEM_PROMPTS_KEY = "waichat:system-prompts";
 export const THEME_KEY = "waichat:theme";
 const MOBILE_BREAKPOINT = 768;
+
+export interface SystemPrompt {
+  id: string;
+  user_id: string;
+  name: string;
+  content: string;
+  created_at: number;
+}
 
 export type ThemeMode = "system" | "light" | "dark";
 
@@ -100,9 +108,14 @@ export default function App() {
   const [defaultModel, setDefaultModel] = useState(
     () => localStorage.getItem(DEFAULT_MODEL_KEY) ?? DEFAULT_MODEL_ID,
   );
-  const [systemPrompt, setSystemPrompt] = useState(
-    () => localStorage.getItem(SYSTEM_PROMPT_KEY) ?? "",
-  );
+  const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(SYSTEM_PROMPTS_KEY) ?? "[]");
+    } catch {
+      return [];
+    }
+  });
+  const [selectedPromptId, setSelectedPromptId] = useState<string | null>(null);
   const [syncSettings, setSyncSettings] = useState(
     () =>
       (localStorage.getItem(SYNC_SETTINGS_KEY) ??
@@ -210,21 +223,19 @@ export default function App() {
     retryPendingCloudDeletes();
   }, [loadConversations, retryPendingCloudDeletes]);
 
-  // Sync System Prompt from Cloud if enabled
+  // Load system prompts from cloud if sync enabled, otherwise use localStorage
   useEffect(() => {
     if (syncSettings) {
-      fetch("/api/settings/system_prompt")
+      fetch("/api/system-prompts")
         .then((res) => {
-          if (!res.ok) throw new Error("Failed to fetch system prompt");
-          return res.json() as Promise<{ value?: string }>;
+          if (!res.ok) throw new Error("Failed to fetch system prompts");
+          return res.json() as Promise<SystemPrompt[]>;
         })
         .then((data) => {
-          if (data.value != null && data.value !== systemPrompt) {
-            setSystemPrompt(data.value);
-            localStorage.setItem(SYSTEM_PROMPT_KEY, data.value);
-          }
+          setSystemPrompts(data);
+          localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(data));
         })
-        .catch((err) => console.error("Cloud sync error (system_prompt):", err));
+        .catch((err) => console.error("Cloud sync error (system_prompts):", err));
     }
   }, [syncSettings]);
 
@@ -387,14 +398,23 @@ export default function App() {
     closeSidebarOnMobile();
   };
 
+  const effectiveSystemPrompt =
+    systemPrompts.find((p) => p.id === selectedPromptId)?.content ?? "";
+
   const handleSend = async (content: string) => {
     if (isStreaming) return;
     const currentModel = activeConversation?.model ?? defaultModel;
     if (!activeConversation) {
       const convo = await newConversation(defaultModel, storageMode);
-      await sendMessage(content, defaultModel, convo.id, storageMode, systemPrompt);
+      await sendMessage(content, defaultModel, convo.id, storageMode, effectiveSystemPrompt);
     } else {
-      await sendMessage(content, currentModel, activeConversation.id, storageMode, systemPrompt);
+      await sendMessage(
+        content,
+        currentModel,
+        activeConversation.id,
+        storageMode,
+        effectiveSystemPrompt,
+      );
     }
     setInputValue("");
     const key = activeConversation?.id || "new";
@@ -430,24 +450,72 @@ export default function App() {
     }
   };
 
-  const handleSystemPromptChange = async (prompt: string, sync: boolean) => {
-    setSystemPrompt(prompt);
-    localStorage.setItem(SYSTEM_PROMPT_KEY, prompt);
+  const savePromptsLocally = (prompts: SystemPrompt[]) => {
+    localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(prompts));
+  };
 
-    setSyncSettings(sync);
-    localStorage.setItem(SYNC_SETTINGS_KEY, String(sync));
-
-    if (sync) {
+  const handleAddSystemPrompt = async (name: string, content: string) => {
+    if (syncSettings) {
       try {
-        await fetch("/api/settings/system_prompt", {
+        const res = await fetch("/api/system-prompts", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ value: prompt }),
+          body: JSON.stringify({ name, content }),
         });
+        if (!res.ok) throw new Error("Failed to save prompt");
+        const prompt = (await res.json()) as SystemPrompt;
+        const updated = [...systemPrompts, prompt];
+        setSystemPrompts(updated);
+        savePromptsLocally(updated);
       } catch (err) {
-        console.error("Failed to sync system prompt to cloud:", err);
+        console.error("Failed to add system prompt:", err);
+        throw err;
+      }
+    } else {
+      const prompt: SystemPrompt = {
+        id: crypto.randomUUID(),
+        user_id: "default",
+        name,
+        content,
+        created_at: Date.now(),
+      };
+      const updated = [...systemPrompts, prompt];
+      setSystemPrompts(updated);
+      savePromptsLocally(updated);
+    }
+  };
+
+  const handleUpdateSystemPrompt = async (id: string, name: string, content: string) => {
+    if (syncSettings) {
+      try {
+        const res = await fetch(`/api/system-prompts/${id}`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, content }),
+        });
+        if (!res.ok) throw new Error("Failed to update prompt");
+      } catch (err) {
+        console.error("Failed to update system prompt:", err);
+        throw err;
       }
     }
+    const updated = systemPrompts.map((p) => (p.id === id ? { ...p, name, content } : p));
+    setSystemPrompts(updated);
+    savePromptsLocally(updated);
+  };
+
+  const handleDeleteSystemPrompt = async (id: string) => {
+    if (syncSettings) {
+      try {
+        await fetch(`/api/system-prompts/${id}`, { method: "DELETE" });
+      } catch (err) {
+        console.error("Failed to delete system prompt:", err);
+      }
+    }
+    const updated = systemPrompts.filter((p) => p.id !== id);
+    setSystemPrompts(updated);
+    savePromptsLocally(updated);
+    if (selectedPromptId === id) setSelectedPromptId(null);
   };
 
   const handleClearConversations = async (mode: StorageMode) => {
@@ -498,7 +566,6 @@ export default function App() {
         settings: Record<string, string>;
       } = {
         settings: {
-          system_prompt: localStorage.getItem(SYSTEM_PROMPT_KEY) || "",
           default_model: localStorage.getItem(DEFAULT_MODEL_KEY) || "",
         },
       };
@@ -617,9 +684,6 @@ export default function App() {
 
       // Apply imported settings if they exist
       if (data.settings) {
-        if (data.settings.system_prompt) {
-          await handleSystemPromptChange(data.settings.system_prompt, syncSettings);
-        }
         if (data.settings.default_model) {
           await handleDefaultModelChange(data.settings.default_model, syncSettings);
         }
@@ -831,6 +895,26 @@ export default function App() {
             </div>
           </header>
 
+          {!activeConversation && systemPrompts.length > 0 && (
+            <div className="flex items-center justify-center gap-2 px-5 pt-4 shrink-0">
+              <label className="text-[11px] md:text-xs font-medium text-gray-500 dark:text-white/40 shrink-0">
+                System Prompt
+              </label>
+              <select
+                value={selectedPromptId ?? ""}
+                onChange={(e) => setSelectedPromptId(e.target.value || null)}
+                className="text-[11px] md:text-xs bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-full px-3 py-1.5 text-gray-700 dark:text-white/80 outline-none focus:border-[#0A84FF] transition-colors cursor-pointer"
+              >
+                <option value="">None</option>
+                {systemPrompts.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
           <MessageList
             messages={messages}
             activeBranch={activeBranch}
@@ -842,7 +926,7 @@ export default function App() {
                 messageId,
                 activeConversation?.model ?? defaultModel,
                 storageMode,
-                systemPrompt,
+                effectiveSystemPrompt,
               )
             }
             onEdit={(messageId, content) =>
@@ -853,7 +937,7 @@ export default function App() {
                 content,
                 messageId,
                 storageMode,
-                systemPrompt,
+                effectiveSystemPrompt,
               )
             }
             onDelete={(messageId) => deleteMessage(messageId)}
@@ -881,9 +965,11 @@ export default function App() {
           onStorageModeChange={handleStorageToggle}
           defaultModel={defaultModel}
           onDefaultModelChange={handleDefaultModelChange}
-          systemPrompt={systemPrompt}
+          systemPrompts={systemPrompts}
           syncSettings={syncSettings}
-          onSystemPromptChange={handleSystemPromptChange}
+          onAddSystemPrompt={handleAddSystemPrompt}
+          onUpdateSystemPrompt={handleUpdateSystemPrompt}
+          onDeleteSystemPrompt={handleDeleteSystemPrompt}
           models={models}
           onClearConversations={handleClearConversations}
           onExportWorkspace={handleExportWorkspace}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -44,33 +44,12 @@ function generateUUID(): string {
   });
 }
 
-/**
- * Read system prompts from localStorage, running a one-time migration of the
- * legacy waichat:system-prompt key if present. Defined outside the component
- * so it runs once at module load time without any React lifecycle involvement.
- */
+/** Pure read of stored system prompts — no side effects. */
 function readSystemPromptsFromStorage(): SystemPrompt[] {
   try {
-    const legacyPrompt = localStorage.getItem("waichat:system-prompt");
     const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
     const parsed = stored ? JSON.parse(stored) : [];
-    let prompts: SystemPrompt[] = Array.isArray(parsed) ? parsed : [];
-
-    if (legacyPrompt?.trim()) {
-      const now = Date.now();
-      const migrated: SystemPrompt = {
-        id: generateUUID(),
-        user_id: "default",
-        name: "Default Prompt",
-        content: legacyPrompt.trim(),
-        created_at: now,
-        updated_at: now,
-      };
-      prompts = [...prompts, migrated];
-      localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(prompts));
-      localStorage.removeItem("waichat:system-prompt");
-    }
-    return prompts;
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
     return [];
   }
@@ -258,6 +237,32 @@ export default function App() {
     const interval = setInterval(runCleanup, 60000);
     return () => clearInterval(interval);
   }, [loadConversations, tempExpiry, clearConversation]);
+
+  // One-time migration: import legacy waichat:system-prompt into the library
+  useEffect(() => {
+    try {
+      const legacyPrompt = localStorage.getItem("waichat:system-prompt");
+      if (legacyPrompt?.trim()) {
+        const now = Date.now();
+        const migrated: SystemPrompt = {
+          id: generateUUID(),
+          user_id: "default",
+          name: "Default Prompt",
+          content: legacyPrompt.trim(),
+          created_at: now,
+          updated_at: now,
+        };
+        setSystemPrompts((prev) => {
+          const updated = [...prev, migrated];
+          localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(updated));
+          return updated;
+        });
+        localStorage.removeItem("waichat:system-prompt");
+      }
+    } catch (err) {
+      console.error("Failed to migrate legacy system prompt:", err);
+    }
+  }, []);
 
   const isStreamingHere =
     isStreaming &&
@@ -560,44 +565,55 @@ export default function App() {
   };
 
   const handleAddSystemPrompt = async (name: string, content: string) => {
+    const now = Date.now();
+    const prompt: SystemPrompt = {
+      id: generateUUID(),
+      user_id: "default",
+      name,
+      content,
+      created_at: now,
+      updated_at: now,
+    };
+
+    // Update local state immediately so the UI is always responsive
+    setSystemPrompts((prev) => {
+      const updated = [...prev, prompt];
+      savePromptsLocally(updated);
+      return updated;
+    });
+
     if (syncSettings) {
       try {
         const res = await fetch("/api/system-prompts", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ name, content }),
+          body: JSON.stringify({
+            id: prompt.id,
+            name: prompt.name,
+            content: prompt.content,
+            created_at: prompt.created_at,
+            updated_at: prompt.updated_at,
+          }),
         });
         if (!res.ok) throw new Error("Failed to save prompt");
-        const prompt = (await res.json()) as SystemPrompt;
-        setSystemPrompts((prev) => {
-          const updated = [...prev, prompt];
-          savePromptsLocally(updated);
-          return updated;
-        });
       } catch (err) {
-        console.error("Failed to add system prompt:", err);
-        throw err;
+        console.error("Failed to sync system prompt to cloud:", err);
       }
-    } else {
-      const now = Date.now();
-      const prompt: SystemPrompt = {
-        id: generateUUID(),
-        user_id: "default",
-        name,
-        content,
-        created_at: now,
-        updated_at: now,
-      };
-      setSystemPrompts((prev) => {
-        const updated = [...prev, prompt];
-        savePromptsLocally(updated);
-        return updated;
-      });
     }
   };
 
   const handleUpdateSystemPrompt = async (id: string, name: string, content: string) => {
     const now = Date.now();
+
+    // Update local state immediately
+    setSystemPrompts((prev) => {
+      const updated = prev.map((p) =>
+        p.id === id ? { ...p, name, content, updated_at: now } : p,
+      );
+      savePromptsLocally(updated);
+      return updated;
+    });
+
     if (syncSettings) {
       try {
         const res = await fetch(`/api/system-prompts/${id}`, {
@@ -607,17 +623,9 @@ export default function App() {
         });
         if (!res.ok) throw new Error("Failed to update prompt");
       } catch (err) {
-        console.error("Failed to update system prompt:", err);
-        throw err;
+        console.error("Failed to sync system prompt update to cloud:", err);
       }
     }
-    setSystemPrompts((prev) => {
-      const updated = prev.map((p) =>
-        p.id === id ? { ...p, name, content, updated_at: now } : p,
-      );
-      savePromptsLocally(updated);
-      return updated;
-    });
   };
 
   const handleDeleteSystemPrompt = async (id: string) => {

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -110,9 +110,24 @@ export default function App() {
   );
   const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>(() => {
     try {
+      const legacyPrompt = localStorage.getItem("waichat:system-prompt");
       const stored = localStorage.getItem(SYSTEM_PROMPTS_KEY);
       const parsed = stored ? JSON.parse(stored) : [];
-      return Array.isArray(parsed) ? parsed : [];
+      let localPrompts: SystemPrompt[] = Array.isArray(parsed) ? parsed : [];
+
+      if (legacyPrompt?.trim()) {
+        const migrated: SystemPrompt = {
+          id: crypto.randomUUID(),
+          user_id: "default",
+          name: "Default Prompt",
+          content: legacyPrompt.trim(),
+          created_at: Date.now(),
+        };
+        localPrompts = [...localPrompts, migrated];
+        localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(localPrompts));
+        localStorage.removeItem("waichat:system-prompt");
+      }
+      return localPrompts;
     } catch {
       return [];
     }
@@ -594,17 +609,6 @@ export default function App() {
     });
     if (selectedPromptId === id) setSelectedPromptId(null);
   };
-
-  // One-time migration: import legacy global system prompt into the library
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    const legacyPrompt = localStorage.getItem("waichat:system-prompt");
-    if (legacyPrompt?.trim()) {
-      handleAddSystemPrompt("Default Prompt", legacyPrompt.trim())
-        .then(() => localStorage.removeItem("waichat:system-prompt"))
-        .catch((err) => console.error("Failed to migrate legacy system prompt:", err));
-    }
-  }, []);
 
   const handleClearConversations = async (mode: StorageMode) => {
     const storage = createStorage(mode);

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -159,6 +159,11 @@ export default function App() {
     activeConversationIdRef.current = activeConversation?.id || null;
   }, [activeConversation?.id]);
 
+  // Reset selected prompt when switching or creating conversations to prevent leakage
+  useEffect(() => {
+    setSelectedPromptId(null);
+  }, [activeConversation?.id]);
+
   const handleTempExpiryChange = useCallback((val: string) => {
     setTempExpiry(val);
     localStorage.setItem("waichat:temp-expiry", val);
@@ -225,20 +230,42 @@ export default function App() {
     retryPendingCloudDeletes();
   }, [loadConversations, retryPendingCloudDeletes]);
 
-  // Load system prompts from cloud if sync enabled, otherwise use localStorage
+  // Load system prompts from cloud if sync enabled, merging local-only prompts up first
   useEffect(() => {
-    if (syncSettings) {
-      fetch("/api/system-prompts")
-        .then((res) => {
-          if (!res.ok) throw new Error("Failed to fetch system prompts");
-          return res.json() as Promise<SystemPrompt[]>;
-        })
-        .then((data) => {
-          setSystemPrompts(data);
-          localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(data));
-        })
-        .catch((err) => console.error("Cloud sync error (system_prompts):", err));
-    }
+    if (!syncSettings) return;
+
+    const syncPrompts = async () => {
+      try {
+        const res = await fetch("/api/system-prompts");
+        if (!res.ok) throw new Error("Failed to fetch system prompts");
+        const cloudPrompts = (await res.json()) as SystemPrompt[];
+        const cloudIds = new Set(cloudPrompts.map((p) => p.id));
+
+        // Upload any local prompts that don't exist in the cloud yet
+        const localOnly = systemPrompts.filter((p) => !cloudIds.has(p.id));
+        await Promise.all(
+          localOnly.map((p) =>
+            fetch("/api/system-prompts", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ name: p.name, content: p.content }),
+            }),
+          ),
+        );
+
+        // Re-fetch the merged list from cloud
+        const merged = localOnly.length > 0
+          ? await fetch("/api/system-prompts").then((r) => r.json() as Promise<SystemPrompt[]>)
+          : cloudPrompts;
+
+        setSystemPrompts(merged);
+        localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(merged));
+      } catch (err) {
+        console.error("Cloud sync error (system_prompts):", err);
+      }
+    };
+
+    syncPrompts();
   }, [syncSettings]);
 
   // Sync Default Model from Cloud if enabled

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -242,20 +242,23 @@ export default function App() {
   useEffect(() => {
     try {
       const legacyPrompt = localStorage.getItem("waichat:system-prompt");
-      if (legacyPrompt?.trim()) {
-        const now = Date.now();
-        const migrated: SystemPrompt = {
-          id: generateUUID(),
-          user_id: "default",
-          name: "Default Prompt",
-          content: legacyPrompt.trim(),
-          created_at: now,
-          updated_at: now,
-        };
-        const current = readSystemPromptsFromStorage();
-        const updated = [...current, migrated];
-        localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(updated));
-        setSystemPrompts(updated);
+      if (legacyPrompt !== null) {
+        if (legacyPrompt.trim()) {
+          const now = Date.now();
+          const migrated: SystemPrompt = {
+            id: generateUUID(),
+            user_id: "default",
+            name: "Default Prompt",
+            content: legacyPrompt.trim(),
+            created_at: now,
+            updated_at: now,
+          };
+          const current = readSystemPromptsFromStorage();
+          const updated = [...current, migrated];
+          localStorage.setItem(SYSTEM_PROMPTS_KEY, JSON.stringify(updated));
+          setSystemPrompts(updated);
+        }
+        // Always remove so the migration never runs again, even for empty/whitespace values
         localStorage.removeItem("waichat:system-prompt");
       }
     } catch (err) {
@@ -568,6 +571,7 @@ export default function App() {
   };
 
   const handleAddSystemPrompt = async (name: string, content: string) => {
+    const originalList = [...systemPrompts];
     const now = Date.now();
     const prompt: SystemPrompt = {
       id: generateUUID(),
@@ -578,7 +582,7 @@ export default function App() {
       updated_at: now,
     };
 
-    // Update local state immediately so the UI is always responsive
+    // Optimistic update
     const newList = [...systemPrompts, prompt];
     savePromptsLocally(newList);
     setSystemPrompts(newList);
@@ -599,14 +603,18 @@ export default function App() {
         if (!res.ok) throw new Error("Failed to save prompt");
       } catch (err) {
         console.error("Failed to sync system prompt to cloud:", err);
+        savePromptsLocally(originalList);
+        setSystemPrompts(originalList);
+        throw err;
       }
     }
   };
 
   const handleUpdateSystemPrompt = async (id: string, name: string, content: string) => {
+    const originalList = [...systemPrompts];
     const now = Date.now();
 
-    // Update local state immediately
+    // Optimistic update
     const updatedList = systemPrompts.map((p) =>
       p.id === id ? { ...p, name, content, updated_at: now } : p,
     );
@@ -623,12 +631,18 @@ export default function App() {
         if (!res.ok) throw new Error("Failed to update prompt");
       } catch (err) {
         console.error("Failed to sync system prompt update to cloud:", err);
+        savePromptsLocally(originalList);
+        setSystemPrompts(originalList);
+        throw err;
       }
     }
   };
 
   const handleDeleteSystemPrompt = async (id: string) => {
-    // Update local state immediately so the UI is responsive and works offline
+    const originalList = [...systemPrompts];
+    const originalSelectedPromptId = selectedPromptId;
+
+    // Optimistic update
     const filteredList = systemPrompts.filter((p) => p.id !== id);
     savePromptsLocally(filteredList);
     setSystemPrompts(filteredList);
@@ -640,6 +654,10 @@ export default function App() {
         if (!res.ok) throw new Error("Failed to delete prompt");
       } catch (err) {
         console.error("Failed to delete system prompt:", err);
+        savePromptsLocally(originalList);
+        setSystemPrompts(originalList);
+        if (originalSelectedPromptId === id) setSelectedPromptId(originalSelectedPromptId);
+        throw err;
       }
     }
   };
@@ -817,17 +835,27 @@ export default function App() {
         }
       }
 
-      // Restore system prompt library — bulk update preserving original IDs and timestamps
+      // Restore system prompt library — merge by updated_at so newer imported versions win
       if (data.systemPrompts && Array.isArray(data.systemPrompts) && data.systemPrompts.length > 0) {
-        const existingIds = new Set(systemPrompts.map((p) => p.id));
-        const toImport = (data.systemPrompts as SystemPrompt[]).filter((p) => !existingIds.has(p.id));
-        if (toImport.length > 0) {
-          const merged = [...systemPrompts, ...toImport];
+        const existingMap = new Map(systemPrompts.map((p) => [p.id, p]));
+        const mergedMap = new Map(systemPrompts.map((p) => [p.id, p]));
+        const toSync: SystemPrompt[] = [];
+
+        for (const p of data.systemPrompts as SystemPrompt[]) {
+          const existing = existingMap.get(p.id);
+          if (!existing || (p.updated_at ?? p.created_at) > (existing.updated_at ?? existing.created_at)) {
+            mergedMap.set(p.id, p);
+            toSync.push(p);
+          }
+        }
+
+        if (toSync.length > 0) {
+          const merged = Array.from(mergedMap.values());
           savePromptsLocally(merged);
           setSystemPrompts(merged);
           if (syncSettings) {
             await Promise.all(
-              toImport.map(async (p) => {
+              toSync.map(async (p) => {
                 try {
                   const res = await fetch("/api/system-prompts", {
                     method: "POST",

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -312,12 +312,16 @@ export default function App() {
         });
         await Promise.all(
           localOnlyOrModified.map(async (p) => {
-            const postRes = await fetch("/api/system-prompts", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ id: p.id, name: p.name, content: p.content, created_at: p.created_at, updated_at: p.updated_at }),
-            });
-            if (!postRes.ok) throw new Error(`Failed to sync prompt: ${p.name}`);
+            try {
+              const postRes = await fetch("/api/system-prompts", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ id: p.id, name: p.name, content: p.content, created_at: p.created_at, updated_at: p.updated_at }),
+              });
+              if (!postRes.ok) throw new Error(`Failed to sync prompt: ${p.name}`);
+            } catch (err) {
+              console.error(err);
+            }
           }),
         );
         if (!active) return;
@@ -629,21 +633,22 @@ export default function App() {
   };
 
   const handleDeleteSystemPrompt = async (id: string) => {
-    if (syncSettings) {
-      try {
-        const res = await fetch(`/api/system-prompts/${id}`, { method: "DELETE" });
-        if (!res.ok) throw new Error("Failed to delete prompt");
-      } catch (err) {
-        console.error("Failed to delete system prompt:", err);
-        throw err;
-      }
-    }
+    // Update local state immediately so the UI is responsive and works offline
     setSystemPrompts((prev) => {
       const updated = prev.filter((p) => p.id !== id);
       savePromptsLocally(updated);
       return updated;
     });
     if (selectedPromptId === id) setSelectedPromptId(null);
+
+    if (syncSettings) {
+      try {
+        const res = await fetch(`/api/system-prompts/${id}`, { method: "DELETE" });
+        if (!res.ok) throw new Error("Failed to delete prompt");
+      } catch (err) {
+        console.error("Failed to delete system prompt:", err);
+      }
+    }
   };
 
   const handleClearConversations = async (mode: StorageMode) => {
@@ -692,10 +697,12 @@ export default function App() {
         local?: { conversations: Conversation[]; messages: Message[] };
         cloud?: { conversations: Conversation[]; messages: Message[] };
         settings: Record<string, string>;
+        systemPrompts?: SystemPrompt[];
       } = {
         settings: {
           default_model: localStorage.getItem(DEFAULT_MODEL_KEY) || "",
         },
+        systemPrompts: systemPrompts,
       };
 
       if (scope === "cloud" || scope === "both") {
@@ -814,6 +821,15 @@ export default function App() {
       if (data.settings) {
         if (data.settings.default_model) {
           await handleDefaultModelChange(data.settings.default_model, syncSettings);
+        }
+      }
+
+      // Restore system prompt library if present
+      if (data.systemPrompts && Array.isArray(data.systemPrompts) && data.systemPrompts.length > 0) {
+        const existingIds = new Set(systemPrompts.map((p) => p.id));
+        const toImport = (data.systemPrompts as SystemPrompt[]).filter((p) => !existingIds.has(p.id));
+        for (const p of toImport) {
+          await handleAddSystemPrompt(p.name, p.content);
         }
       }
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -312,6 +312,7 @@ export default function App() {
           if (!cloud) return true;
           return (p.updated_at ?? p.created_at) > (cloud.updated_at ?? cloud.created_at);
         });
+        let hasUploadError = false;
         await Promise.all(
           localOnlyOrModified.map(async (p) => {
             try {
@@ -323,9 +324,15 @@ export default function App() {
               if (!postRes.ok) throw new Error(`Failed to sync prompt: ${p.name}`);
             } catch (err) {
               console.error(err);
+              hasUploadError = true;
             }
           }),
         );
+        // Abort before overwriting localStorage — any failed upload means the
+        // cloud list is incomplete and would permanently delete local-only prompts
+        if (hasUploadError) {
+          throw new Error("Some prompts failed to upload. Aborting sync to prevent local data loss.");
+        }
         if (!active) return;
 
         // Re-fetch the merged list from cloud
@@ -571,7 +578,6 @@ export default function App() {
   };
 
   const handleAddSystemPrompt = async (name: string, content: string) => {
-    const originalList = [...systemPrompts];
     const now = Date.now();
     const prompt: SystemPrompt = {
       id: generateUUID(),
@@ -602,19 +608,14 @@ export default function App() {
         });
         if (!res.ok) throw new Error("Failed to save prompt");
       } catch (err) {
-        console.error("Failed to sync system prompt to cloud:", err);
-        savePromptsLocally(originalList);
-        setSystemPrompts(originalList);
-        throw err;
+        // Local state is kept — background sync will retry on next load/sync enable
+        console.error("Failed to sync system prompt to cloud (will retry on next sync):", err);
       }
     }
   };
 
   const handleUpdateSystemPrompt = async (id: string, name: string, content: string) => {
-    const originalList = [...systemPrompts];
     const now = Date.now();
-
-    // Optimistic update
     const updatedList = systemPrompts.map((p) =>
       p.id === id ? { ...p, name, content, updated_at: now } : p,
     );
@@ -630,10 +631,8 @@ export default function App() {
         });
         if (!res.ok) throw new Error("Failed to update prompt");
       } catch (err) {
-        console.error("Failed to sync system prompt update to cloud:", err);
-        savePromptsLocally(originalList);
-        setSystemPrompts(originalList);
-        throw err;
+        // Local state is kept — background sync will retry on next load/sync enable
+        console.error("Failed to sync system prompt update to cloud (will retry on next sync):", err);
       }
     }
   };

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -76,6 +76,7 @@ export default function SettingsModal({
   const [editName, setEditName] = useState("");
   const [editContent, setEditContent] = useState("");
   const [isSavingPrompt, setIsSavingPrompt] = useState(false);
+  const [isDeletingPromptId, setIsDeletingPromptId] = useState<string | null>(null);
   const [isExporting, setIsExporting] = useState(false);
   const [exportScope, setExportScope] = useState<"local" | "cloud" | "both">("both");
   const [showExportSelector, setShowExportSelector] = useState(false);
@@ -649,19 +650,23 @@ export default function SettingsModal({
                                   Edit
                                 </button>
                                 <button
+                                  disabled={isDeletingPromptId === prompt.id}
                                   onClick={async () => {
                                     if (confirm(`Delete "${prompt.name}"?`)) {
+                                      setIsDeletingPromptId(prompt.id);
                                       try {
                                         await onDeleteSystemPrompt(prompt.id);
                                         toast.success("Prompt deleted!");
                                       } catch {
                                         toast.error("Failed to delete prompt");
+                                      } finally {
+                                        setIsDeletingPromptId(null);
                                       }
                                     }
                                   }}
-                                  className="text-[11px] font-medium text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-full px-2.5 py-1 transition-all focus:outline-none"
+                                  className="text-[11px] font-medium text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 rounded-full px-2.5 py-1 transition-all focus:outline-none"
                                 >
-                                  Delete
+                                  {isDeletingPromptId === prompt.id ? "Deleting..." : "Delete"}
                                 </button>
                               </div>
                             </div>

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -74,6 +74,7 @@ export default function SettingsModal({
   const [newPromptContent, setNewPromptContent] = useState("");
   const [editingPrompt, setEditingPrompt] = useState<SystemPrompt | null>(null);
   const [editName, setEditName] = useState("");
+  const [confirmDeletePromptId, setConfirmDeletePromptId] = useState<string | null>(null);
   const [editContent, setEditContent] = useState("");
   const [isSavingPrompt, setIsSavingPrompt] = useState(false);
   const [isDeletingPromptId, setIsDeletingPromptId] = useState<string | null>(null);
@@ -181,6 +182,7 @@ export default function SettingsModal({
       setNewPromptName("");
       setNewPromptContent("");
       setEditingPrompt(null);
+      setConfirmDeletePromptId(null);
     }
   }, [open, storageMode, defaultModel, syncSettings]);
 
@@ -628,47 +630,70 @@ export default function SettingsModal({
                           ) : (
                             <div
                               key={prompt.id}
-                              className="flex items-start justify-between gap-3 py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10"
+                              className="rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10 overflow-hidden"
                             >
-                              <div className="min-w-0 flex-1">
-                                <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95 truncate">
-                                  {prompt.name}
-                                </p>
-                                <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5 line-clamp-2">
-                                  {prompt.content}
-                                </p>
+                              <div className="flex items-start justify-between gap-3 py-3 px-4">
+                                <div className="min-w-0 flex-1">
+                                  <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95 truncate">
+                                    {prompt.name}
+                                  </p>
+                                  <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5 line-clamp-2">
+                                    {prompt.content}
+                                  </p>
+                                </div>
+                                <div className="flex gap-1.5 shrink-0">
+                                  <button
+                                    onClick={() => {
+                                      setEditingPrompt(prompt);
+                                      setEditName(prompt.name);
+                                      setEditContent(prompt.content);
+                                    }}
+                                    className="text-[11px] font-medium text-gray-500 dark:text-white/40 hover:text-gray-900 dark:hover:text-white/90 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-2.5 py-1 transition-all focus:outline-none"
+                                  >
+                                    Edit
+                                  </button>
+                                  <button
+                                    disabled={isDeletingPromptId === prompt.id}
+                                    onClick={() => setConfirmDeletePromptId(prompt.id)}
+                                    className="text-[11px] font-medium text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 rounded-full px-2.5 py-1 transition-all focus:outline-none"
+                                  >
+                                    {isDeletingPromptId === prompt.id ? "Deleting..." : "Delete"}
+                                  </button>
+                                </div>
                               </div>
-                              <div className="flex gap-1.5 shrink-0">
-                                <button
-                                  onClick={() => {
-                                    setEditingPrompt(prompt);
-                                    setEditName(prompt.name);
-                                    setEditContent(prompt.content);
-                                  }}
-                                  className="text-[11px] font-medium text-gray-500 dark:text-white/40 hover:text-gray-900 dark:hover:text-white/90 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-2.5 py-1 transition-all focus:outline-none"
-                                >
-                                  Edit
-                                </button>
-                                <button
-                                  disabled={isDeletingPromptId === prompt.id}
-                                  onClick={async () => {
-                                    if (confirm(`Delete "${prompt.name}"?`)) {
-                                      setIsDeletingPromptId(prompt.id);
-                                      try {
-                                        await onDeleteSystemPrompt(prompt.id);
-                                        toast.success("Prompt deleted!");
-                                      } catch {
-                                        toast.error("Failed to delete prompt");
-                                      } finally {
-                                        setIsDeletingPromptId(null);
-                                      }
-                                    }
-                                  }}
-                                  className="text-[11px] font-medium text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 rounded-full px-2.5 py-1 transition-all focus:outline-none"
-                                >
-                                  {isDeletingPromptId === prompt.id ? "Deleting..." : "Delete"}
-                                </button>
-                              </div>
+                              {confirmDeletePromptId === prompt.id && (
+                                <div className="px-4 pb-3 pt-1 border-t-[0.5px] border-red-200 dark:border-red-500/20 bg-red-50/60 dark:bg-red-500/10">
+                                  <p className="text-[11px] md:text-xs text-red-600 dark:text-red-400 font-medium mb-2">
+                                    Delete &ldquo;{prompt.name}&rdquo;? This cannot be undone.
+                                  </p>
+                                  <div className="flex gap-2">
+                                    <button
+                                      disabled={isDeletingPromptId === prompt.id}
+                                      onClick={async () => {
+                                        setIsDeletingPromptId(prompt.id);
+                                        try {
+                                          await onDeleteSystemPrompt(prompt.id);
+                                          setConfirmDeletePromptId(null);
+                                          toast.success("Prompt deleted!");
+                                        } catch {
+                                          toast.error("Failed to delete prompt");
+                                        } finally {
+                                          setIsDeletingPromptId(null);
+                                        }
+                                      }}
+                                      className="text-[11px] font-medium text-white bg-red-500 hover:bg-red-600 disabled:opacity-50 rounded-full px-3 py-1 transition-colors focus:outline-none"
+                                    >
+                                      {isDeletingPromptId === prompt.id ? "Deleting..." : "Yes, delete"}
+                                    </button>
+                                    <button
+                                      onClick={() => setConfirmDeletePromptId(null)}
+                                      className="text-[11px] font-medium text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white/90 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-3 py-1 transition-colors focus:outline-none"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </div>
+                                </div>
+                              )}
                             </div>
                           ),
                         )}

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { SystemPrompt } from "../App";
 import type { Model } from "../hooks/useModels";
 import { useToast } from "../hooks/useToast";
 import type { StorageMode } from "../storage";
@@ -13,9 +14,11 @@ interface SettingsModalProps {
   onStorageModeChange: (mode: StorageMode) => void;
   defaultModel: string;
   onDefaultModelChange: (model: string, sync: boolean) => void;
-  systemPrompt: string;
+  systemPrompts: SystemPrompt[];
   syncSettings: boolean;
-  onSystemPromptChange: (prompt: string, sync: boolean) => void;
+  onAddSystemPrompt: (name: string, content: string) => Promise<void>;
+  onUpdateSystemPrompt: (id: string, name: string, content: string) => Promise<void>;
+  onDeleteSystemPrompt: (id: string) => Promise<void>;
   models: Model[];
   onClearConversations: (mode: StorageMode) => void;
   onExportWorkspace: (scope: "local" | "cloud" | "both") => Promise<void>;
@@ -40,9 +43,11 @@ export default function SettingsModal({
   onStorageModeChange,
   defaultModel,
   onDefaultModelChange,
-  systemPrompt,
+  systemPrompts,
   syncSettings,
-  onSystemPromptChange,
+  onAddSystemPrompt,
+  onUpdateSystemPrompt,
+  onDeleteSystemPrompt,
   models,
   onClearConversations,
   onExportWorkspace,
@@ -60,8 +65,15 @@ export default function SettingsModal({
   // Local draft state — only committed on Save
   const [draftStorageMode, setDraftStorageMode] = useState<StorageMode>(storageMode);
   const [draftModel, setDraftModel] = useState(defaultModel);
-  const [draftSystemPrompt, setDraftSystemPrompt] = useState(systemPrompt);
   const [draftSyncSettings, setDraftSyncSettings] = useState(syncSettings);
+
+  // Prompt library state
+  const [newPromptName, setNewPromptName] = useState("");
+  const [newPromptContent, setNewPromptContent] = useState("");
+  const [editingPrompt, setEditingPrompt] = useState<SystemPrompt | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editContent, setEditContent] = useState("");
+  const [isSavingPrompt, setIsSavingPrompt] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
   const [exportScope, setExportScope] = useState<"local" | "cloud" | "both">("both");
   const [showExportSelector, setShowExportSelector] = useState(false);
@@ -160,12 +172,14 @@ export default function SettingsModal({
     if (open) {
       setDraftStorageMode(storageMode);
       setDraftModel(defaultModel);
-      setDraftSystemPrompt(systemPrompt);
       setDraftSyncSettings(syncSettings);
       fetchSecretsStatus();
       setActiveTab("general");
+      setNewPromptName("");
+      setNewPromptContent("");
+      setEditingPrompt(null);
     }
-  }, [open, storageMode, defaultModel, systemPrompt, syncSettings]);
+  }, [open, storageMode, defaultModel, syncSettings]);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -180,7 +194,6 @@ export default function SettingsModal({
   const handleSave = () => {
     onStorageModeChange(draftStorageMode);
     onDefaultModelChange(draftModel, draftSyncSettings);
-    onSystemPromptChange(draftSystemPrompt, draftSyncSettings);
     onClose();
   };
 
@@ -548,22 +561,145 @@ export default function SettingsModal({
               )}
 
               {activeTab === "prompt" && (
-                <section className="animate-in fade-in slide-in-from-bottom-2 duration-300">
-                  <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
-                    System Prompt
-                  </h3>
-                  <div className="space-y-4">
-                    <textarea
-                      value={draftSystemPrompt}
-                      onChange={(e) => setDraftSystemPrompt(e.target.value)}
-                      placeholder="You are a helpful assistant..."
-                      rows={12}
-                      className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-4 py-3 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
-                    />
-                    <p className="text-xs text-gray-500 dark:text-white/40 leading-relaxed italic">
-                      This instructions are applied to the start of all new conversations to define
-                      the AI's personality and behavior.
-                    </p>
+                <section className="space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-300">
+                  <div>
+                    <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
+                      Saved Prompts
+                    </h3>
+
+                    {systemPrompts.length === 0 ? (
+                      <p className="text-[13px] text-gray-400 dark:text-white/30 italic">
+                        No saved prompts yet. Add one below.
+                      </p>
+                    ) : (
+                      <div className="space-y-2">
+                        {systemPrompts.map((prompt) =>
+                          editingPrompt?.id === prompt.id ? (
+                            <div
+                              key={prompt.id}
+                              className="p-3 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-[#0A84FF]/40 space-y-2"
+                            >
+                              <input
+                                type="text"
+                                value={editName}
+                                onChange={(e) => setEditName(e.target.value)}
+                                className="w-full text-[13px] bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-lg px-3 py-2 text-gray-900 dark:text-white/95 outline-none focus:border-[#0A84FF] transition-colors"
+                                placeholder="Prompt name"
+                              />
+                              <textarea
+                                value={editContent}
+                                onChange={(e) => setEditContent(e.target.value)}
+                                rows={4}
+                                className="w-full text-[13px] bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-lg px-3 py-2 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] transition-colors resize-none"
+                                placeholder="Prompt content..."
+                              />
+                              <div className="flex gap-2">
+                                <button
+                                  disabled={isSavingPrompt || !editName.trim() || !editContent.trim()}
+                                  onClick={async () => {
+                                    setIsSavingPrompt(true);
+                                    try {
+                                      await onUpdateSystemPrompt(prompt.id, editName, editContent);
+                                      setEditingPrompt(null);
+                                    } catch {
+                                      toast.error("Failed to update prompt");
+                                    } finally {
+                                      setIsSavingPrompt(false);
+                                    }
+                                  }}
+                                  className="text-[11px] font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] disabled:opacity-50 rounded-full px-3 py-1.5 transition-all focus:outline-none"
+                                >
+                                  {isSavingPrompt ? "Saving..." : "Save"}
+                                </button>
+                                <button
+                                  onClick={() => setEditingPrompt(null)}
+                                  className="text-[11px] font-medium text-gray-600 dark:text-white/60 hover:text-gray-900 dark:hover:text-white/90 rounded-full px-3 py-1.5 transition-all focus:outline-none"
+                                >
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          ) : (
+                            <div
+                              key={prompt.id}
+                              className="flex items-start justify-between gap-3 py-3 px-4 rounded-xl bg-white/60 dark:bg-white/5 border-[0.5px] border-black/10 dark:border-white/10"
+                            >
+                              <div className="min-w-0 flex-1">
+                                <p className="text-[13px] md:text-sm font-medium text-gray-900 dark:text-white/95 truncate">
+                                  {prompt.name}
+                                </p>
+                                <p className="text-[11px] md:text-xs text-gray-500 dark:text-white/40 mt-0.5 line-clamp-2">
+                                  {prompt.content}
+                                </p>
+                              </div>
+                              <div className="flex gap-1.5 shrink-0">
+                                <button
+                                  onClick={() => {
+                                    setEditingPrompt(prompt);
+                                    setEditName(prompt.name);
+                                    setEditContent(prompt.content);
+                                  }}
+                                  className="text-[11px] font-medium text-gray-500 dark:text-white/40 hover:text-gray-900 dark:hover:text-white/90 hover:bg-black/5 dark:hover:bg-white/10 rounded-full px-2.5 py-1 transition-all focus:outline-none"
+                                >
+                                  Edit
+                                </button>
+                                <button
+                                  onClick={() => {
+                                    if (confirm(`Delete "${prompt.name}"?`)) {
+                                      onDeleteSystemPrompt(prompt.id);
+                                    }
+                                  }}
+                                  className="text-[11px] font-medium text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-full px-2.5 py-1 transition-all focus:outline-none"
+                                >
+                                  Delete
+                                </button>
+                              </div>
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    )}
+                  </div>
+
+                  <div>
+                    <h3 className="text-[11px] md:text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-white/40 mb-4">
+                      Add Prompt
+                    </h3>
+                    <div className="space-y-3">
+                      <input
+                        type="text"
+                        value={newPromptName}
+                        onChange={(e) => setNewPromptName(e.target.value)}
+                        placeholder="Name (e.g. Code Reviewer)"
+                        className="w-full text-[13px] bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors"
+                      />
+                      <textarea
+                        value={newPromptContent}
+                        onChange={(e) => setNewPromptContent(e.target.value)}
+                        placeholder="You are a helpful assistant..."
+                        rows={5}
+                        className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-4 py-3 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
+                      />
+                      <button
+                        disabled={isSavingPrompt || !newPromptName.trim() || !newPromptContent.trim()}
+                        onClick={async () => {
+                          setIsSavingPrompt(true);
+                          try {
+                            await onAddSystemPrompt(newPromptName, newPromptContent);
+                            setNewPromptName("");
+                            setNewPromptContent("");
+                            toast.success("Prompt saved!");
+                          } catch {
+                            toast.error("Failed to save prompt");
+                          } finally {
+                            setIsSavingPrompt(false);
+                          }
+                        }}
+                        className="text-[11px] md:text-xs font-medium text-white bg-[#0A84FF] hover:bg-[#0070E0] disabled:opacity-50 disabled:bg-gray-400 rounded-full px-4 py-2 transition-all focus:outline-none"
+                      >
+                        {isSavingPrompt ? "Saving..." : "Add Prompt"}
+                      </button>
+                    </div>
                   </div>
                 </section>
               )}

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -586,6 +586,7 @@ export default function SettingsModal({
                                 type="text"
                                 value={editName}
                                 onChange={(e) => setEditName(e.target.value)}
+                                maxLength={100}
                                 className="w-full text-[13px] bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-lg px-3 py-2 text-gray-900 dark:text-white/95 outline-none focus:border-[#0A84FF] transition-colors"
                                 placeholder="Prompt name"
                               />
@@ -593,6 +594,7 @@ export default function SettingsModal({
                                 value={editContent}
                                 onChange={(e) => setEditContent(e.target.value)}
                                 rows={4}
+                                maxLength={10000}
                                 className="w-full text-[13px] bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-lg px-3 py-2 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] transition-colors resize-none"
                                 placeholder="Prompt content..."
                               />
@@ -678,6 +680,7 @@ export default function SettingsModal({
                         type="text"
                         value={newPromptName}
                         onChange={(e) => setNewPromptName(e.target.value)}
+                        maxLength={100}
                         placeholder="Name (e.g. Code Reviewer)"
                         className="w-full text-[13px] bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-3 py-2.5 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors"
                       />
@@ -686,6 +689,7 @@ export default function SettingsModal({
                         onChange={(e) => setNewPromptContent(e.target.value)}
                         placeholder="You are a helpful assistant..."
                         rows={5}
+                        maxLength={10000}
                         className="w-full text-base md:text-sm bg-black/5 dark:bg-black/20 border-[0.5px] border-black/10 dark:border-white/10 rounded-xl px-4 py-3 text-gray-900 dark:text-white/95 placeholder:text-gray-400 dark:placeholder:text-white/30 outline-none focus:border-[#0A84FF] focus:bg-white dark:focus:bg-black/30 transition-colors resize-none [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
                       />
                       <button

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -16,6 +16,7 @@ interface SettingsModalProps {
   onDefaultModelChange: (model: string, sync: boolean) => void;
   systemPrompts: SystemPrompt[];
   syncSettings: boolean;
+  onSyncSettingsChange: (sync: boolean) => void;
   onAddSystemPrompt: (name: string, content: string) => Promise<void>;
   onUpdateSystemPrompt: (id: string, name: string, content: string) => Promise<void>;
   onDeleteSystemPrompt: (id: string) => Promise<void>;
@@ -45,6 +46,7 @@ export default function SettingsModal({
   onDefaultModelChange,
   systemPrompts,
   syncSettings,
+  onSyncSettingsChange,
   onAddSystemPrompt,
   onUpdateSystemPrompt,
   onDeleteSystemPrompt,
@@ -194,6 +196,7 @@ export default function SettingsModal({
   const handleSave = () => {
     onStorageModeChange(draftStorageMode);
     onDefaultModelChange(draftModel, draftSyncSettings);
+    onSyncSettingsChange(draftSyncSettings);
     onClose();
   };
 

--- a/src/client/components/SettingsModal.tsx
+++ b/src/client/components/SettingsModal.tsx
@@ -644,9 +644,14 @@ export default function SettingsModal({
                                   Edit
                                 </button>
                                 <button
-                                  onClick={() => {
+                                  onClick={async () => {
                                     if (confirm(`Delete "${prompt.name}"?`)) {
-                                      onDeleteSystemPrompt(prompt.id);
+                                      try {
+                                        await onDeleteSystemPrompt(prompt.id);
+                                        toast.success("Prompt deleted!");
+                                      } catch {
+                                        toast.error("Failed to delete prompt");
+                                      }
                                     }
                                   }}
                                   className="text-[11px] font-medium text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 rounded-full px-2.5 py-1 transition-all focus:outline-none"

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -13,7 +13,7 @@ interface UseChatReturn {
   activeVersions: Record<string, string>;
   loadConversations: () => Promise<void>;
   selectConversation: (id: string) => Promise<void>;
-  newConversation: (model: string, targetMode?: StorageMode) => Promise<Conversation>;
+  newConversation: (model: string, targetMode?: StorageMode, systemPromptId?: string | null) => Promise<Conversation>;
   deleteConversation: (id: string) => Promise<void>;
   updateActiveModel: (model: string) => Promise<void>;
   clearConversation: () => void;
@@ -209,10 +209,10 @@ export function useChat(
   );
 
   const newConversation = useCallback(
-    async (model: string, targetMode?: StorageMode): Promise<Conversation> => {
+    async (model: string, targetMode?: StorageMode, systemPromptId?: string | null): Promise<Conversation> => {
       const mode = targetMode || storageMode;
       const targetStorage = createStorage(mode);
-      const conversation = await targetStorage.createConversation(model);
+      const conversation = await targetStorage.createConversation(model, systemPromptId);
 
       if (mode === storageMode) {
         setConversations((prev) => [conversation, ...prev]);

--- a/src/client/hooks/useChat.ts
+++ b/src/client/hooks/useChat.ts
@@ -13,7 +13,7 @@ interface UseChatReturn {
   activeVersions: Record<string, string>;
   loadConversations: () => Promise<void>;
   selectConversation: (id: string) => Promise<void>;
-  newConversation: (model: string, targetMode?: StorageMode, systemPromptId?: string | null) => Promise<Conversation>;
+  newConversation: (model: string, targetMode?: StorageMode, systemPromptId?: string | null, systemPromptContent?: string | null) => Promise<Conversation>;
   deleteConversation: (id: string) => Promise<void>;
   updateActiveModel: (model: string) => Promise<void>;
   clearConversation: () => void;
@@ -209,10 +209,10 @@ export function useChat(
   );
 
   const newConversation = useCallback(
-    async (model: string, targetMode?: StorageMode, systemPromptId?: string | null): Promise<Conversation> => {
+    async (model: string, targetMode?: StorageMode, systemPromptId?: string | null, systemPromptContent?: string | null): Promise<Conversation> => {
       const mode = targetMode || storageMode;
       const targetStorage = createStorage(mode);
-      const conversation = await targetStorage.createConversation(model, systemPromptId);
+      const conversation = await targetStorage.createConversation(model, systemPromptId, systemPromptContent);
 
       if (mode === storageMode) {
         setConversations((prev) => [conversation, ...prev]);

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -16,11 +16,11 @@ export class CloudStorage implements StorageAdapter {
     return res.json();
   }
 
-  async createConversation(model: string): Promise<Conversation> {
+  async createConversation(model: string, systemPromptId?: string | null): Promise<Conversation> {
     const res = await fetch("/api/conversations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model }),
+      body: JSON.stringify({ model, system_prompt_id: systemPromptId ?? null }),
     });
     if (!res.ok) throw new Error("Failed to create conversation");
     return res.json();

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -16,11 +16,11 @@ export class CloudStorage implements StorageAdapter {
     return res.json();
   }
 
-  async createConversation(model: string, systemPromptId?: string | null): Promise<Conversation> {
+  async createConversation(model: string, systemPromptId?: string | null, systemPromptContent?: string | null): Promise<Conversation> {
     const res = await fetch("/api/conversations", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model, system_prompt_id: systemPromptId ?? null }),
+      body: JSON.stringify({ model, system_prompt_id: systemPromptId ?? null, system_prompt: systemPromptContent ?? null }),
     });
     if (!res.ok) throw new Error("Failed to create conversation");
     return res.json();

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -8,6 +8,7 @@ export interface Conversation {
   is_temporary?: boolean;
   expires_at?: number;
   system_prompt_id?: string | null;
+  system_prompt?: string | null;
 }
 
 export interface Message {
@@ -29,7 +30,7 @@ export interface DeleteMessageResult {
 export interface StorageAdapter {
   getConversations(): Promise<Conversation[]>;
   getConversation(id: string): Promise<{ conversation: Conversation; messages: Message[] } | null>;
-  createConversation(model: string, systemPromptId?: string | null): Promise<Conversation>;
+  createConversation(model: string, systemPromptId?: string | null, systemPromptContent?: string | null): Promise<Conversation>;
   deleteConversation(id: string): Promise<void>;
   updateConversationModel(id: string, model: string): Promise<void>;
   saveMessage(message: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message>;

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -7,6 +7,7 @@ export interface Conversation {
   import_complete?: number | null;
   is_temporary?: boolean;
   expires_at?: number;
+  system_prompt_id?: string | null;
 }
 
 export interface Message {
@@ -28,7 +29,7 @@ export interface DeleteMessageResult {
 export interface StorageAdapter {
   getConversations(): Promise<Conversation[]>;
   getConversation(id: string): Promise<{ conversation: Conversation; messages: Message[] } | null>;
-  createConversation(model: string): Promise<Conversation>;
+  createConversation(model: string, systemPromptId?: string | null): Promise<Conversation>;
   deleteConversation(id: string): Promise<void>;
   updateConversationModel(id: string, model: string): Promise<void>;
   saveMessage(message: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message>;

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -49,6 +49,7 @@ export class LocalStorage implements StorageAdapter {
   async createConversation(
     model: string,
     systemPromptId?: string | null,
+    systemPromptContent?: string | null,
   ): Promise<Conversation> {
     const now = Date.now();
     const expirySetting = localStorage.getItem(TEMP_EXPIRY_KEY) || "1h";
@@ -76,6 +77,7 @@ export class LocalStorage implements StorageAdapter {
       is_temporary: this.isTemporary,
       expires_at,
       system_prompt_id: systemPromptId ?? null,
+      system_prompt: systemPromptContent ?? null,
     };
     const conversations = this.getConversationsRaw();
     conversations.push(conversation);

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -46,7 +46,10 @@ export class LocalStorage implements StorageAdapter {
     return { conversation, messages };
   }
 
-  async createConversation(model: string): Promise<Conversation> {
+  async createConversation(
+    model: string,
+    systemPromptId?: string | null,
+  ): Promise<Conversation> {
     const now = Date.now();
     const expirySetting = localStorage.getItem(TEMP_EXPIRY_KEY) || "1h";
     let expires_at: number | undefined;
@@ -72,6 +75,7 @@ export class LocalStorage implements StorageAdapter {
       updated_at: now,
       is_temporary: this.isTemporary,
       expires_at,
+      system_prompt_id: systemPromptId ?? null,
     };
     const conversations = this.getConversationsRaw();
     conversations.push(conversation);

--- a/src/client/utils/exportUtils.ts
+++ b/src/client/utils/exportUtils.ts
@@ -1,4 +1,5 @@
 import { strToU8, zipSync } from "fflate";
+import type { SystemPrompt } from "../App";
 import type { Conversation, Message } from "../storage";
 
 export function convertToChatGPTFormat(conversations: Conversation[], messages: Message[]) {
@@ -87,6 +88,7 @@ export async function exportWorkspace(
     local?: { conversations: Conversation[]; messages: Message[] };
     cloud?: { conversations: Conversation[]; messages: Message[] };
     settings: Record<string, string>;
+    systemPrompts?: SystemPrompt[];
   },
 ) {
   const manifest = {
@@ -100,7 +102,7 @@ export async function exportWorkspace(
   const zipData: Record<string, Uint8Array> = {
     "manifest.json": strToU8(JSON.stringify(manifest, null, 2)),
     "settings.json": strToU8(JSON.stringify(data.settings, null, 2)),
-    "custom_prompts.json": strToU8(JSON.stringify([], null, 2)),
+    "custom_prompts.json": strToU8(JSON.stringify(data.systemPrompts ?? [], null, 2)),
     "model_configs.json": strToU8(JSON.stringify([], null, 2)),
     "attachments/.placeholder": strToU8(""),
   };

--- a/src/client/utils/importUtils.ts
+++ b/src/client/utils/importUtils.ts
@@ -1,4 +1,5 @@
 import { strFromU8, unzipSync } from "fflate";
+import type { SystemPrompt } from "../App";
 import type { Conversation, Message } from "../storage";
 
 const MAX_COMPRESSED_SIZE = 50 * 1024 * 1024; // 50MB
@@ -10,6 +11,7 @@ export interface ImportResult {
   cloud?: { conversations: Conversation[]; messages: Message[] };
   external?: { conversations: Conversation[]; messages: Message[] };
   settings?: Record<string, string>;
+  systemPrompts?: SystemPrompt[];
 }
 
 export async function parseImportFile(file: File): Promise<ImportResult> {
@@ -122,6 +124,18 @@ export async function parseImportFile(file: File): Promise<ImportResult> {
       result.settings = JSON.parse(strFromU8(unzipped[settingsKey]));
     } catch (e) {
       console.error("Failed to parse settings.json", e);
+    }
+  }
+
+  const promptsKey = keys.find((k) => k.endsWith("custom_prompts.json"));
+  if (isWaiChat && promptsKey) {
+    try {
+      const parsed = JSON.parse(strFromU8(unzipped[promptsKey]));
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        result.systemPrompts = parsed as SystemPrompt[];
+      }
+    } catch (e) {
+      console.error("Failed to parse custom_prompts.json", e);
     }
   }
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -554,11 +554,11 @@ app.post("/api/system-prompts", async (c) => {
     return c.json({ error: "Content must be 10000 characters or less" }, 400);
   }
   const prompt: SystemPrompt = {
-    id: crypto.randomUUID(),
+    id: typeof body.id === "string" && body.id ? body.id : crypto.randomUUID(),
     user_id: "default",
     name,
     content,
-    created_at: Date.now(),
+    created_at: typeof body.created_at === "number" ? body.created_at : Date.now(),
   };
   await c.env.DB.prepare(
     "INSERT INTO system_prompts (id, user_id, name, content, created_at) VALUES (?, ?, ?, ?, ?)",

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -314,7 +314,7 @@ app.get("/api/export", async (c) => {
 });
 
 app.post("/api/conversations", async (c) => {
-  const body = await c.req.json<{ model: string; system_prompt_id?: string }>().catch(() => null);
+  const body = await c.req.json<{ model: string; system_prompt_id?: string; system_prompt?: string }>().catch(() => null);
   if (!body || typeof body.model !== "string" || !body.model.trim()) {
     return c.json({ error: "Model is required and must be a non-empty string" }, 400);
   }
@@ -326,9 +326,10 @@ app.post("/api/conversations", async (c) => {
     created_at: now,
     updated_at: now,
     system_prompt_id: typeof body.system_prompt_id === "string" && body.system_prompt_id.trim() ? body.system_prompt_id.trim() : null,
+    system_prompt: typeof body.system_prompt === "string" && body.system_prompt.trim() ? body.system_prompt.trim() : null,
   };
   await c.env.DB.prepare(
-    "INSERT INTO conversations (id, title, model, created_at, updated_at, system_prompt_id) VALUES (?, ?, ?, ?, ?, ?)",
+    "INSERT INTO conversations (id, title, model, created_at, updated_at, system_prompt_id, system_prompt) VALUES (?, ?, ?, ?, ?, ?, ?)",
   )
     .bind(
       conversation.id,
@@ -337,6 +338,7 @@ app.post("/api/conversations", async (c) => {
       conversation.created_at,
       conversation.updated_at,
       conversation.system_prompt_id,
+      conversation.system_prompt,
     )
     .run();
   return c.json(conversation, 201);

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -586,7 +586,7 @@ app.post("/api/system-prompts", async (c) => {
     updated_at: typeof body.updated_at === "number" ? body.updated_at : now,
   };
   await c.env.DB.prepare(
-    "INSERT INTO system_prompts (id, user_id, name, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, content = excluded.content, updated_at = excluded.updated_at WHERE excluded.updated_at >= system_prompts.updated_at",
+    "INSERT INTO system_prompts (id, user_id, name, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, content = excluded.content, updated_at = excluded.updated_at WHERE system_prompts.updated_at IS NULL OR excluded.updated_at >= system_prompts.updated_at",
   )
     .bind(prompt.id, prompt.user_id, prompt.name, prompt.content, prompt.created_at, prompt.updated_at)
     .run();

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -325,7 +325,7 @@ app.post("/api/conversations", async (c) => {
     model: body.model,
     created_at: now,
     updated_at: now,
-    system_prompt_id: body.system_prompt_id ?? null,
+    system_prompt_id: typeof body.system_prompt_id === "string" && body.system_prompt_id.trim() ? body.system_prompt_id.trim() : null,
   };
   await c.env.DB.prepare(
     "INSERT INTO conversations (id, title, model, created_at, updated_at, system_prompt_id) VALUES (?, ?, ?, ?, ?, ?)",

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -626,8 +626,9 @@ app.patch("/api/system-prompts/:id", async (c) => {
   }
   if (updates.length === 0) return c.json({ error: "Nothing to update" }, 400);
 
+  const updatedAt = typeof body.updated_at === "number" ? body.updated_at : Date.now();
   updates.push("updated_at = ?");
-  params.push(Date.now());
+  params.push(updatedAt);
   params.push(id);
   await c.env.DB.prepare(`UPDATE system_prompts SET ${updates.join(", ")} WHERE id = ?`)
     .bind(...params)

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -541,7 +541,7 @@ app.get("/api/system-prompts", async (c) => {
 });
 
 app.post("/api/system-prompts", async (c) => {
-  const body = await c.req.json().catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) || {};
   const name = typeof body.name === "string" ? body.name.trim() : "";
   const content = typeof body.content === "string" ? body.content.trim() : "";
   if (!name || !content) {
@@ -564,7 +564,7 @@ app.post("/api/system-prompts", async (c) => {
 
 app.patch("/api/system-prompts/:id", async (c) => {
   const id = c.req.param("id");
-  const body = await c.req.json().catch(() => ({}));
+  const body = (await c.req.json().catch(() => ({}))) || {};
 
   const existing = await c.env.DB.prepare("SELECT id FROM system_prompts WHERE id = ?")
     .bind(id)

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -3,7 +3,6 @@ import { cors } from "hono/cors";
 import { AVAILABLE_MODELS, generateTitle, streamAiResponse } from "./ai";
 import { getModelNotice, isModelExcluded } from "./config/model-exclusions";
 import {
-  createConversation,
   deleteConversation,
   deleteSetting,
   getConversation,
@@ -315,16 +314,28 @@ app.get("/api/export", async (c) => {
 });
 
 app.post("/api/conversations", async (c) => {
-  const body = await c.req.json<{ model: string }>();
+  const body = await c.req.json<{ model: string; system_prompt_id?: string }>();
   const now = Date.now();
-  const conversation = {
+  const conversation: import("./types").Conversation = {
     id: crypto.randomUUID(),
     title: "New Conversation",
     model: body.model,
     created_at: now,
     updated_at: now,
+    system_prompt_id: body.system_prompt_id ?? null,
   };
-  await createConversation(c.env.DB, conversation);
+  await c.env.DB.prepare(
+    "INSERT INTO conversations (id, title, model, created_at, updated_at, system_prompt_id) VALUES (?, ?, ?, ?, ?, ?)",
+  )
+    .bind(
+      conversation.id,
+      conversation.title,
+      conversation.model,
+      conversation.created_at,
+      conversation.updated_at,
+      conversation.system_prompt_id,
+    )
+    .run();
   return c.json(conversation, 201);
 });
 
@@ -561,7 +572,7 @@ app.post("/api/system-prompts", async (c) => {
     created_at: typeof body.created_at === "number" ? body.created_at : Date.now(),
   };
   await c.env.DB.prepare(
-    "INSERT INTO system_prompts (id, user_id, name, content, created_at) VALUES (?, ?, ?, ?, ?)",
+    "INSERT INTO system_prompts (id, user_id, name, content, created_at) VALUES (?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, content = excluded.content, created_at = excluded.created_at",
   )
     .bind(prompt.id, prompt.user_id, prompt.name, prompt.content, prompt.created_at)
     .run();

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -318,6 +318,13 @@ app.post("/api/conversations", async (c) => {
   if (!body || typeof body.model !== "string" || !body.model.trim()) {
     return c.json({ error: "Model is required and must be a non-empty string" }, 400);
   }
+  const systemPromptContent =
+    typeof body.system_prompt === "string" && body.system_prompt.trim()
+      ? body.system_prompt.trim()
+      : null;
+  if (systemPromptContent && systemPromptContent.length > 10000) {
+    return c.json({ error: "system_prompt must be 10000 characters or less" }, 400);
+  }
   const now = Date.now();
   const conversation: Conversation = {
     id: crypto.randomUUID(),
@@ -326,7 +333,7 @@ app.post("/api/conversations", async (c) => {
     created_at: now,
     updated_at: now,
     system_prompt_id: typeof body.system_prompt_id === "string" && body.system_prompt_id.trim() ? body.system_prompt_id.trim() : null,
-    system_prompt: typeof body.system_prompt === "string" && body.system_prompt.trim() ? body.system_prompt.trim() : null,
+    system_prompt: systemPromptContent,
   };
   await c.env.DB.prepare(
     "INSERT INTO conversations (id, title, model, created_at, updated_at, system_prompt_id, system_prompt) VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -549,7 +556,7 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
 // System Prompt Library
 app.get("/api/system-prompts", async (c) => {
   const prompts = await c.env.DB.prepare(
-    "SELECT id, user_id, name, content, created_at FROM system_prompts ORDER BY created_at ASC",
+    "SELECT id, user_id, name, content, created_at, updated_at FROM system_prompts ORDER BY created_at ASC",
   )
     .all<SystemPrompt>()
     .then((r) => r.results);
@@ -569,17 +576,19 @@ app.post("/api/system-prompts", async (c) => {
   if (content.length > 10000) {
     return c.json({ error: "Content must be 10000 characters or less" }, 400);
   }
+  const now = Date.now();
   const prompt: SystemPrompt = {
-    id: typeof body.id === "string" && body.id ? body.id : crypto.randomUUID(),
+    id: typeof body.id === "string" && body.id.trim() && body.id.length <= 36 ? body.id.trim() : crypto.randomUUID(),
     user_id: "default",
     name,
     content,
-    created_at: typeof body.created_at === "number" ? body.created_at : Date.now(),
+    created_at: typeof body.created_at === "number" ? body.created_at : now,
+    updated_at: typeof body.updated_at === "number" ? body.updated_at : now,
   };
   await c.env.DB.prepare(
-    "INSERT INTO system_prompts (id, user_id, name, content, created_at) VALUES (?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, content = excluded.content, created_at = excluded.created_at",
+    "INSERT INTO system_prompts (id, user_id, name, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, content = excluded.content, updated_at = excluded.updated_at WHERE excluded.updated_at >= system_prompts.updated_at",
   )
-    .bind(prompt.id, prompt.user_id, prompt.name, prompt.content, prompt.created_at)
+    .bind(prompt.id, prompt.user_id, prompt.name, prompt.content, prompt.created_at, prompt.updated_at)
     .run();
   return c.json(prompt, 201);
 });
@@ -617,6 +626,8 @@ app.patch("/api/system-prompts/:id", async (c) => {
   }
   if (updates.length === 0) return c.json({ error: "Nothing to update" }, 400);
 
+  updates.push("updated_at = ?");
+  params.push(Date.now());
   params.push(id);
   await c.env.DB.prepare(`UPDATE system_prompts SET ${updates.join(", ")} WHERE id = ?`)
     .bind(...params)

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -18,7 +18,7 @@ import {
   updateConversationTimestamp,
   updateConversationTitle,
 } from "./db";
-import type { ChatRequest, Env, Message, Model } from "./types";
+import type { ChatRequest, Env, Message, Model, SystemPrompt } from "./types";
 
 // Isolate-specific in-memory cache for models
 let modelCache: { data: Model[]; timestamp: number } | null = null;
@@ -528,6 +528,70 @@ app.delete("/api/conversations/:conversationId/messages/:messageId", async (c) =
     console.error("[DELETE /message] error:", e);
     return c.json({ error: "Failed to delete message" }, 500);
   }
+});
+
+// System Prompt Library
+app.get("/api/system-prompts", async (c) => {
+  const prompts = await c.env.DB.prepare(
+    "SELECT id, user_id, name, content, created_at FROM system_prompts ORDER BY created_at ASC",
+  )
+    .all<SystemPrompt>()
+    .then((r) => r.results);
+  return c.json(prompts);
+});
+
+app.post("/api/system-prompts", async (c) => {
+  const { name, content } = await c.req.json<{ name: string; content: string }>();
+  if (!name?.trim() || !content?.trim()) {
+    return c.json({ error: "Name and content are required" }, 400);
+  }
+  const prompt: SystemPrompt = {
+    id: crypto.randomUUID(),
+    user_id: "default",
+    name: name.trim(),
+    content: content.trim(),
+    created_at: Date.now(),
+  };
+  await c.env.DB.prepare(
+    "INSERT INTO system_prompts (id, user_id, name, content, created_at) VALUES (?, ?, ?, ?, ?)",
+  )
+    .bind(prompt.id, prompt.user_id, prompt.name, prompt.content, prompt.created_at)
+    .run();
+  return c.json(prompt, 201);
+});
+
+app.patch("/api/system-prompts/:id", async (c) => {
+  const id = c.req.param("id");
+  const { name, content } = await c.req.json<{ name?: string; content?: string }>();
+
+  const existing = await c.env.DB.prepare("SELECT id FROM system_prompts WHERE id = ?")
+    .bind(id)
+    .first<{ id: string }>();
+  if (!existing) return c.json({ error: "Not found" }, 404);
+
+  const updates: string[] = [];
+  const params: (string | number)[] = [];
+  if (name !== undefined) {
+    updates.push("name = ?");
+    params.push(name.trim());
+  }
+  if (content !== undefined) {
+    updates.push("content = ?");
+    params.push(content.trim());
+  }
+  if (updates.length === 0) return c.json({ error: "Nothing to update" }, 400);
+
+  params.push(id);
+  await c.env.DB.prepare(`UPDATE system_prompts SET ${updates.join(", ")} WHERE id = ?`)
+    .bind(...params)
+    .run();
+  return c.json({ success: true });
+});
+
+app.delete("/api/system-prompts/:id", async (c) => {
+  const id = c.req.param("id");
+  await c.env.DB.prepare("DELETE FROM system_prompts WHERE id = ?").bind(id).run();
+  return c.json({ success: true });
 });
 
 // Settings

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -547,6 +547,12 @@ app.post("/api/system-prompts", async (c) => {
   if (!name || !content) {
     return c.json({ error: "Name and content are required and must be non-empty strings" }, 400);
   }
+  if (name.length > 100) {
+    return c.json({ error: "Name must be 100 characters or less" }, 400);
+  }
+  if (content.length > 10000) {
+    return c.json({ error: "Content must be 10000 characters or less" }, 400);
+  }
   const prompt: SystemPrompt = {
     id: crypto.randomUUID(),
     user_id: "default",
@@ -577,12 +583,18 @@ app.patch("/api/system-prompts/:id", async (c) => {
     if (typeof body.name !== "string" || !body.name.trim()) {
       return c.json({ error: "Name must be a non-empty string" }, 400);
     }
+    if (body.name.trim().length > 100) {
+      return c.json({ error: "Name must be 100 characters or less" }, 400);
+    }
     updates.push("name = ?");
     params.push(body.name.trim());
   }
   if (body.content !== undefined) {
     if (typeof body.content !== "string" || !body.content.trim()) {
       return c.json({ error: "Content must be a non-empty string" }, 400);
+    }
+    if (body.content.trim().length > 10000) {
+      return c.json({ error: "Content must be 10000 characters or less" }, 400);
     }
     updates.push("content = ?");
     params.push(body.content.trim());

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -17,7 +17,7 @@ import {
   updateConversationTimestamp,
   updateConversationTitle,
 } from "./db";
-import type { ChatRequest, Env, Message, Model, SystemPrompt } from "./types";
+import type { ChatRequest, Conversation, Env, Message, Model, SystemPrompt } from "./types";
 
 // Isolate-specific in-memory cache for models
 let modelCache: { data: Model[]; timestamp: number } | null = null;
@@ -319,7 +319,7 @@ app.post("/api/conversations", async (c) => {
     return c.json({ error: "Model is required and must be a non-empty string" }, 400);
   }
   const now = Date.now();
-  const conversation: import("./types").Conversation = {
+  const conversation: Conversation = {
     id: crypto.randomUUID(),
     title: "New Conversation",
     model: body.model,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -541,15 +541,17 @@ app.get("/api/system-prompts", async (c) => {
 });
 
 app.post("/api/system-prompts", async (c) => {
-  const { name, content } = await c.req.json<{ name: string; content: string }>();
-  if (!name?.trim() || !content?.trim()) {
-    return c.json({ error: "Name and content are required" }, 400);
+  const body = await c.req.json().catch(() => ({}));
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  const content = typeof body.content === "string" ? body.content.trim() : "";
+  if (!name || !content) {
+    return c.json({ error: "Name and content are required and must be non-empty strings" }, 400);
   }
   const prompt: SystemPrompt = {
     id: crypto.randomUUID(),
     user_id: "default",
-    name: name.trim(),
-    content: content.trim(),
+    name,
+    content,
     created_at: Date.now(),
   };
   await c.env.DB.prepare(
@@ -562,7 +564,7 @@ app.post("/api/system-prompts", async (c) => {
 
 app.patch("/api/system-prompts/:id", async (c) => {
   const id = c.req.param("id");
-  const { name, content } = await c.req.json<{ name?: string; content?: string }>();
+  const body = await c.req.json().catch(() => ({}));
 
   const existing = await c.env.DB.prepare("SELECT id FROM system_prompts WHERE id = ?")
     .bind(id)
@@ -571,13 +573,19 @@ app.patch("/api/system-prompts/:id", async (c) => {
 
   const updates: string[] = [];
   const params: (string | number)[] = [];
-  if (name !== undefined) {
+  if (body.name !== undefined) {
+    if (typeof body.name !== "string" || !body.name.trim()) {
+      return c.json({ error: "Name must be a non-empty string" }, 400);
+    }
     updates.push("name = ?");
-    params.push(name.trim());
+    params.push(body.name.trim());
   }
-  if (content !== undefined) {
+  if (body.content !== undefined) {
+    if (typeof body.content !== "string" || !body.content.trim()) {
+      return c.json({ error: "Content must be a non-empty string" }, 400);
+    }
     updates.push("content = ?");
-    params.push(content.trim());
+    params.push(body.content.trim());
   }
   if (updates.length === 0) return c.json({ error: "Nothing to update" }, 400);
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -314,7 +314,10 @@ app.get("/api/export", async (c) => {
 });
 
 app.post("/api/conversations", async (c) => {
-  const body = await c.req.json<{ model: string; system_prompt_id?: string }>();
+  const body = await c.req.json<{ model: string; system_prompt_id?: string }>().catch(() => null);
+  if (!body || typeof body.model !== "string" || !body.model.trim()) {
+    return c.json({ error: "Model is required and must be a non-empty string" }, 400);
+  }
   const now = Date.now();
   const conversation: import("./types").Conversation = {
     id: crypto.randomUUID(),

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -40,7 +40,7 @@ export interface SystemPrompt {
   name: string;
   content: string;
   created_at: number;
-  updated_at: number;
+  updated_at?: number | null;
 }
 
 export interface ChatRequest {

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -14,6 +14,7 @@ export interface Conversation {
   updated_at: number;
   import_complete?: number | null;
   system_prompt_id?: string | null;
+  system_prompt?: string | null;
 }
 
 export interface Message {

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -32,6 +32,14 @@ export interface Model {
   notice?: string;
 }
 
+export interface SystemPrompt {
+  id: string;
+  user_id: string;
+  name: string;
+  content: string;
+  created_at: number;
+}
+
 export interface ChatRequest {
   conversation_id: string;
   model: string;

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -40,6 +40,7 @@ export interface SystemPrompt {
   name: string;
   content: string;
   created_at: number;
+  updated_at: number;
 }
 
 export interface ChatRequest {

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -13,6 +13,7 @@ export interface Conversation {
   created_at: number;
   updated_at: number;
   import_complete?: number | null;
+  system_prompt_id?: string | null;
 }
 
 export interface Message {


### PR DESCRIPTION
## Summary

Closes #46. Replaces the single global system prompt with a named prompt library.

- **D1 migration** (`0008_add_system_prompts.sql`) — new `system_prompts` table with `id`, `user_id`, `name`, `content`, `created_at`
- **API** — four CRUD endpoints: `GET/POST /api/system-prompts` and `PATCH/DELETE /api/system-prompts/:id`
- **Settings UI** — "System Prompt" tab now shows a list of saved prompts (name + truncated content, inline edit/delete) with an "Add Prompt" form below
- **New chat flow** — a "System Prompt" dropdown appears above the message list when starting a new chat (hidden if no prompts exist); the selected prompt's content is passed as the system message for that conversation only
- **Storage** — prompts are persisted in `waichat:system-prompts` localStorage; synced to/from cloud via the new API when "Sync Settings to Cloud" is enabled
- **No global default** — the old single `waichat:system-prompt` key and its cloud sync are removed; existing conversations are unaffected

## Reviewer notes

- `user_id` defaults to `"default"` — the app is single-tenant so no auth needed, but the column is there for future use
- Prompt selection resets to "None" on each page load / new chat — it's intentionally ephemeral (per the spec: "applies only to that session")
- The `syncSettings` toggle in General now also controls whether prompt library changes are written to the cloud API