### PR TITLE
feat: export chat to Markdown or PDF

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import { HatGlasses, SquarePen } from "lucide-react";
+import { Download, HatGlasses, SquarePen } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ChatInput from "./components/ChatInput";
 import MessageList from "./components/MessageList";
@@ -122,6 +122,7 @@ export default function App() {
 
   const pendingSelectionRef = useRef<string | null>(null);
   const [storageDropdownOpen, setStorageDropdownOpen] = useState(false);
+  const [exportDropdownOpen, setExportDropdownOpen] = useState(false);
 
   const isTemporaryChat = storageMode === "temporary";
 
@@ -719,8 +720,9 @@ export default function App() {
   };
 
   const handleChatExport = useCallback(
-    (_id: string, format: "markdown" | "pdf") => {
+    (format: "markdown" | "pdf") => {
       if (!activeConversation) return;
+      setExportDropdownOpen(false);
       if (format === "markdown") {
         exportAsMarkdown(activeConversation, activeBranch);
       } else {
@@ -950,8 +952,6 @@ export default function App() {
           onDelete={deleteConversation}
           onMove={handleMoveConversation}
           onRename={renameConversation}
-          onExport={handleChatExport}
-          activeConversationId={activeConversation?.id ?? null}
           onSearch={(q, signal) => createStorage(storageMode).searchConversations(q, signal)}
           onSettingsOpen={() => setSettingsOpen(true)}
           onModeChange={handleStorageToggle}
@@ -1098,6 +1098,40 @@ export default function App() {
               </div>
 
               <div className="flex items-center gap-1.5">
+                {activeConversation && (
+                  <div className="relative">
+                    <button
+                      onClick={() => setExportDropdownOpen((o) => !o)}
+                      className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none"
+                      title="Export conversation"
+                      aria-expanded={exportDropdownOpen}
+                    >
+                      <Download size={18} strokeWidth={2} />
+                    </button>
+                    {exportDropdownOpen && (
+                      <>
+                        <div
+                          className="fixed inset-0 z-40"
+                          onClick={() => setExportDropdownOpen(false)}
+                        />
+                        <div className="absolute right-0 mt-1 w-40 rounded-xl bg-white dark:bg-[#1c1c1e] shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-50 overflow-hidden backdrop-blur-xl">
+                          <button
+                            onClick={() => handleChatExport("markdown")}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                          >
+                            Export as .md
+                          </button>
+                          <button
+                            onClick={() => handleChatExport("pdf")}
+                            className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                          >
+                            Export as PDF
+                          </button>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
                 <button
                   onClick={() => handleStorageToggle("temporary")}
                   className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-slate-600 hover:bg-slate-50 dark:text-white/65 dark:hover:text-slate-400 dark:hover:bg-slate-500/10 transition-colors focus:outline-none"

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1114,7 +1114,7 @@ export default function App() {
                           className="fixed inset-0 z-40"
                           onClick={() => setExportDropdownOpen(false)}
                         />
-                        <div className="absolute right-0 mt-1 w-40 rounded-xl bg-white dark:bg-[#1c1c1e] shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-50 overflow-hidden backdrop-blur-xl">
+                        <div className="absolute right-0 mt-1 w-40 rounded-xl bg-white/95 dark:bg-[#1c1c1e]/95 shadow-xl border border-black/5 dark:border-white/10 py-1.5 z-50 overflow-hidden backdrop-blur-xl">
                           <button
                             onClick={() => handleChatExport("markdown")}
                             className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -720,14 +720,14 @@ export default function App() {
 
   const handleChatExport = useCallback(
     (_id: string, format: "markdown" | "pdf") => {
-      if (!activeConversation || !messages.length) return;
+      if (!activeConversation || !activeBranch.length) return;
       if (format === "markdown") {
-        exportAsMarkdown(activeConversation, messages);
+        exportAsMarkdown(activeConversation, activeBranch);
       } else {
-        exportAsPdf(activeConversation, messages);
+        exportAsPdf(activeConversation, activeBranch);
       }
     },
-    [activeConversation, messages],
+    [activeConversation, activeBranch],
   );
 
   const handleExportWorkspace = async (scope: "local" | "cloud" | "both") => {
@@ -952,7 +952,7 @@ export default function App() {
           onRename={renameConversation}
           onExport={handleChatExport}
           activeConversationId={activeConversation?.id ?? null}
-          messagesLoaded={messages.length > 0 || activeConversation == null}
+          messagesLoaded={activeBranch.length > 0 || activeConversation == null}
           onSearch={(q, signal) => createStorage(storageMode).searchConversations(q, signal)}
           onSettingsOpen={() => setSettingsOpen(true)}
           onModeChange={handleStorageToggle}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -721,7 +721,7 @@ export default function App() {
 
   const handleChatExport = useCallback(
     (format: "markdown" | "pdf") => {
-      if (!activeConversation) return;
+      if (!activeConversation || activeBranch.length === 0) return;
       setExportDropdownOpen(false);
       if (format === "markdown") {
         exportAsMarkdown(activeConversation, activeBranch);
@@ -1098,7 +1098,7 @@ export default function App() {
               </div>
 
               <div className="flex items-center gap-1.5">
-                {activeConversation && (
+                {activeConversation && activeBranch.length > 0 && (
                   <div className="relative">
                     <button
                       onClick={() => setExportDropdownOpen((o) => !o)}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -720,7 +720,7 @@ export default function App() {
 
   const handleChatExport = useCallback(
     (_id: string, format: "markdown" | "pdf") => {
-      if (!activeConversation || !activeBranch.length) return;
+      if (!activeConversation) return;
       if (format === "markdown") {
         exportAsMarkdown(activeConversation, activeBranch);
       } else {
@@ -952,7 +952,6 @@ export default function App() {
           onRename={renameConversation}
           onExport={handleChatExport}
           activeConversationId={activeConversation?.id ?? null}
-          messagesLoaded={activeBranch.length > 0 || activeConversation == null}
           onSearch={(q, signal) => createStorage(storageMode).searchConversations(q, signal)}
           onSettingsOpen={() => setSettingsOpen(true)}
           onModeChange={handleStorageToggle}

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -12,6 +12,7 @@ import { useToast } from "./hooks/useToast";
 import { useTransfer } from "./hooks/useTransfer";
 import type { Conversation, Message, StorageMode } from "./storage";
 import { createStorage } from "./storage";
+import { exportAsMarkdown, exportAsPdf } from "./utils/chatExport";
 import { exportWorkspace } from "./utils/exportUtils";
 import { parseImportFile } from "./utils/importUtils";
 
@@ -131,8 +132,8 @@ export default function App() {
   const [defaultModel, setDefaultModel] = useState(
     () => localStorage.getItem(DEFAULT_MODEL_KEY) ?? DEFAULT_MODEL_ID,
   );
-  const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>(
-    () => readSystemPromptsFromStorage(),
+  const [systemPrompts, setSystemPrompts] = useState<SystemPrompt[]>(() =>
+    readSystemPromptsFromStorage(),
   );
   const [selectedPromptId, setSelectedPromptId] = useState<string | null>(null);
   const [syncSettings, setSyncSettings] = useState(
@@ -319,7 +320,13 @@ export default function App() {
               const postRes = await fetch("/api/system-prompts", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ id: p.id, name: p.name, content: p.content, created_at: p.created_at, updated_at: p.updated_at }),
+                body: JSON.stringify({
+                  id: p.id,
+                  name: p.name,
+                  content: p.content,
+                  created_at: p.created_at,
+                  updated_at: p.updated_at,
+                }),
               });
               if (!postRes.ok) throw new Error(`Failed to sync prompt: ${p.name}`);
             } catch (err) {
@@ -331,7 +338,9 @@ export default function App() {
         // Abort before overwriting localStorage — any failed upload means the
         // cloud list is incomplete and would permanently delete local-only prompts
         if (hasUploadError) {
-          throw new Error("Some prompts failed to upload. Aborting sync to prevent local data loss.");
+          throw new Error(
+            "Some prompts failed to upload. Aborting sync to prevent local data loss.",
+          );
         }
         if (!active) return;
 
@@ -528,7 +537,12 @@ export default function App() {
     if (isStreaming) return;
     const currentModel = activeConversation?.model ?? defaultModel;
     if (!activeConversation) {
-      const convo = await newConversation(defaultModel, storageMode, selectedPromptId, effectiveSystemPrompt || null);
+      const convo = await newConversation(
+        defaultModel,
+        storageMode,
+        selectedPromptId,
+        effectiveSystemPrompt || null,
+      );
       await sendMessage(content, defaultModel, convo.id, storageMode, effectiveSystemPrompt);
     } else {
       await sendMessage(
@@ -632,7 +646,10 @@ export default function App() {
         if (!res.ok) throw new Error("Failed to update prompt");
       } catch (err) {
         // Local state is kept — background sync will retry on next load/sync enable
-        console.error("Failed to sync system prompt update to cloud (will retry on next sync):", err);
+        console.error(
+          "Failed to sync system prompt update to cloud (will retry on next sync):",
+          err,
+        );
       }
     }
   };
@@ -700,6 +717,18 @@ export default function App() {
       cancelMove();
     }
   };
+
+  const handleChatExport = useCallback(
+    (_id: string, format: "markdown" | "pdf") => {
+      if (!activeConversation || !messages.length) return;
+      if (format === "markdown") {
+        exportAsMarkdown(activeConversation, messages);
+      } else {
+        exportAsPdf(activeConversation, messages);
+      }
+    },
+    [activeConversation, messages],
+  );
 
   const handleExportWorkspace = async (scope: "local" | "cloud" | "both") => {
     try {
@@ -835,14 +864,21 @@ export default function App() {
       }
 
       // Restore system prompt library — merge by updated_at so newer imported versions win
-      if (data.systemPrompts && Array.isArray(data.systemPrompts) && data.systemPrompts.length > 0) {
+      if (
+        data.systemPrompts &&
+        Array.isArray(data.systemPrompts) &&
+        data.systemPrompts.length > 0
+      ) {
         const existingMap = new Map(systemPrompts.map((p) => [p.id, p]));
         const mergedMap = new Map(systemPrompts.map((p) => [p.id, p]));
         const toSync: SystemPrompt[] = [];
 
         for (const p of data.systemPrompts as SystemPrompt[]) {
           const existing = existingMap.get(p.id);
-          if (!existing || (p.updated_at ?? p.created_at) > (existing.updated_at ?? existing.created_at)) {
+          if (
+            !existing ||
+            (p.updated_at ?? p.created_at) > (existing.updated_at ?? existing.created_at)
+          ) {
             mergedMap.set(p.id, p);
             toSync.push(p);
           }
@@ -914,6 +950,9 @@ export default function App() {
           onDelete={deleteConversation}
           onMove={handleMoveConversation}
           onRename={renameConversation}
+          onExport={handleChatExport}
+          activeConversationId={activeConversation?.id ?? null}
+          messagesLoaded={messages.length > 0 || activeConversation == null}
           onSearch={(q, signal) => createStorage(storageMode).searchConversations(q, signal)}
           onSettingsOpen={() => setSettingsOpen(true)}
           onModeChange={handleStorageToggle}

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -91,6 +91,11 @@ export default function Sidebar({
   const [editTitle, setEditTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
   const [exportMenuId, setExportMenuId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setExportMenuId(null);
+  }, [openMenuId]);
+
   const [isMobileMenu, setIsMobileMenu] = useState(false);
   const [menuPos, setMenuPos] = useState<{ top?: number; bottom?: number; left?: number }>({});
   const MENU_HEIGHT_ESTIMATE = 200;

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -84,7 +84,7 @@ export default function Sidebar({
   const [isRenaming, setIsRenaming] = useState(false);
   const [isMobileMenu, setIsMobileMenu] = useState(false);
   const [menuPos, setMenuPos] = useState<{ top?: number; bottom?: number; left?: number }>({});
-  const MENU_HEIGHT_ESTIMATE = 200;
+  const MENU_HEIGHT_ESTIMATE = 160;
   const menuRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -3,6 +3,8 @@ import {
   ChevronDown,
   Cloud,
   Database,
+  Download,
+  FileText,
   HatGlasses,
   Loader2,
   Pencil,
@@ -24,6 +26,9 @@ interface SidebarProps {
   onDelete: (id: string) => void;
   onMove: (id: string, targetMode?: StorageMode) => void;
   onRename: (id: string, title: string) => Promise<void>;
+  onExport: (id: string, format: "markdown" | "pdf") => void;
+  activeConversationId: string | null;
+  messagesLoaded: boolean;
   onSettingsOpen: () => void;
   onModeChange: (mode: StorageMode) => void;
   onSearch: (query: string, signal?: AbortSignal) => Promise<ConversationSearchResult[]>;
@@ -46,6 +51,9 @@ export default function Sidebar({
   onDelete,
   onMove,
   onRename,
+  onExport,
+  activeConversationId,
+  messagesLoaded,
   onSettingsOpen,
   onModeChange,
   onSearch,
@@ -82,9 +90,10 @@ export default function Sidebar({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
+  const [exportMenuId, setExportMenuId] = useState<string | null>(null);
   const [isMobileMenu, setIsMobileMenu] = useState(false);
   const [menuPos, setMenuPos] = useState<{ top?: number; bottom?: number; left?: number }>({});
-  const MENU_HEIGHT_ESTIMATE = 160;
+  const MENU_HEIGHT_ESTIMATE = 200;
   const menuRef = useRef<HTMLDivElement>(null);
   const editInputRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -143,6 +152,7 @@ export default function Sidebar({
       // Handle Context Menu click-away
       if (menuRef.current && !menuRef.current.contains(target)) {
         setOpenMenuId(null);
+        setExportMenuId(null);
       }
 
       // Handle Expiry Dropdown click-away
@@ -153,6 +163,7 @@ export default function Sidebar({
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setOpenMenuId(null);
+        setExportMenuId(null);
         setExpiryDropdownOpen(false);
       }
     };
@@ -660,6 +671,62 @@ export default function Sidebar({
                           Move Chat to {targetMode === "cloud" ? "Cloud" : "Local"}
                         </button>
                       )}
+                      <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
+                      <div className="relative">
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setExportMenuId(exportMenuId === c.id ? null : c.id);
+                          }}
+                          disabled={c.id !== activeConversationId || !messagesLoaded}
+                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                          role="menuitem"
+                          title={
+                            c.id !== activeConversationId
+                              ? "Open this conversation to export"
+                              : !messagesLoaded
+                                ? "Messages are loading…"
+                                : undefined
+                          }
+                        >
+                          <Download size={14} />
+                          Export
+                          <ChevronDown
+                            size={12}
+                            className={`ml-auto transition-transform ${exportMenuId === c.id ? "rotate-180" : ""}`}
+                          />
+                        </button>
+                        {exportMenuId === c.id && (
+                          <div className="border-t border-black/5 dark:border-white/10">
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setOpenMenuId(null);
+                                setExportMenuId(null);
+                                onExport(c.id, "markdown");
+                              }}
+                              className="w-full flex items-center gap-2 px-3 py-2 pl-8 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                              role="menuitem"
+                            >
+                              <FileText size={13} />
+                              Export as Markdown
+                            </button>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setOpenMenuId(null);
+                                setExportMenuId(null);
+                                onExport(c.id, "pdf");
+                              }}
+                              className="w-full flex items-center gap-2 px-3 py-2 pl-8 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
+                              role="menuitem"
+                            >
+                              <FileText size={13} />
+                              Export as PDF
+                            </button>
+                          </div>
+                        )}
+                      </div>
                       <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
                       <button
                         onClick={(e) => {

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -3,8 +3,6 @@ import {
   ChevronDown,
   Cloud,
   Database,
-  Download,
-  FileText,
   HatGlasses,
   Loader2,
   Pencil,
@@ -26,8 +24,6 @@ interface SidebarProps {
   onDelete: (id: string) => void;
   onMove: (id: string, targetMode?: StorageMode) => void;
   onRename: (id: string, title: string) => Promise<void>;
-  onExport: (id: string, format: "markdown" | "pdf") => void;
-  activeConversationId: string | null;
   onSettingsOpen: () => void;
   onModeChange: (mode: StorageMode) => void;
   onSearch: (query: string, signal?: AbortSignal) => Promise<ConversationSearchResult[]>;
@@ -50,8 +46,6 @@ export default function Sidebar({
   onDelete,
   onMove,
   onRename,
-  onExport,
-  activeConversationId,
   onSettingsOpen,
   onModeChange,
   onSearch,
@@ -88,12 +82,6 @@ export default function Sidebar({
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editTitle, setEditTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
-  const [exportMenuId, setExportMenuId] = useState<string | null>(null);
-
-  useEffect(() => {
-    setExportMenuId(null);
-  }, [openMenuId]);
-
   const [isMobileMenu, setIsMobileMenu] = useState(false);
   const [menuPos, setMenuPos] = useState<{ top?: number; bottom?: number; left?: number }>({});
   const MENU_HEIGHT_ESTIMATE = 200;
@@ -155,7 +143,6 @@ export default function Sidebar({
       // Handle Context Menu click-away
       if (menuRef.current && !menuRef.current.contains(target)) {
         setOpenMenuId(null);
-        setExportMenuId(null);
       }
 
       // Handle Expiry Dropdown click-away
@@ -166,7 +153,6 @@ export default function Sidebar({
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         setOpenMenuId(null);
-        setExportMenuId(null);
         setExpiryDropdownOpen(false);
       }
     };
@@ -674,60 +660,6 @@ export default function Sidebar({
                           Move Chat to {targetMode === "cloud" ? "Cloud" : "Local"}
                         </button>
                       )}
-                      <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
-                      <div className="relative">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setExportMenuId(exportMenuId === c.id ? null : c.id);
-                          }}
-                          disabled={c.id !== activeConversationId}
-                          className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                          role="menuitem"
-                          title={
-                            c.id !== activeConversationId
-                              ? "Open this conversation to export"
-                              : undefined
-                          }
-                        >
-                          <Download size={14} />
-                          Export
-                          <ChevronDown
-                            size={12}
-                            className={`ml-auto transition-transform ${exportMenuId === c.id ? "rotate-180" : ""}`}
-                          />
-                        </button>
-                        {exportMenuId === c.id && (
-                          <div className="border-t border-black/5 dark:border-white/10">
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setOpenMenuId(null);
-                                setExportMenuId(null);
-                                onExport(c.id, "markdown");
-                              }}
-                              className="w-full flex items-center gap-2 px-3 py-2 pl-8 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-                              role="menuitem"
-                            >
-                              <FileText size={13} />
-                              Export as Markdown
-                            </button>
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setOpenMenuId(null);
-                                setExportMenuId(null);
-                                onExport(c.id, "pdf");
-                              }}
-                              className="w-full flex items-center gap-2 px-3 py-2 pl-8 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 transition-colors"
-                              role="menuitem"
-                            >
-                              <FileText size={13} />
-                              Export as PDF
-                            </button>
-                          </div>
-                        )}
-                      </div>
                       <div className="h-[0.5px] bg-black/5 dark:bg-white/10 mx-2 my-1" />
                       <button
                         onClick={(e) => {

--- a/src/client/components/Sidebar.tsx
+++ b/src/client/components/Sidebar.tsx
@@ -28,7 +28,6 @@ interface SidebarProps {
   onRename: (id: string, title: string) => Promise<void>;
   onExport: (id: string, format: "markdown" | "pdf") => void;
   activeConversationId: string | null;
-  messagesLoaded: boolean;
   onSettingsOpen: () => void;
   onModeChange: (mode: StorageMode) => void;
   onSearch: (query: string, signal?: AbortSignal) => Promise<ConversationSearchResult[]>;
@@ -53,7 +52,6 @@ export default function Sidebar({
   onRename,
   onExport,
   activeConversationId,
-  messagesLoaded,
   onSettingsOpen,
   onModeChange,
   onSearch,
@@ -683,15 +681,13 @@ export default function Sidebar({
                             e.stopPropagation();
                             setExportMenuId(exportMenuId === c.id ? null : c.id);
                           }}
-                          disabled={c.id !== activeConversationId || !messagesLoaded}
+                          disabled={c.id !== activeConversationId}
                           className="w-full flex items-center gap-2 px-3 py-2 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                           role="menuitem"
                           title={
                             c.id !== activeConversationId
                               ? "Open this conversation to export"
-                              : !messagesLoaded
-                                ? "Messages are loading…"
-                                : undefined
+                              : undefined
                           }
                         >
                           <Download size={14} />

--- a/src/client/utils/chatExport.ts
+++ b/src/client/utils/chatExport.ts
@@ -27,7 +27,7 @@ export function exportAsMarkdown(conversation: Conversation, messages: Message[]
   for (const msg of messages) {
     const role = msg.role === "user" ? "**User**" : "**Assistant**";
     lines.push(role);
-    lines.push(msg.content);
+    lines.push(msg.content || "");
     lines.push("");
   }
 
@@ -52,11 +52,12 @@ export function exportAsPdf(conversation: Conversation, messages: Message[]): vo
 
   // Convert content: fenced code blocks → <pre><code>, rest -> escaped paragraphs
   function renderContent(raw: string): string {
+    if (!raw) return "";
     const parts = raw.split(/(```[\s\S]*?```)/g);
     return parts
       .map((part) => {
         if (part.startsWith("```")) {
-          const inner = part.replace(/^```[^\n]*\n?/, "").replace(/```$/, "");
+          const inner = part.replace(/^```[a-zA-Z0-9+#_-]*\n?/, "").replace(/```$/, "");
           return `<pre><code>${escapeHtml(inner)}</code></pre>`;
         }
         if (!part) return "";

--- a/src/client/utils/chatExport.ts
+++ b/src/client/utils/chatExport.ts
@@ -1,0 +1,173 @@
+import type { Conversation, Message } from "../storage";
+
+function slugify(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-");
+  return slug || "waichat-export";
+}
+
+function formatDate(ts: number): string {
+  return new Date(ts).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function exportAsMarkdown(conversation: Conversation, messages: Message[]): void {
+  const title = conversation.title || "WaiChat Export";
+  const date = formatDate(Date.now());
+
+  const lines: string[] = [`# ${title}`, `_Exported from WaiChat on ${date}_`, "", "---", ""];
+
+  for (const msg of messages) {
+    const role = msg.role === "user" ? "**User**" : "**Assistant**";
+    lines.push(role);
+    lines.push(msg.content);
+    lines.push("");
+  }
+
+  const content = lines.join("\n");
+  const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `${slugify(title)}.md`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function exportAsPdf(conversation: Conversation, messages: Message[]): void {
+  const title = conversation.title || "WaiChat Export";
+  const date = formatDate(Date.now());
+
+  const escapeHtml = (text: string) =>
+    text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+  // Convert content: fenced code blocks → <pre><code>, rest -> escaped paragraphs
+  function renderContent(raw: string): string {
+    const parts = raw.split(/(```[\s\S]*?```)/g);
+    return parts
+      .map((part) => {
+        if (part.startsWith("```")) {
+          const inner = part.replace(/^```[^\n]*\n?/, "").replace(/```$/, "");
+          return `<pre><code>${escapeHtml(inner)}</code></pre>`;
+        }
+        return `<p>${escapeHtml(part).replace(/\n/g, "<br>")}</p>`;
+      })
+      .join("");
+  }
+
+  const messagesHtml = messages
+    .map((msg) => {
+      const roleLabel = msg.role === "user" ? "User" : "Assistant";
+      return `<div class="message">
+  <div class="role">${roleLabel}</div>
+  <div class="content">${renderContent(msg.content)}</div>
+</div>`;
+    })
+    .join("\n");
+
+  const printStyle = `
+    <style>
+      @media print {
+        body > *:not(#waichat-print-export) { display: none !important; }
+        #waichat-print-export { display: block !important; }
+      }
+      #waichat-print-export {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 13px;
+        line-height: 1.6;
+        color: #111;
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 40px 24px;
+        display: none;
+      }
+      #waichat-print-export h1 {
+        font-size: 22px;
+        font-weight: 700;
+        margin: 0 0 4px;
+      }
+      #waichat-print-export .export-meta {
+        color: #666;
+        font-style: italic;
+        font-size: 12px;
+        margin-bottom: 24px;
+      }
+      #waichat-print-export hr {
+        border: none;
+        border-top: 1px solid #ddd;
+        margin: 24px 0;
+      }
+      #waichat-print-export .message {
+        margin-bottom: 20px;
+      }
+      #waichat-print-export .role {
+        font-weight: 700;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #444;
+        margin-bottom: 4px;
+      }
+      #waichat-print-export .content p {
+        margin: 0 0 8px;
+      }
+      #waichat-print-export pre {
+        background: #f5f5f5;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        padding: 12px;
+        overflow-x: auto;
+        margin: 8px 0;
+      }
+      #waichat-print-export code {
+        font-family: "SF Mono", "Fira Code", "Fira Mono", monospace;
+        font-size: 12px;
+      }
+    </style>
+  `;
+
+  const existing = document.getElementById("waichat-print-export");
+  if (existing) existing.remove();
+
+  const styleId = "waichat-print-style";
+  const existingStyle = document.getElementById(styleId);
+  if (existingStyle) existingStyle.remove();
+
+  const styleEl = document.createElement("style");
+  styleEl.id = styleId;
+  styleEl.setAttribute("media", "print");
+  styleEl.textContent = `
+    body > *:not(#waichat-print-export) { display: none !important; }
+    #waichat-print-export { display: block !important; }
+  `;
+
+  const div = document.createElement("div");
+  div.id = "waichat-print-export";
+  div.innerHTML = `
+    ${printStyle}
+    <h1>${escapeHtml(title)}</h1>
+    <div class="export-meta">Exported from WaiChat on ${date}</div>
+    <hr>
+    ${messagesHtml}
+  `;
+
+  document.head.appendChild(styleEl);
+  document.body.appendChild(div);
+
+  window.print();
+
+  // Clean up after print dialog closes
+  setTimeout(() => {
+    div.remove();
+    styleEl.remove();
+  }, 1000);
+}

--- a/src/client/utils/chatExport.ts
+++ b/src/client/utils/chatExport.ts
@@ -40,7 +40,7 @@ export function exportAsMarkdown(conversation: Conversation, messages: Message[]
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 export function exportAsPdf(conversation: Conversation, messages: Message[]): void {
@@ -61,7 +61,7 @@ export function exportAsPdf(conversation: Conversation, messages: Message[]): vo
           return `<pre><code>${escapeHtml(inner)}</code></pre>`;
         }
         if (!part) return "";
-        return `<p>${escapeHtml(part).replace(/\n/g, "<br>")}</p>`;
+        return `<p>${escapeHtml(part).replace(/\r?\n/g, "<br>")}</p>`;
       })
       .join("");
   }

--- a/src/client/utils/chatExport.ts
+++ b/src/client/utils/chatExport.ts
@@ -3,15 +3,15 @@ import type { Conversation, Message } from "../storage";
 function slugify(title: string): string {
   const slug = title
     .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
     .trim()
+    .replace(/[\\/:*?"<>|]/g, "")
     .replace(/\s+/g, "-")
     .replace(/-+/g, "-");
   return slug || "waichat-export";
 }
 
 function formatDate(ts: number): string {
-  return new Date(ts).toLocaleDateString("en-US", {
+  return new Date(ts).toLocaleDateString(undefined, {
     year: "numeric",
     month: "long",
     day: "numeric",
@@ -76,21 +76,35 @@ export function exportAsPdf(conversation: Conversation, messages: Message[]): vo
     })
     .join("\n");
 
-  const printStyle = `
-    <style>
-      @media print {
-        body > *:not(#waichat-print-export) { display: none !important; }
-        #waichat-print-export { display: block !important; }
+  const existing = document.getElementById("waichat-print-export");
+  if (existing) existing.remove();
+
+  const styleId = "waichat-print-style";
+  const existingStyle = document.getElementById(styleId);
+  if (existingStyle) existingStyle.remove();
+
+  const styleEl = document.createElement("style");
+  styleEl.id = styleId;
+  styleEl.textContent = `
+    #waichat-print-export {
+      display: none;
+    }
+    @media print {
+      html, body {
+        background: white !important;
+        color: #111 !important;
+      }
+      body > *:not(#waichat-print-export) {
+        display: none !important;
       }
       #waichat-print-export {
+        display: block !important;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         font-size: 13px;
         line-height: 1.6;
-        color: #111;
         max-width: 720px;
         margin: 0 auto;
         padding: 40px 24px;
-        display: none;
       }
       #waichat-print-export h1 {
         font-size: 22px;
@@ -110,6 +124,7 @@ export function exportAsPdf(conversation: Conversation, messages: Message[]): vo
       }
       #waichat-print-export .message {
         margin-bottom: 20px;
+        break-inside: avoid;
       }
       #waichat-print-export .role {
         font-weight: 700;
@@ -129,33 +144,18 @@ export function exportAsPdf(conversation: Conversation, messages: Message[]): vo
         padding: 12px;
         overflow-x: auto;
         margin: 8px 0;
+        break-inside: avoid;
       }
       #waichat-print-export code {
         font-family: "SF Mono", "Fira Code", "Fira Mono", monospace;
         font-size: 12px;
       }
-    </style>
-  `;
-
-  const existing = document.getElementById("waichat-print-export");
-  if (existing) existing.remove();
-
-  const styleId = "waichat-print-style";
-  const existingStyle = document.getElementById(styleId);
-  if (existingStyle) existingStyle.remove();
-
-  const styleEl = document.createElement("style");
-  styleEl.id = styleId;
-  styleEl.setAttribute("media", "print");
-  styleEl.textContent = `
-    body > *:not(#waichat-print-export) { display: none !important; }
-    #waichat-print-export { display: block !important; }
+    }
   `;
 
   const div = document.createElement("div");
   div.id = "waichat-print-export";
   div.innerHTML = `
-    ${printStyle}
     <h1>${escapeHtml(title)}</h1>
     <div class="export-meta">Exported from WaiChat on ${date}</div>
     <hr>

--- a/src/client/utils/chatExport.ts
+++ b/src/client/utils/chatExport.ts
@@ -59,6 +59,7 @@ export function exportAsPdf(conversation: Conversation, messages: Message[]): vo
           const inner = part.replace(/^```[^\n]*\n?/, "").replace(/```$/, "");
           return `<pre><code>${escapeHtml(inner)}</code></pre>`;
         }
+        if (!part) return "";
         return `<p>${escapeHtml(part).replace(/\n/g, "<br>")}</p>`;
       })
       .join("");
@@ -163,11 +164,11 @@ export function exportAsPdf(conversation: Conversation, messages: Message[]): vo
   document.head.appendChild(styleEl);
   document.body.appendChild(div);
 
-  window.print();
-
-  // Clean up after print dialog closes
-  setTimeout(() => {
+  const cleanup = () => {
     div.remove();
     styleEl.remove();
-  }, 1000);
+  };
+
+  window.addEventListener("afterprint", cleanup, { once: true });
+  window.print();
 }


### PR DESCRIPTION
Closes #54

## Summary

- Adds an **Export** item to the conversation 3-dots dropdown menu
- Opens an inline submenu with two options: **Export as Markdown** and **Export as PDF**
- Export is disabled when the conversation isn't active or messages haven't loaded yet (no extra API calls)

## What changed

**`src/client/utils/chatExport.ts`** (new file — all export logic lives here)
- `exportAsMarkdown`: builds a Markdown document with title, export date, role labels, and message content (fenced code blocks preserved); triggers a browser download via Blob URL with a slugified filename
- `exportAsPdf`: injects a hidden `#waichat-print-export` div + `media="print"` stylesheet that hides all other page content, then calls `window.print()`; cleans up after 1s; code blocks rendered as `<pre><code>` with monospace + subtle border

**`src/client/components/Sidebar.tsx`**
- New props: `onExport`, `activeConversationId`, `messagesLoaded`
- Export menu item with chevron-based inline expand, two sub-items beneath it
- Disabled with tooltip when viewing a non-active conversation or messages are still loading

**`src/client/App.tsx`**
- Imports `exportAsMarkdown` / `exportAsPdf`
- `handleChatExport` callback (memoized) delegates to the utility using already-loaded `messages` and `activeConversation`
- Passes new props to `<Sidebar>`

## No new dependencies
Both Markdown and PDF export are implemented natively — no jsPDF, html2canvas, or any markdown library.