### PR TITLE
feat: search conversations in sidebar

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -914,6 +914,7 @@ export default function App() {
           onDelete={deleteConversation}
           onMove={handleMoveConversation}
           onRename={renameConversation}
+          onSearch={(q) => createStorage(storageMode).searchConversations(q)}
           onSettingsOpen={() => setSettingsOpen(true)}
           onModeChange={handleStorageToggle}
           currentMode={storageMode}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -914,7 +914,7 @@ export default function App() {
           onDelete={deleteConversation}
           onMove={handleMoveConversation}
           onRename={renameConversation}
-          onSearch={(q) => createStorage(storageMode).searchConversations(q)}
+          onSearch={(q, signal) => createStorage(storageMode).searchConversations(q, signal)}
           onSettingsOpen={() => setSettingsOpen(true)}
           onModeChange={handleStorageToggle}
           currentMode={storageMode}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -162,68 +162,81 @@ export default function Sidebar({
     }
   }, [editingId]);
 
+  // Immediately clear stale results on every query/mode change so title fallback shows instantly
   useEffect(() => {
-    if (!searchQuery) {
-      setApiSearchResults(null);
-      setLocalSearchResults(null);
-      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-      return;
-    }
+    setApiSearchResults(null);
+    setLocalSearchResults(null);
+  }, [searchQuery, currentMode]);
+
+  // Debounced cloud search — no dependency on `conversations` to avoid redundant requests
+  useEffect(() => {
+    if (currentMode !== "cloud" || !searchQuery) return;
 
     const controller = new AbortController();
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
 
     searchDebounceRef.current = setTimeout(async () => {
-      if (currentMode === "cloud") {
-        try {
-          const res = await fetch(
-            `/api/conversations/search?q=${encodeURIComponent(searchQuery)}`,
-            { signal: controller.signal },
-          );
-          if (res.ok) {
-            const data: ConversationSearchResult[] = await res.json();
-            setApiSearchResults(data);
-          }
-        } catch (err: any) {
-          if (err.name !== "AbortError") console.error(err);
+      try {
+        const res = await fetch(
+          `/api/conversations/search?q=${encodeURIComponent(searchQuery)}`,
+          { signal: controller.signal },
+        );
+        if (res.ok) {
+          const data: ConversationSearchResult[] = await res.json();
+          setApiSearchResults(data);
         }
-      } else {
-        const lowerQ = searchQuery.toLowerCase();
-        const results: ConversationSearchResult[] = [];
-        for (const c of conversations) {
-          const titleMatch = c.title.toLowerCase().includes(lowerQ);
-          let snippet = "";
-          try {
-            const rawMessages = localStorage.getItem(`waichat:messages:${c.id}`);
-            if (rawMessages) {
-              const msgs: { content: string; deleted_at?: number }[] = JSON.parse(rawMessages);
-              for (const m of msgs) {
-                if (m.deleted_at) continue;
-                const lowerContent = m.content.toLowerCase();
-                const idx = lowerContent.indexOf(lowerQ);
-                if (idx !== -1) {
-                  const start = Math.max(0, idx - 40);
-                  const end = Math.min(m.content.length, idx + lowerQ.length + 40);
-                  snippet =
-                    (start > 0 ? "…" : "") +
-                    m.content.slice(start, end) +
-                    (end < m.content.length ? "…" : "");
-                  break;
-                }
-              }
-            }
-          } catch {}
-          if (titleMatch || snippet) {
-            results.push({ id: c.id, title: c.title, snippet, updated_at: c.updated_at });
-          }
-        }
-        setLocalSearchResults(results);
+      } catch (err: any) {
+        if (err.name !== "AbortError") console.error(err);
       }
     }, 300);
 
     return () => {
       if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
       controller.abort();
+    };
+  }, [searchQuery, currentMode]);
+
+  // Debounced local search — depends on conversations so it re-runs when the list updates
+  useEffect(() => {
+    if (currentMode === "cloud" || !searchQuery) return;
+
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+
+    searchDebounceRef.current = setTimeout(() => {
+      const lowerQ = searchQuery.toLowerCase();
+      const results: ConversationSearchResult[] = [];
+      for (const c of conversations) {
+        const titleMatch = c.title.toLowerCase().includes(lowerQ);
+        let snippet = "";
+        try {
+          const rawMessages = localStorage.getItem(`waichat:messages:${c.id}`);
+          if (rawMessages) {
+            const msgs: { content: string; deleted_at?: number }[] = JSON.parse(rawMessages);
+            for (const m of msgs) {
+              if (m.deleted_at) continue;
+              const lowerContent = m.content.toLowerCase();
+              const idx = lowerContent.indexOf(lowerQ);
+              if (idx !== -1) {
+                const start = Math.max(0, idx - 40);
+                const end = Math.min(m.content.length, idx + lowerQ.length + 40);
+                snippet =
+                  (start > 0 ? "…" : "") +
+                  m.content.slice(start, end) +
+                  (end < m.content.length ? "…" : "");
+                break;
+              }
+            }
+          }
+        } catch {}
+        if (titleMatch || snippet) {
+          results.push({ id: c.id, title: c.title, snippet, updated_at: c.updated_at });
+        }
+      }
+      setLocalSearchResults(results);
+    }, 300);
+
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
     };
   }, [searchQuery, currentMode, conversations]);
 

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -67,6 +67,12 @@ export default function Sidebar({
   useEffect(() => {
     onSearchRef.current = onSearch;
   }, [onSearch]);
+
+  useEffect(() => {
+    setSearchQuery("");
+    setSearchResults(null);
+  }, [currentMode]);
+
   const [expiryDropdownOpen, setExpiryDropdownOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
   const [pendingMove, setPendingMove] = useState<Conversation | null>(null);
@@ -431,7 +437,11 @@ export default function Sidebar({
                 {result.snippet && (
                   <span
                     className={`text-[11px] mt-0.5 line-clamp-2 ${
-                      activeId === result.id ? "text-white/70" : "text-gray-400 dark:text-white/35"
+                      activeId === result.id
+                        ? currentMode === "local"
+                          ? "text-gray-900/70"
+                          : "text-white/70"
+                        : "text-gray-400 dark:text-white/35"
                     }`}
                   >
                     {result.snippet}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -6,10 +6,12 @@ import {
   HatGlasses,
   Loader2,
   Pencil,
+  Search,
   Trash2,
+  X,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Conversation, StorageMode } from "../storage";
+import type { Conversation, ConversationSearchResult, StorageMode } from "../storage";
 import ConfirmModal from "./ConfirmModal";
 
 interface SidebarProps {
@@ -53,6 +55,10 @@ export default function Sidebar({
   streamingStorageMode,
   movingConversationId,
 }: SidebarProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [apiSearchResults, setApiSearchResults] = useState<ConversationSearchResult[] | null>(null);
+  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [expiryDropdownOpen, setExpiryDropdownOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
   const [pendingMove, setPendingMove] = useState<Conversation | null>(null);
@@ -155,6 +161,92 @@ export default function Sidebar({
     }
   }, [editingId]);
 
+  useEffect(() => {
+    if (!searchQuery) {
+      setApiSearchResults(null);
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+      return;
+    }
+
+    if (currentMode !== "cloud") return;
+
+    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/conversations/search?q=${encodeURIComponent(searchQuery)}`);
+        if (res.ok) {
+          const data: ConversationSearchResult[] = await res.json();
+          setApiSearchResults(data);
+        }
+      } catch {}
+    }, 300);
+
+    return () => {
+      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+    };
+  }, [searchQuery, currentMode]);
+
+  useEffect(() => {
+    const handleEscapeSearch = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && searchQuery) {
+        setSearchQuery("");
+        setApiSearchResults(null);
+      }
+    };
+    document.addEventListener("keydown", handleEscapeSearch);
+    return () => document.removeEventListener("keydown", handleEscapeSearch);
+  }, [searchQuery]);
+
+  const localSearchResults = (): ConversationSearchResult[] => {
+    const lowerQ = searchQuery.toLowerCase();
+    const results: ConversationSearchResult[] = [];
+    for (const c of conversations) {
+      const titleMatch = c.title.toLowerCase().includes(lowerQ);
+      let snippet = "";
+
+      try {
+        const rawMessages = localStorage.getItem(`waichat:messages:${c.id}`);
+        if (rawMessages) {
+          const msgs: { content: string; deleted_at?: number }[] = JSON.parse(rawMessages);
+          for (const m of msgs) {
+            if (m.deleted_at) continue;
+            const lowerContent = m.content.toLowerCase();
+            const idx = lowerContent.indexOf(lowerQ);
+            if (idx !== -1) {
+              const start = Math.max(0, idx - 40);
+              const end = Math.min(m.content.length, idx + lowerQ.length + 40);
+              snippet =
+                (start > 0 ? "…" : "") +
+                m.content.slice(start, end) +
+                (end < m.content.length ? "…" : "");
+              break;
+            }
+          }
+        }
+      } catch {}
+
+      if (titleMatch || snippet) {
+        results.push({ id: c.id, title: c.title, snippet, updated_at: c.updated_at });
+      }
+    }
+    return results;
+  };
+
+  const getDisplayResults = (): ConversationSearchResult[] | null => {
+    if (!searchQuery) return null;
+    if (currentMode === "cloud") {
+      if (apiSearchResults !== null) return apiSearchResults;
+      // While waiting for API, show title matches from loaded conversations
+      const lowerQ = searchQuery.toLowerCase();
+      return conversations
+        .filter((c) => c.title.toLowerCase().includes(lowerQ))
+        .map((c) => ({ id: c.id, title: c.title, snippet: "", updated_at: c.updated_at }));
+    }
+    return localSearchResults();
+  };
+
+  const displayResults = getDisplayResults();
+
   const handleRenameClick = (c: Conversation) => {
     setEditTitle(c.title);
     setEditingId(c.id);
@@ -255,6 +347,37 @@ export default function Sidebar({
           </div>
         </div>
 
+        {/* Search Bar */}
+        <div className="px-4 pb-3">
+          <div className="relative flex items-center">
+            <Search
+              size={14}
+              className="absolute left-2.5 text-gray-400 dark:text-white/30 pointer-events-none shrink-0"
+            />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search conversations…"
+              className="w-full bg-black/5 dark:bg-white/5 border border-black/8 dark:border-white/10 rounded-lg pl-8 pr-7 py-1.5 text-[13px] text-gray-700 dark:text-white/80 placeholder:text-gray-400 dark:placeholder:text-white/25 outline-none focus:ring-1 focus:ring-black/15 dark:focus:ring-white/15 transition-all"
+            />
+            {searchQuery && (
+              <button
+                onClick={() => {
+                  setSearchQuery("");
+                  setApiSearchResults(null);
+                  searchInputRef.current?.focus();
+                }}
+                className="absolute right-2 text-gray-400 hover:text-gray-700 dark:text-white/30 dark:hover:text-white/70 transition-colors"
+                aria-label="Clear search"
+              >
+                <X size={13} />
+              </button>
+            )}
+          </div>
+        </div>
+
         <nav className="flex-1 overflow-y-auto px-2 pb-2 space-y-1 [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/10 [&::-webkit-scrollbar-thumb]:rounded-full">
           <div className="px-4 py-3 pb-2 text-[10px] md:text-[11px] font-semibold text-gray-400 dark:text-white/30 tracking-[0.05em] flex items-center justify-between">
             {currentMode === "temporary" ? (
@@ -310,237 +433,270 @@ export default function Sidebar({
               conversations.length > 0 && <span className="uppercase text-[11px]">Recent</span>
             )}
           </div>
-          {conversations.length === 0 && (
+          {!displayResults && conversations.length === 0 && (
             <p className="text-sm text-gray-500 dark:text-white/40 text-center mt-10">
               No conversations yet
             </p>
           )}
-          {conversations.map((c) => {
-            const isMoving = movingConversationId === c.id;
-            const isThisStreaming =
-              c.id === streamingConversationId && currentMode === streamingStorageMode;
-            const isMoveDisabled = isMoving || isThisStreaming;
-
-            return (
+          {displayResults !== null && displayResults.length === 0 && (
+            <p className="text-sm text-gray-500 dark:text-white/40 text-center mt-10">
+              No conversations found
+            </p>
+          )}
+          {displayResults !== null &&
+            displayResults.map((result) => (
               <div
-                key={c.id}
-                data-id={c.id}
-                className={`group relative flex items-center rounded-lg pl-3 pr-0 py-1.5 cursor-pointer text-[13px] md:text-sm transition-all duration-150 [--fade-size:1.1rem] hover:[--fade-size:2rem] ${
-                  openMenuId === c.id ? "[--fade-size:2rem]" : ""
-                } ${
-                  activeId === c.id
+                key={result.id}
+                className={`group relative flex flex-col rounded-lg pl-3 pr-3 py-2 cursor-pointer text-[13px] md:text-sm transition-all duration-150 ${
+                  activeId === result.id
                     ? currentMode === "cloud"
                       ? "bg-brand-cloud text-white font-medium"
                       : currentMode === "temporary"
                         ? "bg-slate-500 text-white font-medium"
                         : "bg-brand-local text-gray-900 font-medium"
-                    : `${
-                        openMenuId === c.id
-                          ? "bg-black/8 dark:bg-white/10 text-gray-900 dark:text-white"
-                          : "text-gray-600 dark:text-white/65"
-                      } hover:bg-black/5 hover:text-gray-900 dark:hover:bg-white/5 dark:hover:text-white/95`
+                    : "text-gray-600 dark:text-white/65 hover:bg-black/5 hover:text-gray-900 dark:hover:bg-white/5 dark:hover:text-white/95"
                 }`}
-                onClick={() => {
-                  if (isLongPressRef.current) {
-                    isLongPressRef.current = false;
-                    return;
-                  }
-                  onSelect(c.id);
-                }}
-                onTouchStart={handleTouchStart}
-                onTouchEnd={handleTouchEnd}
-                onTouchMove={handleTouchMove}
-                onContextMenu={(e) => {
-                  if (window.innerWidth < 768) e.preventDefault();
-                }}
+                onClick={() => onSelect(result.id)}
               >
-                {editingId === c.id ? (
-                  <div className="flex-1 min-w-0" onClick={(e) => e.stopPropagation()}>
-                    <input
-                      ref={editInputRef}
-                      type="text"
-                      value={editTitle}
-                      onChange={(e) => setEditTitle(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleSaveRename(c.id);
-                        if (e.key === "Escape") setEditingId(null);
-                      }}
-                      onBlur={() => !isRenaming && setEditingId(null)}
-                      disabled={isRenaming}
-                      className={`w-full bg-white/50 dark:bg-black/20 border border-black/10 dark:border-white/20 rounded px-1.5 py-0.5 outline-none text-[13px] md:text-sm focus:ring-1 ${
-                        currentMode === "cloud"
-                          ? "focus:ring-brand-cloud/50"
-                          : "focus:ring-brand-local/50"
-                      }`}
-                    />
-                  </div>
-                ) : (
-                  <div
-                    className="flex-1 relative flex items-center gap-2 overflow-hidden min-w-0 w-full transition-all duration-200"
-                    title={isThisStreaming ? "Generation in progress..." : undefined}
-                    style={{
-                      maskImage:
-                        "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
-                      WebkitMaskImage:
-                        "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
-                    }}
+                <span className="truncate font-medium">{result.title}</span>
+                {result.snippet && (
+                  <span
+                    className={`text-[11px] mt-0.5 line-clamp-2 ${
+                      activeId === result.id ? "text-white/70" : "text-gray-400 dark:text-white/35"
+                    }`}
                   >
-                    {isThisStreaming && (
-                      <div
-                        className={`shrink-0 w-1.5 h-1.5 rounded-full animate-pulse ${
-                          activeId === c.id
-                            ? currentMode === "cloud"
-                              ? "bg-white"
-                              : "bg-gray-900"
-                            : currentMode === "cloud"
-                              ? "bg-brand-cloud"
-                              : "bg-brand-local"
+                    {result.snippet}
+                  </span>
+                )}
+              </div>
+            ))}
+          {displayResults === null &&
+            conversations.map((c) => {
+              const isMoving = movingConversationId === c.id;
+              const isThisStreaming =
+                c.id === streamingConversationId && currentMode === streamingStorageMode;
+              const isMoveDisabled = isMoving || isThisStreaming;
+
+              return (
+                <div
+                  key={c.id}
+                  data-id={c.id}
+                  className={`group relative flex items-center rounded-lg pl-3 pr-0 py-1.5 cursor-pointer text-[13px] md:text-sm transition-all duration-150 [--fade-size:1.1rem] hover:[--fade-size:2rem] ${
+                    openMenuId === c.id ? "[--fade-size:2rem]" : ""
+                  } ${
+                    activeId === c.id
+                      ? currentMode === "cloud"
+                        ? "bg-brand-cloud text-white font-medium"
+                        : currentMode === "temporary"
+                          ? "bg-slate-500 text-white font-medium"
+                          : "bg-brand-local text-gray-900 font-medium"
+                      : `${
+                          openMenuId === c.id
+                            ? "bg-black/8 dark:bg-white/10 text-gray-900 dark:text-white"
+                            : "text-gray-600 dark:text-white/65"
+                        } hover:bg-black/5 hover:text-gray-900 dark:hover:bg-white/5 dark:hover:text-white/95`
+                  }`}
+                  onClick={() => {
+                    if (isLongPressRef.current) {
+                      isLongPressRef.current = false;
+                      return;
+                    }
+                    onSelect(c.id);
+                  }}
+                  onTouchStart={handleTouchStart}
+                  onTouchEnd={handleTouchEnd}
+                  onTouchMove={handleTouchMove}
+                  onContextMenu={(e) => {
+                    if (window.innerWidth < 768) e.preventDefault();
+                  }}
+                >
+                  {editingId === c.id ? (
+                    <div className="flex-1 min-w-0" onClick={(e) => e.stopPropagation()}>
+                      <input
+                        ref={editInputRef}
+                        type="text"
+                        value={editTitle}
+                        onChange={(e) => setEditTitle(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") handleSaveRename(c.id);
+                          if (e.key === "Escape") setEditingId(null);
+                        }}
+                        onBlur={() => !isRenaming && setEditingId(null)}
+                        disabled={isRenaming}
+                        className={`w-full bg-white/50 dark:bg-black/20 border border-black/10 dark:border-white/20 rounded px-1.5 py-0.5 outline-none text-[13px] md:text-sm focus:ring-1 ${
+                          currentMode === "cloud"
+                            ? "focus:ring-brand-cloud/50"
+                            : "focus:ring-brand-local/50"
                         }`}
                       />
-                    )}
-                    <span className="whitespace-nowrap">{c.title}</span>
-                  </div>
-                )}
-                <div
-                  className={`hidden md:flex items-center shrink-0 transition-all duration-200 overflow-hidden ${
-                    openMenuId === c.id
-                      ? "w-8 ml-2 opacity-100"
-                      : "w-0 opacity-0 group-hover:w-8 group-hover:ml-2 group-hover:opacity-100"
-                  }`}
-                >
-                  <div className="relative">
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setIsMobileMenu(false);
-                        setOpenMenuId(openMenuId === c.id ? null : c.id);
+                    </div>
+                  ) : (
+                    <div
+                      className="flex-1 relative flex items-center gap-2 overflow-hidden min-w-0 w-full transition-all duration-200"
+                      title={isThisStreaming ? "Generation in progress..." : undefined}
+                      style={{
+                        maskImage:
+                          "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
+                        WebkitMaskImage:
+                          "linear-gradient(to right, black calc(100% - var(--fade-size)), transparent 100%)",
                       }}
-                      className={`p-1.5 rounded-md focus:outline-none transition-all ${
-                        openMenuId === c.id
-                          ? activeId === c.id
-                            ? "bg-white/20 text-white"
-                            : "bg-black/5 text-gray-900 dark:bg-white/10 dark:text-white"
-                          : activeId === c.id
-                            ? currentMode === "cloud"
-                              ? "text-white/70 hover:text-white opacity-100"
-                              : "text-gray-900/60 hover:text-gray-900 opacity-100"
-                            : "text-gray-400 hover:text-gray-900 dark:text-white/40 dark:hover:text-white/95 opacity-0 group-hover:opacity-100"
-                      }`}
-                      aria-label="Conversation actions"
-                      aria-haspopup="menu"
-                      aria-expanded={openMenuId === c.id}
                     >
-                      <svg
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        className="w-4 h-4"
-                      >
-                        <circle cx="12" cy="12" r="1" strokeWidth="2" />
-                        <circle cx="12" cy="5" r="1" strokeWidth="2" />
-                        <circle cx="12" cy="19" r="1" strokeWidth="2" />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-
-                {openMenuId === c.id && (
+                      {isThisStreaming && (
+                        <div
+                          className={`shrink-0 w-1.5 h-1.5 rounded-full animate-pulse ${
+                            activeId === c.id
+                              ? currentMode === "cloud"
+                                ? "bg-white"
+                                : "bg-gray-900"
+                              : currentMode === "cloud"
+                                ? "bg-brand-cloud"
+                                : "bg-brand-local"
+                          }`}
+                        />
+                      )}
+                      <span className="whitespace-nowrap">{c.title}</span>
+                    </div>
+                  )}
                   <div
-                    ref={menuRef}
-                    role="menu"
-                    className={`${
-                      isMobileMenu ? "fixed" : "absolute right-2 mt-8"
-                    } w-44 rounded-xl bg-white dark:bg-[#1c1c1e] shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-[100] overflow-hidden backdrop-blur-xl`}
-                    style={
-                      isMobileMenu
-                        ? {
-                            top: menuPos.top,
-                            bottom: menuPos.bottom,
-                            left: menuPos.left,
-                          }
-                        : {}
-                    }
+                    className={`hidden md:flex items-center shrink-0 transition-all duration-200 overflow-hidden ${
+                      openMenuId === c.id
+                        ? "w-8 ml-2 opacity-100"
+                        : "w-0 opacity-0 group-hover:w-8 group-hover:ml-2 group-hover:opacity-100"
+                    }`}
                   >
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleRenameClick(c);
-                      }}
-                      disabled={isMoveDisabled}
-                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                      role="menuitem"
-                    >
-                      <Pencil size={14} />
-                      Rename
-                    </button>
-                    <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
-                    {c.is_temporary ? (
-                      <>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setOpenMenuId(null);
-                            setPendingMoveTarget("cloud");
-                            setPendingMove(c);
-                          }}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-                          role="menuitem"
-                        >
-                          <Cloud size={14} />
-                          Save Chat to Cloud
-                        </button>
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setOpenMenuId(null);
-                            setPendingMoveTarget("local");
-                            setPendingMove(c);
-                          }}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-                          role="menuitem"
-                        >
-                          <Database size={14} />
-                          Save Chat to Local
-                        </button>
-                      </>
-                    ) : (
+                    <div className="relative">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
-                          setOpenMenuId(null);
-                          if (!isMoveDisabled) onMove(c.id);
+                          setIsMobileMenu(false);
+                          setOpenMenuId(openMenuId === c.id ? null : c.id);
+                        }}
+                        className={`p-1.5 rounded-md focus:outline-none transition-all ${
+                          openMenuId === c.id
+                            ? activeId === c.id
+                              ? "bg-white/20 text-white"
+                              : "bg-black/5 text-gray-900 dark:bg-white/10 dark:text-white"
+                            : activeId === c.id
+                              ? currentMode === "cloud"
+                                ? "text-white/70 hover:text-white opacity-100"
+                                : "text-gray-900/60 hover:text-gray-900 opacity-100"
+                              : "text-gray-400 hover:text-gray-900 dark:text-white/40 dark:hover:text-white/95 opacity-0 group-hover:opacity-100"
+                        }`}
+                        aria-label="Conversation actions"
+                        aria-haspopup="menu"
+                        aria-expanded={openMenuId === c.id}
+                      >
+                        <svg
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          className="w-4 h-4"
+                        >
+                          <circle cx="12" cy="12" r="1" strokeWidth="2" />
+                          <circle cx="12" cy="5" r="1" strokeWidth="2" />
+                          <circle cx="12" cy="19" r="1" strokeWidth="2" />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+
+                  {openMenuId === c.id && (
+                    <div
+                      ref={menuRef}
+                      role="menu"
+                      className={`${
+                        isMobileMenu ? "fixed" : "absolute right-2 mt-8"
+                      } w-44 rounded-xl bg-white dark:bg-[#1c1c1e] shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-[100] overflow-hidden backdrop-blur-xl`}
+                      style={
+                        isMobileMenu
+                          ? {
+                              top: menuPos.top,
+                              bottom: menuPos.bottom,
+                              left: menuPos.left,
+                            }
+                          : {}
+                      }
+                    >
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleRenameClick(c);
                         }}
                         disabled={isMoveDisabled}
                         className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                         role="menuitem"
                       >
-                        {isMoving ? (
-                          <Loader2 size={14} className="animate-spin" />
-                        ) : (
-                          <ArrowUpRight size={14} />
-                        )}
-                        Move Chat to {targetMode === "cloud" ? "Cloud" : "Local"}
+                        <Pencil size={14} />
+                        Rename
                       </button>
-                    )}
-                    <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setOpenMenuId(null);
-                        setPendingDelete(c);
-                      }}
-                      disabled={isMoveDisabled}
-                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                      role="menuitem"
-                    >
-                      <Trash2 size={14} />
-                      Delete
-                    </button>
-                  </div>
-                )}
-              </div>
-            );
-          })}
+                      <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
+                      {c.is_temporary ? (
+                        <>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setOpenMenuId(null);
+                              setPendingMoveTarget("cloud");
+                              setPendingMove(c);
+                            }}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                            role="menuitem"
+                          >
+                            <Cloud size={14} />
+                            Save Chat to Cloud
+                          </button>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              setOpenMenuId(null);
+                              setPendingMoveTarget("local");
+                              setPendingMove(c);
+                            }}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                            role="menuitem"
+                          >
+                            <Database size={14} />
+                            Save Chat to Local
+                          </button>
+                        </>
+                      ) : (
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setOpenMenuId(null);
+                            if (!isMoveDisabled) onMove(c.id);
+                          }}
+                          disabled={isMoveDisabled}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                          role="menuitem"
+                        >
+                          {isMoving ? (
+                            <Loader2 size={14} className="animate-spin" />
+                          ) : (
+                            <ArrowUpRight size={14} />
+                          )}
+                          Move Chat to {targetMode === "cloud" ? "Cloud" : "Local"}
+                        </button>
+                      )}
+                      <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setOpenMenuId(null);
+                          setPendingDelete(c);
+                        }}
+                        disabled={isMoveDisabled}
+                        className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        role="menuitem"
+                      >
+                        <Trash2 size={14} />
+                        Delete
+                      </button>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
         </nav>
 
         <div className="p-4 border-t-[0.5px] border-black/10 dark:border-white/10 flex items-center gap-3">

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -57,6 +57,7 @@ export default function Sidebar({
 }: SidebarProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [apiSearchResults, setApiSearchResults] = useState<ConversationSearchResult[] | null>(null);
+  const [localSearchResults, setLocalSearchResults] = useState<ConversationSearchResult[] | null>(null);
   const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [expiryDropdownOpen, setExpiryDropdownOpen] = useState(false);
@@ -164,85 +165,92 @@ export default function Sidebar({
   useEffect(() => {
     if (!searchQuery) {
       setApiSearchResults(null);
+      setLocalSearchResults(null);
       if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
       return;
     }
 
-    if (currentMode !== "cloud") return;
-
+    const controller = new AbortController();
     if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+
     searchDebounceRef.current = setTimeout(async () => {
-      try {
-        const res = await fetch(`/api/conversations/search?q=${encodeURIComponent(searchQuery)}`);
-        if (res.ok) {
-          const data: ConversationSearchResult[] = await res.json();
-          setApiSearchResults(data);
+      if (currentMode === "cloud") {
+        try {
+          const res = await fetch(
+            `/api/conversations/search?q=${encodeURIComponent(searchQuery)}`,
+            { signal: controller.signal },
+          );
+          if (res.ok) {
+            const data: ConversationSearchResult[] = await res.json();
+            setApiSearchResults(data);
+          }
+        } catch (err: any) {
+          if (err.name !== "AbortError") console.error(err);
         }
-      } catch {}
+      } else {
+        const lowerQ = searchQuery.toLowerCase();
+        const results: ConversationSearchResult[] = [];
+        for (const c of conversations) {
+          const titleMatch = c.title.toLowerCase().includes(lowerQ);
+          let snippet = "";
+          try {
+            const rawMessages = localStorage.getItem(`waichat:messages:${c.id}`);
+            if (rawMessages) {
+              const msgs: { content: string; deleted_at?: number }[] = JSON.parse(rawMessages);
+              for (const m of msgs) {
+                if (m.deleted_at) continue;
+                const lowerContent = m.content.toLowerCase();
+                const idx = lowerContent.indexOf(lowerQ);
+                if (idx !== -1) {
+                  const start = Math.max(0, idx - 40);
+                  const end = Math.min(m.content.length, idx + lowerQ.length + 40);
+                  snippet =
+                    (start > 0 ? "…" : "") +
+                    m.content.slice(start, end) +
+                    (end < m.content.length ? "…" : "");
+                  break;
+                }
+              }
+            }
+          } catch {}
+          if (titleMatch || snippet) {
+            results.push({ id: c.id, title: c.title, snippet, updated_at: c.updated_at });
+          }
+        }
+        setLocalSearchResults(results);
+      }
     }, 300);
 
     return () => {
       if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+      controller.abort();
     };
-  }, [searchQuery, currentMode]);
+  }, [searchQuery, currentMode, conversations]);
 
   useEffect(() => {
     const handleEscapeSearch = (e: KeyboardEvent) => {
       if (e.key === "Escape" && searchQuery) {
         setSearchQuery("");
         setApiSearchResults(null);
+        setLocalSearchResults(null);
       }
     };
     document.addEventListener("keydown", handleEscapeSearch);
     return () => document.removeEventListener("keydown", handleEscapeSearch);
   }, [searchQuery]);
 
-  const localSearchResults = (): ConversationSearchResult[] => {
-    const lowerQ = searchQuery.toLowerCase();
-    const results: ConversationSearchResult[] = [];
-    for (const c of conversations) {
-      const titleMatch = c.title.toLowerCase().includes(lowerQ);
-      let snippet = "";
-
-      try {
-        const rawMessages = localStorage.getItem(`waichat:messages:${c.id}`);
-        if (rawMessages) {
-          const msgs: { content: string; deleted_at?: number }[] = JSON.parse(rawMessages);
-          for (const m of msgs) {
-            if (m.deleted_at) continue;
-            const lowerContent = m.content.toLowerCase();
-            const idx = lowerContent.indexOf(lowerQ);
-            if (idx !== -1) {
-              const start = Math.max(0, idx - 40);
-              const end = Math.min(m.content.length, idx + lowerQ.length + 40);
-              snippet =
-                (start > 0 ? "…" : "") +
-                m.content.slice(start, end) +
-                (end < m.content.length ? "…" : "");
-              break;
-            }
-          }
-        }
-      } catch {}
-
-      if (titleMatch || snippet) {
-        results.push({ id: c.id, title: c.title, snippet, updated_at: c.updated_at });
-      }
-    }
-    return results;
-  };
-
   const getDisplayResults = (): ConversationSearchResult[] | null => {
     if (!searchQuery) return null;
     if (currentMode === "cloud") {
       if (apiSearchResults !== null) return apiSearchResults;
-      // While waiting for API, show title matches from loaded conversations
-      const lowerQ = searchQuery.toLowerCase();
-      return conversations
-        .filter((c) => c.title.toLowerCase().includes(lowerQ))
-        .map((c) => ({ id: c.id, title: c.title, snippet: "", updated_at: c.updated_at }));
+    } else {
+      if (localSearchResults !== null) return localSearchResults;
     }
-    return localSearchResults();
+    // While waiting for debounced results, show instant title matches
+    const lowerQ = searchQuery.toLowerCase();
+    return conversations
+      .filter((c) => c.title.toLowerCase().includes(lowerQ))
+      .map((c) => ({ id: c.id, title: c.title, snippet: "", updated_at: c.updated_at }));
   };
 
   const displayResults = getDisplayResults();
@@ -367,6 +375,7 @@ export default function Sidebar({
                 onClick={() => {
                   setSearchQuery("");
                   setApiSearchResults(null);
+                  setLocalSearchResults(null);
                   searchInputRef.current?.focus();
                 }}
                 className="absolute right-2 text-gray-400 hover:text-gray-700 dark:text-white/30 dark:hover:text-white/70 transition-colors"

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Trash2,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { Conversation, ConversationSearchResult, StorageMode } from "../storage";
 import ConfirmModal from "./ConfirmModal";
 
@@ -201,7 +201,7 @@ export default function Sidebar({
     };
   }, [searchQuery]);
 
-  const getDisplayResults = (): ConversationSearchResult[] | null => {
+  const displayResults = useMemo(() => {
     if (!searchQuery) return null;
     // Only use stored results if they belong to the current query — no async clear needed
     if (searchResults?.q === searchQuery) return searchResults.results;
@@ -210,9 +210,7 @@ export default function Sidebar({
     return conversations
       .filter((c) => c.title.toLowerCase().includes(lowerQ))
       .map((c) => ({ id: c.id, title: c.title, snippet: "", updated_at: c.updated_at }));
-  };
-
-  const displayResults = getDisplayResults();
+  }, [searchQuery, searchResults, conversations]);
 
   const handleRenameClick = (c: Conversation) => {
     setEditTitle(c.title);

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -26,7 +26,7 @@ interface SidebarProps {
   onRename: (id: string, title: string) => Promise<void>;
   onSettingsOpen: () => void;
   onModeChange: (mode: StorageMode) => void;
-  onSearch: (query: string) => Promise<ConversationSearchResult[]>;
+  onSearch: (query: string, signal?: AbortSignal) => Promise<ConversationSearchResult[]>;
   currentMode: StorageMode;
   tempExpiry: string;
   onTempExpiryChange: (value: string) => void;
@@ -186,9 +186,10 @@ export default function Sidebar({
 
     let active = true;
     const captured = searchQuery;
+    const controller = new AbortController();
     const timer = setTimeout(async () => {
       try {
-        const results = await onSearchRef.current(captured);
+        const results = await onSearchRef.current(captured, controller.signal);
         if (active) setSearchResults({ q: captured, results });
       } catch (err: any) {
         if (err.name !== "AbortError") console.error(err);
@@ -197,6 +198,7 @@ export default function Sidebar({
 
     return () => {
       active = false;
+      controller.abort();
       clearTimeout(timer);
     };
   }, [searchQuery]);

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -63,6 +63,10 @@ export default function Sidebar({
     results: ConversationSearchResult[];
   } | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const onSearchRef = useRef(onSearch);
+  useEffect(() => {
+    onSearchRef.current = onSearch;
+  }, [onSearch]);
   const [expiryDropdownOpen, setExpiryDropdownOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
   const [pendingMove, setPendingMove] = useState<Conversation | null>(null);
@@ -165,22 +169,28 @@ export default function Sidebar({
     }
   }, [editingId]);
 
-  // Debounced search via StorageAdapter — tagged with the query so stale results are never shown
+  // Debounced search via StorageAdapter — tagged with the query so stale results are never shown.
+  // onSearch is accessed via ref so inline arrow function re-renders in App don't reset the debounce.
+  // active flag discards responses from races where a slower request resolves after a newer one.
   useEffect(() => {
     if (!searchQuery) return;
 
+    let active = true;
     const captured = searchQuery;
     const timer = setTimeout(async () => {
       try {
-        const results = await onSearch(captured);
-        setSearchResults({ q: captured, results });
+        const results = await onSearchRef.current(captured);
+        if (active) setSearchResults({ q: captured, results });
       } catch (err: any) {
         if (err.name !== "AbortError") console.error(err);
       }
     }, 300);
 
-    return () => clearTimeout(timer);
-  }, [searchQuery, onSearch]);
+    return () => {
+      active = false;
+      clearTimeout(timer);
+    };
+  }, [searchQuery]);
 
   const getDisplayResults = (): ConversationSearchResult[] | null => {
     if (!searchQuery) return null;
@@ -310,6 +320,7 @@ export default function Sidebar({
               onKeyDown={(e) => {
                 if (e.key === "Escape" && searchQuery) {
                   e.preventDefault();
+                  e.stopPropagation();
                   setSearchQuery("");
                   setSearchResults(null);
                 }

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -206,19 +206,21 @@ export default function Sidebar({
         try {
           const rawMessages = localStorage.getItem(`waichat:messages:${c.id}`);
           if (rawMessages) {
-            const msgs: { content: string; deleted_at?: number }[] = JSON.parse(rawMessages);
-            for (const m of msgs) {
-              if (m.deleted_at) continue;
-              const lowerContent = m.content.toLowerCase();
-              const idx = lowerContent.indexOf(lowerQ);
-              if (idx !== -1) {
-                const start = Math.max(0, idx - 40);
-                const end = Math.min(m.content.length, idx + lowerQ.length + 40);
-                snippet =
-                  (start > 0 ? "…" : "") +
-                  m.content.slice(start, end) +
-                  (end < m.content.length ? "…" : "");
-                break;
+            const msgs = JSON.parse(rawMessages);
+            if (Array.isArray(msgs)) {
+              for (const m of msgs) {
+                if (m.deleted_at) continue;
+                const lowerContent = m.content.toLowerCase();
+                const idx = lowerContent.indexOf(lowerQ);
+                if (idx !== -1) {
+                  const start = Math.max(0, idx - 40);
+                  const end = Math.min(m.content.length, idx + lowerQ.length + 40);
+                  snippet =
+                    (start > 0 ? "…" : "") +
+                    m.content.slice(start, end) +
+                    (end < m.content.length ? "…" : "");
+                  break;
+                }
               }
             }
           }
@@ -232,18 +234,6 @@ export default function Sidebar({
 
     return () => clearTimeout(timer);
   }, [searchQuery, currentMode, conversations]);
-
-  useEffect(() => {
-    const handleEscapeSearch = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && searchQuery) {
-        setSearchQuery("");
-        setApiSearchResults(null);
-        setLocalSearchResults(null);
-      }
-    };
-    document.addEventListener("keydown", handleEscapeSearch);
-    return () => document.removeEventListener("keydown", handleEscapeSearch);
-  }, [searchQuery]);
 
   const getDisplayResults = (): ConversationSearchResult[] | null => {
     if (!searchQuery) return null;
@@ -373,6 +363,14 @@ export default function Sidebar({
               type="text"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape" && searchQuery) {
+                  e.preventDefault();
+                  setSearchQuery("");
+                  setApiSearchResults(null);
+                  setLocalSearchResults(null);
+                }
+              }}
               placeholder="Search conversations…"
               className="w-full bg-black/5 dark:bg-white/5 border border-black/8 dark:border-white/10 rounded-lg pl-8 pr-7 py-1.5 text-[13px] text-gray-700 dark:text-white/80 placeholder:text-gray-400 dark:placeholder:text-white/25 outline-none focus:ring-1 focus:ring-black/15 dark:focus:ring-white/15 transition-all"
             />

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -58,7 +58,6 @@ export default function Sidebar({
   const [searchQuery, setSearchQuery] = useState("");
   const [apiSearchResults, setApiSearchResults] = useState<ConversationSearchResult[] | null>(null);
   const [localSearchResults, setLocalSearchResults] = useState<ConversationSearchResult[] | null>(null);
-  const searchDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [expiryDropdownOpen, setExpiryDropdownOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
@@ -173,9 +172,7 @@ export default function Sidebar({
     if (currentMode !== "cloud" || !searchQuery) return;
 
     const controller = new AbortController();
-    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-
-    searchDebounceRef.current = setTimeout(async () => {
+    const timer = setTimeout(async () => {
       try {
         const res = await fetch(
           `/api/conversations/search?q=${encodeURIComponent(searchQuery)}`,
@@ -191,7 +188,7 @@ export default function Sidebar({
     }, 300);
 
     return () => {
-      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
+      clearTimeout(timer);
       controller.abort();
     };
   }, [searchQuery, currentMode]);
@@ -200,9 +197,7 @@ export default function Sidebar({
   useEffect(() => {
     if (currentMode === "cloud" || !searchQuery) return;
 
-    if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-
-    searchDebounceRef.current = setTimeout(() => {
+    const timer = setTimeout(() => {
       const lowerQ = searchQuery.toLowerCase();
       const results: ConversationSearchResult[] = [];
       for (const c of conversations) {
@@ -235,9 +230,7 @@ export default function Sidebar({
       setLocalSearchResults(results);
     }, 300);
 
-    return () => {
-      if (searchDebounceRef.current) clearTimeout(searchDebounceRef.current);
-    };
+    return () => clearTimeout(timer);
   }, [searchQuery, currentMode, conversations]);
 
   useEffect(() => {
@@ -541,7 +534,10 @@ export default function Sidebar({
                         onChange={(e) => setEditTitle(e.target.value)}
                         onKeyDown={(e) => {
                           if (e.key === "Enter") handleSaveRename(c.id);
-                          if (e.key === "Escape") setEditingId(null);
+                          if (e.key === "Escape") {
+                            e.stopPropagation();
+                            setEditingId(null);
+                          }
                         }}
                         onBlur={() => !isRenaming && setEditingId(null)}
                         disabled={isRenaming}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -173,7 +173,10 @@ export default function Sidebar({
   // onSearch is accessed via ref so inline arrow function re-renders in App don't reset the debounce.
   // active flag discards responses from races where a slower request resolves after a newer one.
   useEffect(() => {
-    if (!searchQuery) return;
+    if (!searchQuery) {
+      setSearchResults(null);
+      return;
+    }
 
     let active = true;
     const captured = searchQuery;

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -26,6 +26,7 @@ interface SidebarProps {
   onRename: (id: string, title: string) => Promise<void>;
   onSettingsOpen: () => void;
   onModeChange: (mode: StorageMode) => void;
+  onSearch: (query: string) => Promise<ConversationSearchResult[]>;
   currentMode: StorageMode;
   tempExpiry: string;
   onTempExpiryChange: (value: string) => void;
@@ -47,6 +48,7 @@ export default function Sidebar({
   onRename,
   onSettingsOpen,
   onModeChange,
+  onSearch,
   currentMode,
   tempExpiry,
   onTempExpiryChange,
@@ -56,8 +58,10 @@ export default function Sidebar({
   movingConversationId,
 }: SidebarProps) {
   const [searchQuery, setSearchQuery] = useState("");
-  const [apiSearchResults, setApiSearchResults] = useState<ConversationSearchResult[] | null>(null);
-  const [localSearchResults, setLocalSearchResults] = useState<ConversationSearchResult[] | null>(null);
+  const [searchResults, setSearchResults] = useState<{
+    q: string;
+    results: ConversationSearchResult[];
+  } | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [expiryDropdownOpen, setExpiryDropdownOpen] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<Conversation | null>(null);
@@ -161,88 +165,28 @@ export default function Sidebar({
     }
   }, [editingId]);
 
-  // Immediately clear stale results on every query/mode change so title fallback shows instantly
+  // Debounced search via StorageAdapter — tagged with the query so stale results are never shown
   useEffect(() => {
-    setApiSearchResults(null);
-    setLocalSearchResults(null);
-  }, [searchQuery, currentMode]);
+    if (!searchQuery) return;
 
-  // Debounced cloud search — no dependency on `conversations` to avoid redundant requests
-  useEffect(() => {
-    if (currentMode !== "cloud" || !searchQuery) return;
-
-    const controller = new AbortController();
+    const captured = searchQuery;
     const timer = setTimeout(async () => {
       try {
-        const res = await fetch(
-          `/api/conversations/search?q=${encodeURIComponent(searchQuery)}`,
-          { signal: controller.signal },
-        );
-        if (res.ok) {
-          const data: ConversationSearchResult[] = await res.json();
-          setApiSearchResults(data);
-        }
+        const results = await onSearch(captured);
+        setSearchResults({ q: captured, results });
       } catch (err: any) {
         if (err.name !== "AbortError") console.error(err);
       }
     }, 300);
 
-    return () => {
-      clearTimeout(timer);
-      controller.abort();
-    };
-  }, [searchQuery, currentMode]);
-
-  // Debounced local search — depends on conversations so it re-runs when the list updates
-  useEffect(() => {
-    if (currentMode === "cloud" || !searchQuery) return;
-
-    const timer = setTimeout(() => {
-      const lowerQ = searchQuery.toLowerCase();
-      const results: ConversationSearchResult[] = [];
-      for (const c of conversations) {
-        const titleMatch = c.title.toLowerCase().includes(lowerQ);
-        let snippet = "";
-        try {
-          const rawMessages = localStorage.getItem(`waichat:messages:${c.id}`);
-          if (rawMessages) {
-            const msgs = JSON.parse(rawMessages);
-            if (Array.isArray(msgs)) {
-              for (const m of msgs) {
-                if (m.deleted_at) continue;
-                const lowerContent = m.content.toLowerCase();
-                const idx = lowerContent.indexOf(lowerQ);
-                if (idx !== -1) {
-                  const start = Math.max(0, idx - 40);
-                  const end = Math.min(m.content.length, idx + lowerQ.length + 40);
-                  snippet =
-                    (start > 0 ? "…" : "") +
-                    m.content.slice(start, end) +
-                    (end < m.content.length ? "…" : "");
-                  break;
-                }
-              }
-            }
-          }
-        } catch {}
-        if (titleMatch || snippet) {
-          results.push({ id: c.id, title: c.title, snippet, updated_at: c.updated_at });
-        }
-      }
-      setLocalSearchResults(results);
-    }, 300);
-
     return () => clearTimeout(timer);
-  }, [searchQuery, currentMode, conversations]);
+  }, [searchQuery, onSearch]);
 
   const getDisplayResults = (): ConversationSearchResult[] | null => {
     if (!searchQuery) return null;
-    if (currentMode === "cloud") {
-      if (apiSearchResults !== null) return apiSearchResults;
-    } else {
-      if (localSearchResults !== null) return localSearchResults;
-    }
-    // While waiting for debounced results, show instant title matches
+    // Only use stored results if they belong to the current query — no async clear needed
+    if (searchResults?.q === searchQuery) return searchResults.results;
+    // While debounce is pending, show instant title matches (synchronous, no flash)
     const lowerQ = searchQuery.toLowerCase();
     return conversations
       .filter((c) => c.title.toLowerCase().includes(lowerQ))
@@ -367,8 +311,7 @@ export default function Sidebar({
                 if (e.key === "Escape" && searchQuery) {
                   e.preventDefault();
                   setSearchQuery("");
-                  setApiSearchResults(null);
-                  setLocalSearchResults(null);
+                  setSearchResults(null);
                 }
               }}
               placeholder="Search conversations…"
@@ -378,8 +321,7 @@ export default function Sidebar({
               <button
                 onClick={() => {
                   setSearchQuery("");
-                  setApiSearchResults(null);
-                  setLocalSearchResults(null);
+                  setSearchResults(null);
                   searchInputRef.current?.focus();
                 }}
                 className="absolute right-2 text-gray-400 hover:text-gray-700 dark:text-white/30 dark:hover:text-white/70 transition-colors"

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -85,8 +85,8 @@ export class CloudStorage implements StorageAdapter {
       throw new Error(errorData.error || "Import failed");
     }
   }
-  async searchConversations(query: string): Promise<ConversationSearchResult[]> {
-    const res = await fetch(`/api/conversations/search?q=${encodeURIComponent(query)}`);
+  async searchConversations(query: string, signal?: AbortSignal): Promise<ConversationSearchResult[]> {
+    const res = await fetch(`/api/conversations/search?q=${encodeURIComponent(query)}`, { signal });
     if (!res.ok) return [];
     return res.json();
   }

--- a/src/client/storage/cloud.ts
+++ b/src/client/storage/cloud.ts
@@ -1,4 +1,4 @@
-import type { Conversation, DeleteMessageResult, Message, StorageAdapter } from "./index";
+import type { Conversation, ConversationSearchResult, DeleteMessageResult, Message, StorageAdapter } from "./index";
 
 export class CloudStorage implements StorageAdapter {
   async getConversations(): Promise<Conversation[]> {
@@ -85,6 +85,12 @@ export class CloudStorage implements StorageAdapter {
       throw new Error(errorData.error || "Import failed");
     }
   }
+  async searchConversations(query: string): Promise<ConversationSearchResult[]> {
+    const res = await fetch(`/api/conversations/search?q=${encodeURIComponent(query)}`);
+    if (!res.ok) return [];
+    return res.json();
+  }
+
   async clear(): Promise<void> {
     const res = await fetch("/api/conversations", { method: "DELETE" });
     if (!res.ok) {

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -30,7 +30,11 @@ export interface DeleteMessageResult {
 export interface StorageAdapter {
   getConversations(): Promise<Conversation[]>;
   getConversation(id: string): Promise<{ conversation: Conversation; messages: Message[] } | null>;
-  createConversation(model: string, systemPromptId?: string | null, systemPromptContent?: string | null): Promise<Conversation>;
+  createConversation(
+    model: string,
+    systemPromptId?: string | null,
+    systemPromptContent?: string | null,
+  ): Promise<Conversation>;
   deleteConversation(id: string): Promise<void>;
   updateConversationModel(id: string, model: string): Promise<void>;
   saveMessage(message: Omit<Message, "id" | "created_at"> & { id?: string }): Promise<Message>;
@@ -45,6 +49,13 @@ export interface StorageAdapter {
 }
 
 export type StorageMode = "cloud" | "local" | "temporary";
+
+export interface ConversationSearchResult {
+  id: string;
+  title: string;
+  snippet: string;
+  updated_at: number;
+}
 
 import { CloudStorage } from "./cloud";
 import { LocalStorage } from "./local";

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -44,7 +44,7 @@ export interface StorageAdapter {
     id: string,
   ): Promise<{ conversation: Conversation; messages: Message[] } | null>;
   importConversation(conversation: Conversation, messages: Message[]): Promise<void>;
-  searchConversations(query: string): Promise<ConversationSearchResult[]>;
+  searchConversations(query: string, signal?: AbortSignal): Promise<ConversationSearchResult[]>;
   clear?(): Promise<void>;
   cleanup?(expirySetting: string, isInitial: boolean): Promise<string[]>;
 }

--- a/src/client/storage/index.ts
+++ b/src/client/storage/index.ts
@@ -44,6 +44,7 @@ export interface StorageAdapter {
     id: string,
   ): Promise<{ conversation: Conversation; messages: Message[] } | null>;
   importConversation(conversation: Conversation, messages: Message[]): Promise<void>;
+  searchConversations(query: string): Promise<ConversationSearchResult[]>;
   clear?(): Promise<void>;
   cleanup?(expirySetting: string, isInitial: boolean): Promise<string[]>;
 }

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -189,7 +189,7 @@ export class LocalStorage implements StorageAdapter {
     this.setMessages(conversation.id, messages);
   }
 
-  async searchConversations(query: string): Promise<ConversationSearchResult[]> {
+  async searchConversations(query: string, _signal?: AbortSignal): Promise<ConversationSearchResult[]> {
     const trimmed = query.trim();
     if (!trimmed) return [];
     const lowerQ = trimmed.toLowerCase();

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -190,7 +190,9 @@ export class LocalStorage implements StorageAdapter {
   }
 
   async searchConversations(query: string): Promise<ConversationSearchResult[]> {
-    const lowerQ = query.toLowerCase();
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+    const lowerQ = trimmed.toLowerCase();
     const conversations = await this.getConversations();
     const results: ConversationSearchResult[] = [];
 

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -201,15 +201,16 @@ export class LocalStorage implements StorageAdapter {
       const messages = this.getMessagesRaw(c.id);
       for (const m of messages) {
         if (m.deleted_at) continue;
-        const lowerContent = m.content.toLowerCase();
+        const content = m.content ?? "";
+        const lowerContent = content.toLowerCase();
         const idx = lowerContent.indexOf(lowerQ);
         if (idx !== -1) {
           const start = Math.max(0, idx - 40);
-          const end = Math.min(m.content.length, idx + query.length + 40);
+          const end = Math.min(content.length, idx + query.length + 40);
           snippet =
             (start > 0 ? "…" : "") +
-            m.content.slice(start, end) +
-            (end < m.content.length ? "…" : "");
+            content.slice(start, end) +
+            (end < content.length ? "…" : "");
           break;
         }
       }

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -199,7 +199,8 @@ export class LocalStorage implements StorageAdapter {
       let snippet = "";
 
       const messages = this.getMessagesRaw(c.id);
-      for (const m of messages) {
+      for (let i = messages.length - 1; i >= 0; i--) {
+        const m = messages[i];
         if (m.deleted_at) continue;
         const content = m.content ?? "";
         const lowerContent = content.toLowerCase();

--- a/src/client/storage/local.ts
+++ b/src/client/storage/local.ts
@@ -1,4 +1,4 @@
-import type { Conversation, DeleteMessageResult, Message, StorageAdapter } from "./index";
+import type { Conversation, ConversationSearchResult, DeleteMessageResult, Message, StorageAdapter } from "./index";
 
 const CONVERSATIONS_KEY = "waichat:conversations";
 const MESSAGES_KEY = (id: string) => `waichat:messages:${id}`;
@@ -187,6 +187,39 @@ export class LocalStorage implements StorageAdapter {
     });
     this.setConversations(existing);
     this.setMessages(conversation.id, messages);
+  }
+
+  async searchConversations(query: string): Promise<ConversationSearchResult[]> {
+    const lowerQ = query.toLowerCase();
+    const conversations = await this.getConversations();
+    const results: ConversationSearchResult[] = [];
+
+    for (const c of conversations) {
+      const titleMatch = c.title.toLowerCase().includes(lowerQ);
+      let snippet = "";
+
+      const messages = this.getMessagesRaw(c.id);
+      for (const m of messages) {
+        if (m.deleted_at) continue;
+        const lowerContent = m.content.toLowerCase();
+        const idx = lowerContent.indexOf(lowerQ);
+        if (idx !== -1) {
+          const start = Math.max(0, idx - 40);
+          const end = Math.min(m.content.length, idx + query.length + 40);
+          snippet =
+            (start > 0 ? "…" : "") +
+            m.content.slice(start, end) +
+            (end < m.content.length ? "…" : "");
+          break;
+        }
+      }
+
+      if (titleMatch || snippet) {
+        results.push({ id: c.id, title: c.title, snippet, updated_at: c.updated_at });
+      }
+    }
+
+    return results;
   }
 
   async cleanup(expirySetting: string, isInitial: boolean): Promise<string[]> {

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -363,24 +363,20 @@ app.get("/api/conversations/search", async (c) => {
   const like = `%${q}%`;
 
   const rows = await c.env.DB.prepare(
-    `SELECT c.id, c.title, c.updated_at, m.content AS message_content
+    `SELECT c.id, c.title, c.updated_at, MAX(CASE WHEN m.content LIKE ? THEN m.content END) AS message_content
      FROM conversations c
-     JOIN messages m ON m.conversation_id = c.id
-     WHERE m.deleted_at IS NULL AND (c.title LIKE ? OR m.content LIKE ?)
+     LEFT JOIN messages m ON m.conversation_id = c.id AND m.deleted_at IS NULL
+     WHERE c.title LIKE ? OR m.content LIKE ?
+     GROUP BY c.id
      ORDER BY c.updated_at DESC
      LIMIT 50`,
   )
-    .bind(like, like)
-    .all<{ id: string; title: string; updated_at: number; message_content: string }>();
+    .bind(like, like, like)
+    .all<{ id: string; title: string; updated_at: number; message_content: string | null }>();
 
-  // Deduplicate by conversation id, keeping first (most recent) match per conversation
-  const seen = new Set<string>();
   const results: { id: string; title: string; snippet: string; updated_at: number }[] = [];
 
   for (const row of rows.results) {
-    if (seen.has(row.id)) continue;
-    seen.add(row.id);
-
     const content = row.message_content ?? "";
     const lowerContent = content.toLowerCase();
     const lowerQ = q.toLowerCase();

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -360,13 +360,14 @@ app.get("/api/conversations/search", async (c) => {
   const q = c.req.query("q")?.trim() ?? "";
   if (!q) return c.json([]);
 
-  const like = `%${q}%`;
+  const escaped = q.replace(/[\\%_]/g, "\\$&");
+  const like = `%${escaped}%`;
 
   const rows = await c.env.DB.prepare(
-    `SELECT c.id, c.title, c.updated_at, MAX(CASE WHEN m.content LIKE ? THEN m.content END) AS message_content
+    `SELECT c.id, c.title, c.updated_at, MAX(CASE WHEN m.content LIKE ? ESCAPE '\\' THEN m.content END) AS message_content
      FROM conversations c
      LEFT JOIN messages m ON m.conversation_id = c.id AND m.deleted_at IS NULL
-     WHERE c.title LIKE ? OR m.content LIKE ?
+     WHERE c.title LIKE ? ESCAPE '\\' OR m.content LIKE ? ESCAPE '\\'
      GROUP BY c.id
      ORDER BY c.updated_at DESC
      LIMIT 50`,

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -364,15 +364,15 @@ app.get("/api/conversations/search", async (c) => {
   const like = `%${escaped}%`;
 
   const rows = await c.env.DB.prepare(
-    `SELECT c.id, c.title, c.updated_at, MAX(CASE WHEN m.content LIKE ? ESCAPE '\\' THEN m.content END) AS message_content
+    `SELECT c.id, c.title, c.updated_at, MAX(m.content) AS message_content
      FROM conversations c
-     LEFT JOIN messages m ON m.conversation_id = c.id AND m.deleted_at IS NULL
-     WHERE c.title LIKE ? ESCAPE '\\' OR m.content LIKE ? ESCAPE '\\'
+     LEFT JOIN messages m ON m.conversation_id = c.id AND m.deleted_at IS NULL AND m.content LIKE ? ESCAPE '\\'
+     WHERE c.title LIKE ? ESCAPE '\\' OR m.id IS NOT NULL
      GROUP BY c.id
      ORDER BY c.updated_at DESC
      LIMIT 50`,
   )
-    .bind(like, like, like)
+    .bind(like, like)
     .all<{ id: string; title: string; updated_at: number; message_content: string | null }>();
 
   const results: { id: string; title: string; snippet: string; updated_at: number }[] = [];

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -314,7 +314,9 @@ app.get("/api/export", async (c) => {
 });
 
 app.post("/api/conversations", async (c) => {
-  const body = await c.req.json<{ model: string; system_prompt_id?: string; system_prompt?: string }>().catch(() => null);
+  const body = await c.req
+    .json<{ model: string; system_prompt_id?: string; system_prompt?: string }>()
+    .catch(() => null);
   if (!body || typeof body.model !== "string" || !body.model.trim()) {
     return c.json({ error: "Model is required and must be a non-empty string" }, 400);
   }
@@ -332,7 +334,10 @@ app.post("/api/conversations", async (c) => {
     model: body.model,
     created_at: now,
     updated_at: now,
-    system_prompt_id: typeof body.system_prompt_id === "string" && body.system_prompt_id.trim() ? body.system_prompt_id.trim() : null,
+    system_prompt_id:
+      typeof body.system_prompt_id === "string" && body.system_prompt_id.trim()
+        ? body.system_prompt_id.trim()
+        : null,
     system_prompt: systemPromptContent,
   };
   await c.env.DB.prepare(
@@ -349,6 +354,50 @@ app.post("/api/conversations", async (c) => {
     )
     .run();
   return c.json(conversation, 201);
+});
+
+app.get("/api/conversations/search", async (c) => {
+  const q = c.req.query("q")?.trim() ?? "";
+  if (!q) return c.json([]);
+
+  const like = `%${q}%`;
+
+  const rows = await c.env.DB.prepare(
+    `SELECT c.id, c.title, c.updated_at, m.content AS message_content
+     FROM conversations c
+     JOIN messages m ON m.conversation_id = c.id
+     WHERE m.deleted_at IS NULL AND (c.title LIKE ? OR m.content LIKE ?)
+     ORDER BY c.updated_at DESC
+     LIMIT 50`,
+  )
+    .bind(like, like)
+    .all<{ id: string; title: string; updated_at: number; message_content: string }>();
+
+  // Deduplicate by conversation id, keeping first (most recent) match per conversation
+  const seen = new Set<string>();
+  const results: { id: string; title: string; snippet: string; updated_at: number }[] = [];
+
+  for (const row of rows.results) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+
+    const content = row.message_content ?? "";
+    const lowerContent = content.toLowerCase();
+    const lowerQ = q.toLowerCase();
+    const matchIdx = lowerContent.indexOf(lowerQ);
+
+    let snippet = "";
+    if (matchIdx !== -1) {
+      const start = Math.max(0, matchIdx - 40);
+      const end = Math.min(content.length, matchIdx + q.length + 40);
+      snippet =
+        (start > 0 ? "…" : "") + content.slice(start, end) + (end < content.length ? "…" : "");
+    }
+
+    results.push({ id: row.id, title: row.title, snippet, updated_at: row.updated_at });
+  }
+
+  return c.json(results);
 });
 
 app.get("/api/conversations/:id", async (c) => {
@@ -578,7 +627,10 @@ app.post("/api/system-prompts", async (c) => {
   }
   const now = Date.now();
   const prompt: SystemPrompt = {
-    id: typeof body.id === "string" && body.id.trim() && body.id.length <= 36 ? body.id.trim() : crypto.randomUUID(),
+    id:
+      typeof body.id === "string" && body.id.trim() && body.id.length <= 36
+        ? body.id.trim()
+        : crypto.randomUUID(),
     user_id: "default",
     name,
     content,
@@ -588,7 +640,14 @@ app.post("/api/system-prompts", async (c) => {
   await c.env.DB.prepare(
     "INSERT INTO system_prompts (id, user_id, name, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET name = excluded.name, content = excluded.content, updated_at = excluded.updated_at WHERE system_prompts.updated_at IS NULL OR excluded.updated_at >= system_prompts.updated_at",
   )
-    .bind(prompt.id, prompt.user_id, prompt.name, prompt.content, prompt.created_at, prompt.updated_at)
+    .bind(
+      prompt.id,
+      prompt.user_id,
+      prompt.name,
+      prompt.content,
+      prompt.created_at,
+      prompt.updated_at,
+    )
     .run();
   return c.json(prompt, 201);
 });

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -364,7 +364,7 @@ app.get("/api/conversations/search", async (c) => {
   const like = `%${escaped}%`;
 
   const rows = await c.env.DB.prepare(
-    `SELECT c.id, c.title, c.updated_at, MAX(m.content) AS message_content
+    `SELECT c.id, c.title, c.updated_at, m.content AS message_content, MAX(m.created_at)
      FROM conversations c
      LEFT JOIN messages m ON m.conversation_id = c.id AND m.deleted_at IS NULL AND m.content LIKE ? ESCAPE '\\'
      WHERE c.title LIKE ? ESCAPE '\\' OR m.id IS NOT NULL


### PR DESCRIPTION
## Summary

- Adds a search bar at the top of the sidebar conversation list (above entries) with a magnifying glass icon and a `×` clear button that appears when the field is non-empty
- **Title search** filters the already-loaded conversation list instantly (client-side, no debounce)
- **Content search** hits `GET /api/conversations/search?q=<query>` with a 300ms debounce in cloud mode; local/temporary mode scans localStorage message cache client-side only
- Results replace the normal conversation list while the query is non-empty; each result shows the conversation title and a muted ~80-char snippet around the first match
- "No conversations found" empty state when results are empty
- `Escape` clears the search and restores the normal list
- `ConversationSearchResult` type added to `src/client/storage/index.ts`
- No new dependencies; debounce uses plain `setTimeout`/`clearTimeout`

## Changes

- `src/worker/index.ts` — new `GET /api/conversations/search` route (registered before `/:id` to avoid shadowing), LIKE query on title + message content, deduplicates by conversation, returns snippet
- `src/client/storage/index.ts` — `ConversationSearchResult` interface
- `src/client/components/Sidebar.tsx` — search bar UI, debounced API call, local search fallback, results/empty-state rendering

## Test plan

- [x] Type in the search bar — conversation list filters by title immediately
- [x] In cloud mode, wait 300ms — content matches from the API appear with snippets
- [x] In local/temporary mode — content matches come from localStorage, no API call made
- [x] Click a search result — opens the conversation normally
- [x] Press Escape — clears the search and restores the normal list
- [x] `×` button clears the field and refocuses the input
- [x] Empty query shows normal conversation list
- [x] Query with no matches shows "No conversations found"

Closes #49

Co-Authored-By: aiwithrana <ai@withrana.com>