### PR TITLE
feat: model picker in chat input + mobile 3-dot nav menu (#109)

### DIFF
--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -485,6 +485,29 @@ export default function App() {
     };
   }, [storageDropdownOpen]);
 
+  // Close mobile menu when clicking outside or pressing Escape
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (!(e.target instanceof Element) || !e.target.closest(".mobile-menu-container")) {
+        setMobileMenuOpen(false);
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileMenuOpen(false);
+    };
+
+    if (mobileMenuOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      document.addEventListener("keydown", handleKeyDown);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [mobileMenuOpen]);
+
   const closeSidebarOnMobile = () => {
     if (window.innerWidth < MOBILE_BREAKPOINT) {
       setSidebarOpen(false);
@@ -1122,7 +1145,7 @@ export default function App() {
               </div>
 
               {/* Mobile: 3-dot menu for Export, Temporary Chat, New Chat */}
-              <div className="relative md:hidden">
+              <div className="relative md:hidden mobile-menu-container">
                 <button
                   onClick={() => setMobileMenuOpen((o) => !o)}
                   className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none"
@@ -1132,8 +1155,6 @@ export default function App() {
                   <MoreVertical size={18} strokeWidth={2} />
                 </button>
                 {mobileMenuOpen && (
-                  <>
-                    <div className="fixed inset-0 z-40" onClick={() => setMobileMenuOpen(false)} />
                     <div role="menu" className="absolute right-0 top-full mt-1 w-48 p-1.5 rounded-2xl bg-white/95 dark:bg-[#1c1c1e]/95 shadow-xl border border-black/5 dark:border-white/10 z-50 overflow-hidden backdrop-blur-xl">
                       {activeConversation && activeBranch.length > 0 && (
                         <>
@@ -1185,7 +1206,6 @@ export default function App() {
                         New Chat
                       </button>
                     </div>
-                  </>
                 )}
               </div>
             </div>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,4 +1,4 @@
-import { Download, HatGlasses, MoreHorizontal, SquarePen } from "lucide-react";
+import { Download, HatGlasses, MoreVertical, SquarePen } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ChatInput from "./components/ChatInput";
 import MessageList from "./components/MessageList";
@@ -1129,7 +1129,7 @@ export default function App() {
                   aria-label="More options"
                   aria-expanded={mobileMenuOpen}
                 >
-                  <MoreHorizontal size={18} strokeWidth={2} />
+                  <MoreVertical size={18} strokeWidth={2} />
                 </button>
                 {mobileMenuOpen && (
                   <>

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1,8 +1,7 @@
-import { Download, HatGlasses, SquarePen } from "lucide-react";
+import { Download, HatGlasses, MoreHorizontal, SquarePen } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import ChatInput from "./components/ChatInput";
 import MessageList from "./components/MessageList";
-import ModelPicker from "./components/ModelPicker";
 import SettingsModal from "./components/SettingsModal";
 import Sidebar from "./components/Sidebar";
 import { ToastContainer } from "./components/Toast";
@@ -123,6 +122,7 @@ export default function App() {
   const pendingSelectionRef = useRef<string | null>(null);
   const [storageDropdownOpen, setStorageDropdownOpen] = useState(false);
   const [exportDropdownOpen, setExportDropdownOpen] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const isTemporaryChat = storageMode === "temporary";
 
@@ -985,34 +985,6 @@ export default function App() {
                   </svg>
                 </button>
               )}
-
-              <div
-                className={`flex items-center gap-2 border-[0.5px] border-black/5 dark:border-white/10 rounded-full pl-3 pr-2 py-1.5 transition-all ${
-                  isTemporaryChat
-                    ? "bg-slate-500/10 hover:bg-slate-500/20 dark:bg-slate-500/15 dark:hover:bg-slate-500/25"
-                    : storageMode === "cloud"
-                      ? "bg-brand-cloud/10 hover:bg-brand-cloud/20 dark:bg-brand-cloud/15 dark:hover:bg-brand-cloud/25"
-                      : "bg-brand-local/10 hover:bg-brand-local/20 dark:bg-brand-local/15 dark:hover:bg-brand-local/25"
-                }`}
-              >
-                <div
-                  className={`w-2 h-2 rounded-full ${
-                    isTemporaryChat
-                      ? "bg-slate-500 shadow-sm shadow-slate-500/50"
-                      : storageMode === "cloud"
-                        ? "bg-brand-cloud"
-                        : "bg-brand-local"
-                  }`}
-                ></div>
-                <div className="flex-1 min-w-0">
-                  <ModelPicker
-                    models={models}
-                    value={activeConversation?.model ?? defaultModel}
-                    onChange={handleModelChange}
-                    disabled={isStreaming}
-                  />
-                </div>
-              </div>
             </div>
 
             <div className="flex items-center gap-3">
@@ -1097,7 +1069,8 @@ export default function App() {
                 </div>
               </div>
 
-              <div className="flex items-center gap-1.5">
+              {/* Desktop: individual action buttons */}
+              <div className="hidden md:flex items-center gap-1.5">
                 {activeConversation && activeBranch.length > 0 && (
                   <div className="relative">
                     <button
@@ -1146,6 +1119,70 @@ export default function App() {
                 >
                   <SquarePen size={18} strokeWidth={2} />
                 </button>
+              </div>
+
+              {/* Mobile: 3-dot menu for Export, Temporary Chat, New Chat */}
+              <div className="relative md:hidden">
+                <button
+                  onClick={() => setMobileMenuOpen((o) => !o)}
+                  className="w-8 h-8 rounded-md flex items-center justify-center text-gray-500 hover:text-gray-900 hover:bg-black/5 dark:text-white/65 dark:hover:text-white/95 dark:hover:bg-white/5 transition-colors focus:outline-none"
+                  aria-label="More options"
+                  aria-expanded={mobileMenuOpen}
+                >
+                  <MoreHorizontal size={18} strokeWidth={2} />
+                </button>
+                {mobileMenuOpen && (
+                  <>
+                    <div className="fixed inset-0 z-40" onClick={() => setMobileMenuOpen(false)} />
+                    <div className="absolute right-0 top-full mt-1 w-48 p-1.5 rounded-2xl bg-white/95 dark:bg-[#1c1c1e]/95 shadow-xl border border-black/5 dark:border-white/10 z-50 overflow-hidden backdrop-blur-xl">
+                      {activeConversation && activeBranch.length > 0 && (
+                        <>
+                          <button
+                            onClick={() => {
+                              handleChatExport("markdown");
+                              setMobileMenuOpen(false);
+                            }}
+                            className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl transition-colors"
+                          >
+                            <Download size={15} strokeWidth={2} />
+                            Export as .md
+                          </button>
+                          <button
+                            onClick={() => {
+                              handleChatExport("pdf");
+                              setMobileMenuOpen(false);
+                            }}
+                            className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl transition-colors"
+                          >
+                            <Download size={15} strokeWidth={2} />
+                            Export as PDF
+                          </button>
+                          <div className="h-px bg-black/5 dark:bg-white/10 my-1" />
+                        </>
+                      )}
+                      <button
+                        onClick={() => {
+                          handleStorageToggle("temporary");
+                          setMobileMenuOpen(false);
+                        }}
+                        className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl transition-colors"
+                      >
+                        <HatGlasses size={15} strokeWidth={2} />
+                        Temporary Chat
+                      </button>
+                      <button
+                        onClick={() => {
+                          handleNew(storageMode);
+                          setMobileMenuOpen(false);
+                        }}
+                        className="w-full flex items-center gap-2.5 px-3 py-2.5 text-left text-[13px] text-gray-700 dark:text-white/80 hover:bg-black/5 dark:hover:bg-white/5 rounded-xl transition-colors"
+                      >
+                        <SquarePen size={15} strokeWidth={2} />
+                        New Chat
+                      </button>
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           </header>
@@ -1210,6 +1247,9 @@ export default function App() {
             initialValue={pendingPrompt}
             onClearInitialValue={() => setPendingPrompt("")}
             onAbort={stopGeneration}
+            models={models}
+            modelValue={activeConversation?.model ?? defaultModel}
+            onModelChange={handleModelChange}
           />
         </main>
 

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -1134,10 +1134,11 @@ export default function App() {
                 {mobileMenuOpen && (
                   <>
                     <div className="fixed inset-0 z-40" onClick={() => setMobileMenuOpen(false)} />
-                    <div className="absolute right-0 top-full mt-1 w-48 p-1.5 rounded-2xl bg-white/95 dark:bg-[#1c1c1e]/95 shadow-xl border border-black/5 dark:border-white/10 z-50 overflow-hidden backdrop-blur-xl">
+                    <div role="menu" className="absolute right-0 top-full mt-1 w-48 p-1.5 rounded-2xl bg-white/95 dark:bg-[#1c1c1e]/95 shadow-xl border border-black/5 dark:border-white/10 z-50 overflow-hidden backdrop-blur-xl">
                       {activeConversation && activeBranch.length > 0 && (
                         <>
                           <button
+                            role="menuitem"
                             onClick={() => {
                               handleChatExport("markdown");
                               setMobileMenuOpen(false);
@@ -1148,6 +1149,7 @@ export default function App() {
                             Export as .md
                           </button>
                           <button
+                            role="menuitem"
                             onClick={() => {
                               handleChatExport("pdf");
                               setMobileMenuOpen(false);
@@ -1161,6 +1163,7 @@ export default function App() {
                         </>
                       )}
                       <button
+                        role="menuitem"
                         onClick={() => {
                           handleStorageToggle("temporary");
                           setMobileMenuOpen(false);
@@ -1171,6 +1174,7 @@ export default function App() {
                         Temporary Chat
                       </button>
                       <button
+                        role="menuitem"
                         onClick={() => {
                           handleNew(storageMode);
                           setMobileMenuOpen(false);

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -115,7 +115,7 @@ export default function ChatInput({
               models={models}
               value={modelValue}
               onChange={onModelChange}
-              disabled={isGenerating}
+              disabled={disabled || isGenerating}
               className="max-w-[200px]"
             />
 

--- a/src/client/components/ChatInput.tsx
+++ b/src/client/components/ChatInput.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef } from "react";
+import type { Model } from "../hooks/useModels";
 import type { StorageMode } from "../storage";
+import ModelPicker from "./ModelPicker";
 
 interface ChatInputProps {
   onSend: (content: string) => void;
@@ -12,6 +14,9 @@ interface ChatInputProps {
   initialValue?: string;
   onClearInitialValue?: () => void;
   onAbort?: () => void;
+  models: Model[];
+  modelValue: string;
+  onModelChange: (model: string) => void;
 }
 
 export default function ChatInput({
@@ -25,6 +30,9 @@ export default function ChatInput({
   initialValue,
   onClearInitialValue,
   onAbort,
+  models,
+  modelValue,
+  onModelChange,
 }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -45,13 +53,12 @@ export default function ChatInput({
   }, [value]);
 
   const handleSend = (e?: React.FormEvent) => {
-    e?.preventDefault(); // Prevent page reload if triggered via form submission
+    e?.preventDefault();
     const trimmed = value.trim();
     if (!trimmed || disabled || isGenerating) return;
     onSend(trimmed);
     onChange("");
 
-    // Reset height after sending
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
     }
@@ -100,43 +107,35 @@ export default function ChatInput({
             }
             disabled={disabled || (isGenerating && !isStreamingHere)}
             rows={1}
-            className="w-full bg-transparent border-none text-gray-900 dark:text-white/95 text-base outline-none resize-none leading-relaxed min-h-[24px] max-h-[200px] pr-12 placeholder:text-gray-400 dark:placeholder:text-white/40 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
+            className="w-full bg-transparent border-none text-gray-900 dark:text-white/95 text-base outline-none resize-none leading-relaxed min-h-[24px] max-h-[200px] placeholder:text-gray-400 dark:placeholder:text-white/40 [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-thumb]:bg-black/10 dark:[&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-full"
           />
 
-          <button
-            type="submit"
-            disabled={disabled || isGenerating || !value.trim()}
-            className="absolute right-3 top-2.5 w-8 h-8 bg-black/5 dark:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 rounded-full flex items-center justify-center text-gray-500 dark:text-white/80 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black hover:scale-105 disabled:opacity-40 disabled:hover:bg-black/5 disabled:hover:text-gray-500 dark:disabled:hover:bg-white/10 dark:disabled:hover:text-white/80 disabled:hover:scale-100 transition-all duration-200 cursor-pointer"
-            aria-label="Send message"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              className="w-4 h-4 stroke-[2.5]"
-            >
-              <line x1="22" y1="2" x2="11" y2="13"></line>
-              <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
-            </svg>
-          </button>
+          <div className="flex items-center justify-between mt-2 pt-2 border-t-[0.5px] border-black/5 dark:border-white/5">
+            <ModelPicker
+              models={models}
+              value={modelValue}
+              onChange={onModelChange}
+              disabled={isGenerating}
+              className="max-w-[200px]"
+            />
 
-          {/*<div className="flex justify-between items-center mt-3 border-t-[0.5px] border-black/5 dark:border-white/5 pt-2">
             <button
-              type="button"
-              className="flex items-center gap-2 bg-transparent border-none text-gray-500 hover:text-gray-900 dark:text-white/50 dark:hover:text-white/95 text-[13px] md:text-sm font-medium cursor-pointer transition-colors focus:outline-none"
-              aria-label="Attach file"
+              type="submit"
+              disabled={disabled || isGenerating || !value.trim()}
+              className="w-8 h-8 bg-black/5 dark:bg-white/10 border-[0.5px] border-black/10 dark:border-white/10 rounded-full flex items-center justify-center text-gray-500 dark:text-white/80 hover:bg-black hover:text-white dark:hover:bg-white dark:hover:text-black hover:scale-105 disabled:opacity-40 disabled:hover:bg-black/5 disabled:hover:text-gray-500 dark:disabled:hover:bg-white/10 dark:disabled:hover:text-white/80 disabled:hover:scale-100 transition-all duration-200 cursor-pointer shrink-0"
+              aria-label="Send message"
             >
               <svg
                 viewBox="0 0 24 24"
                 fill="none"
                 stroke="currentColor"
-                className="w-5 h-5 stroke-[1.5]"
+                className="w-4 h-4 stroke-[2.5]"
               >
-                <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"></path>
+                <line x1="22" y1="2" x2="11" y2="13"></line>
+                <polygon points="22 2 15 22 11 13 2 9 22 2"></polygon>
               </svg>
-              Files
             </button>
-          </div>*/}
+          </div>
         </form>
 
         <div className="text-center text-xs text-gray-400 dark:text-white/40 mt-3 hidden md:block tracking-wide">


### PR DESCRIPTION
Closes #109 

## Summary

- **Model Picker relocated to chat input** — removed the model picker pill from the top nav entirely; the picker now lives in the bottom bar of the chat input box (left of the send button), visible on all screen sizes. Matches the pattern used by Claude.ai.
- **Mobile nav 3-dot menu** — on mobile (below `md` breakpoint), Export Chat (Markdown/PDF), Temporary Chat toggle, and New Chat are collapsed into a `MoreHorizontal` dropdown in the top-right of the nav. Storage Mode dropdown remains always visible.
- **Desktop nav unchanged** — Export, Temporary Chat, and New Chat remain as standalone icon buttons on `md+` screens; the 3-dot menu is hidden.

## Changes

| File | What changed |
|---|---|
| `src/client/App.tsx` | Removed `ModelPicker` import/usage from nav; added `mobileMenuOpen` state; added mobile 3-dot dropdown; desktop action buttons now `hidden md:flex`; passes `models`/`modelValue`/`onModelChange` to `ChatInput` |
| `src/client/components/ChatInput.tsx` | Added `models`, `modelValue`, `onModelChange` props; moved send button from absolute to a flex bottom bar; `ModelPicker` embedded left of send button |

## Test plan

- [x] Desktop: model picker appears inside the input box, model changes work for both new and existing conversations
- [x] Desktop: Export, Temporary Chat, New Chat buttons visible in nav as standalone icons; no 3-dot button visible
- [x] Mobile: Storage Mode dropdown visible in nav; 3-dot button visible
- [x] Mobile: 3-dot menu opens with Export (only when a conversation is active), Temporary Chat, New Chat
- [x] Mobile: each 3-dot menu action works correctly and closes the menu
- [x] No regression in streaming, abort, or message sending behaviour

Co-Authored-By: aiwithrana <ai@withrana.com>